### PR TITLE
fix: synchronize player dynamic palette generation with surfaceStyle settings

### DIFF
--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/PlayerScreen.kt
@@ -79,6 +79,8 @@ import cx.aswin.boxcast.feature.player.components.SimplePlayerControls
 import cx.aswin.boxcast.core.designsystem.components.AdvancedPlayerControls
 import cx.aswin.boxcast.core.designsystem.theme.generateBrandColorScheme
 import cx.aswin.boxcast.core.designsystem.theme.luminance
+import cx.aswin.boxcast.core.designsystem.theme.SurfaceStyles
+import cx.aswin.boxcast.core.data.UserPreferencesRepository
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.material3.ColorScheme
@@ -287,7 +289,15 @@ fun PlayerContent(
 ) {
     // 1. Color Extraction Logic
     val context = LocalContext.current
-    val isDarkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val userPrefs = remember(context) { UserPreferencesRepository(context) }
+    val surfaceStyle by userPrefs.surfaceStyleStream.collectAsState(initial = remember { userPrefs.cachedSurfaceStyle })
+
+    val effectiveDarkTheme = when (surfaceStyle) {
+        SurfaceStyles.AMOLED, SurfaceStyles.CLASSIC_DARK -> true
+        SurfaceStyles.PURE_WHITE, SurfaceStyles.CLASSIC_LIGHT -> false
+        else -> MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    }
+
     var extractedColorScheme by remember { mutableStateOf<ColorScheme?>(null) }
     val colorScheme = extractedColorScheme ?: MaterialTheme.colorScheme
     
@@ -303,16 +313,17 @@ fun PlayerContent(
             .build()
     )
     
-    LaunchedEffect(imageUrl, painter.state, isDarkTheme) {
+    LaunchedEffect(imageUrl, painter.state, effectiveDarkTheme, surfaceStyle) {
         val state = painter.state
         if (state is coil.compose.AsyncImagePainter.State.Success) {
              val bitmap = (state.result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
              if (bitmap != null) {
                  val seed = extractSeedColor(bitmap)
-                 extractedColorScheme = generateBrandColorScheme(seed, isDarkTheme)
+                 extractedColorScheme = generateBrandColorScheme(seed, effectiveDarkTheme, surfaceStyle)
              }
         }
     }
+
 
 
     // 2. State Observations

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/UnifiedPlayerSheet.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/UnifiedPlayerSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import cx.aswin.boxcast.core.designsystem.theme.generateBrandColorScheme
 import cx.aswin.boxcast.core.designsystem.theme.luminance
+import cx.aswin.boxcast.core.designsystem.theme.SurfaceStyles
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -115,7 +116,13 @@ fun UnifiedPlayerSheet(
     val hasSeenTitleTapTip by userPrefs.hasSeenTitleTapTip.collectAsState(initial = true)
     val hasSeenSwipeMinimizeTip by userPrefs.hasSeenSwipeMinimizeTip.collectAsState(initial = true)
 
-    val effectiveDarkTheme = MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    val surfaceStyle by userPrefs.surfaceStyleStream.collectAsState(initial = remember { userPrefs.cachedSurfaceStyle })
+
+    val effectiveDarkTheme = when (surfaceStyle) {
+        SurfaceStyles.AMOLED, SurfaceStyles.CLASSIC_DARK -> true
+        SurfaceStyles.PURE_WHITE, SurfaceStyles.CLASSIC_LIGHT -> false
+        else -> MaterialTheme.colorScheme.surface.luminance() < 0.5f
+    }
 
     SideEffect {
         window?.let { win ->
@@ -141,16 +148,17 @@ fun UnifiedPlayerSheet(
             .build()
     )
     
-    LaunchedEffect(episode.imageUrl, painter.state, effectiveDarkTheme) {
+    LaunchedEffect(episode.imageUrl, painter.state, effectiveDarkTheme, surfaceStyle) {
         val painterState = painter.state
         if (painterState is AsyncImagePainter.State.Success) {
             val bitmap = (painterState.result.drawable as? android.graphics.drawable.BitmapDrawable)?.bitmap
             if (bitmap != null) {
                 val seedColor = extractSeedColor(bitmap)
-                extractedColorScheme = generateBrandColorScheme(seedColor, effectiveDarkTheme)
+                extractedColorScheme = generateBrandColorScheme(seedColor, effectiveDarkTheme, surfaceStyle)
             }
         }
     }
+
 
     
     // Sheet state (internal)


### PR DESCRIPTION
Fixes player and mini-player theme synchronization when selecting custom surface styles (AMOLED/Pitch Black, Classic Dark/Blackish, Pure White, Classic Light/Whitish). Collects surfaceStyle in PlayerScreen and UnifiedPlayerSheet and passes both effectiveDarkTheme and surfaceStyle to generateBrandColorScheme.