### PR TITLE
fix: hoist surfaceStyle/effectiveDarkTheme via CompositionLocals for player theme sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,9 @@ scratch/
 
 # GCP service account key (ephemeral, never commit)
 gcp-key.json
+
+# Firebase local cache
+.firebase/
+
+# Editor settings
+.vscode/

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -2477,7 +2477,6 @@ class MainActivity : ComponentActivity() {
                         containerHeight = containerHeight,
                         collapsedStateHorizontalPadding = 12.dp,
                         expandTrigger = expandPlayerTrigger, // Pass the trigger here
-                        isDarkTheme = darkTheme,
                         onEpisodeInfoClick = { episode ->
                             if (episode.id.startsWith("briefing_")) {
                                 val region = episode.id.removePrefix("briefing_").substringBefore("_")

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/theme/Theme.kt
@@ -11,10 +11,24 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+
+/**
+ * CompositionLocal providing the active surface style key (e.g. [SurfaceStyles.AMOLED]).
+ * Provided by [BoxCastTheme]; available to any composable in the tree.
+ */
+val LocalSurfaceStyle = staticCompositionLocalOf { SurfaceStyles.CLASSIC_DYNAMIC }
+
+/**
+ * CompositionLocal providing the effective dark-theme boolean resolved from the
+ * surface style. Provided by [BoxCastTheme]; available to any composable in the tree.
+ */
+val LocalEffectiveDarkTheme = staticCompositionLocalOf { false }
 
 /**
  * Surface style modes that control background/surface lightness.
@@ -44,6 +58,17 @@ object SurfaceStyles {
     data class Entry(val key: String, val label: String, val subtitle: String)
 }
 
+/**
+ * Resolves whether the UI should render in dark mode based on the selected [surfaceStyle].
+ * Forced-dark styles (AMOLED, CLASSIC_DARK) → true; forced-light styles (PURE_WHITE,
+ * CLASSIC_LIGHT) → false; everything else falls back to the provided [darkTheme].
+ */
+fun computeEffectiveDarkTheme(surfaceStyle: String, darkTheme: Boolean): Boolean = when (surfaceStyle) {
+    SurfaceStyles.AMOLED, SurfaceStyles.CLASSIC_DARK -> true
+    SurfaceStyles.PURE_WHITE, SurfaceStyles.CLASSIC_LIGHT -> false
+    else -> darkTheme
+}
+
 @Composable
 fun BoxCastTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
@@ -53,11 +78,7 @@ fun BoxCastTheme(
     content: @Composable () -> Unit
 ) {
     // Determine effective darkTheme
-    val effectiveDarkTheme = when (surfaceStyle) {
-        SurfaceStyles.AMOLED, SurfaceStyles.CLASSIC_DARK -> true
-        SurfaceStyles.PURE_WHITE, SurfaceStyles.CLASSIC_LIGHT -> false
-        else -> darkTheme
-    }
+    val effectiveDarkTheme = computeEffectiveDarkTheme(surfaceStyle, darkTheme)
 
     // Determine effective dynamicColor. All themes support dynamic accent coloring if enabled.
     val effectiveDynamicColor = dynamicColor
@@ -83,12 +104,17 @@ fun BoxCastTheme(
         }
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = BoxCastTypography,
-        shapes = BoxCastShapes,
-        content = content
-    )
+    CompositionLocalProvider(
+        LocalSurfaceStyle provides surfaceStyle,
+        LocalEffectiveDarkTheme provides effectiveDarkTheme
+    ) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = BoxCastTypography,
+            shapes = BoxCastShapes,
+            content = content
+        )
+    }
 }
 
 /**

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/FullPlayerContent.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/FullPlayerContent.kt
@@ -79,7 +79,6 @@ import cx.aswin.boxcast.core.designsystem.theme.LocalEffectiveDarkTheme
 fun FullPlayerContent(
     playbackRepository: PlaybackRepository,
     downloadRepository: cx.aswin.boxcast.core.data.DownloadRepository,
-    isDarkTheme: Boolean,
     colorScheme: ColorScheme,
     isFullscreenVideo: Boolean = false,
     onFullscreenVideoChange: (Boolean) -> Unit = {},

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/FullPlayerContent.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/FullPlayerContent.kt
@@ -72,6 +72,7 @@ import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material3.*
 import androidx.compose.ui.text.style.TextOverflow
+import cx.aswin.boxcast.core.designsystem.theme.LocalEffectiveDarkTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -177,11 +178,12 @@ fun FullPlayerContent(
         showFullscreenTranscript = false
     }
     
+    val resolvedDark = LocalEffectiveDarkTheme.current
     SideEffect {
         window?.let { win ->
              val insetsController = androidx.core.view.WindowCompat.getInsetsController(win, win.decorView)
-             insetsController.isAppearanceLightStatusBars = !isDarkTheme
-             insetsController.isAppearanceLightNavigationBars = !isDarkTheme
+             insetsController.isAppearanceLightStatusBars = !resolvedDark
+             insetsController.isAppearanceLightNavigationBars = !resolvedDark
         }
     }
     

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/PlayerScreen.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/PlayerScreen.kt
@@ -78,9 +78,8 @@ import kotlin.random.Random
 import cx.aswin.boxcast.feature.player.components.SimplePlayerControls
 import cx.aswin.boxcast.core.designsystem.components.AdvancedPlayerControls
 import cx.aswin.boxcast.core.designsystem.theme.generateBrandColorScheme
-import cx.aswin.boxcast.core.designsystem.theme.luminance
-import cx.aswin.boxcast.core.designsystem.theme.SurfaceStyles
-import cx.aswin.boxcast.core.data.UserPreferencesRepository
+import cx.aswin.boxcast.core.designsystem.theme.LocalSurfaceStyle
+import cx.aswin.boxcast.core.designsystem.theme.LocalEffectiveDarkTheme
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.material3.ColorScheme
@@ -289,14 +288,8 @@ fun PlayerContent(
 ) {
     // 1. Color Extraction Logic
     val context = LocalContext.current
-    val userPrefs = remember(context) { UserPreferencesRepository(context) }
-    val surfaceStyle by userPrefs.surfaceStyleStream.collectAsState(initial = remember { userPrefs.cachedSurfaceStyle })
-
-    val effectiveDarkTheme = when (surfaceStyle) {
-        SurfaceStyles.AMOLED, SurfaceStyles.CLASSIC_DARK -> true
-        SurfaceStyles.PURE_WHITE, SurfaceStyles.CLASSIC_LIGHT -> false
-        else -> MaterialTheme.colorScheme.surface.luminance() < 0.5f
-    }
+    val surfaceStyle = LocalSurfaceStyle.current
+    val effectiveDarkTheme = LocalEffectiveDarkTheme.current
 
     var extractedColorScheme by remember { mutableStateOf<ColorScheme?>(null) }
     val colorScheme = extractedColorScheme ?: MaterialTheme.colorScheme

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/UnifiedPlayerSheet.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/UnifiedPlayerSheet.kt
@@ -543,7 +543,6 @@ fun UnifiedPlayerSheet(
                             FullPlayerContent(
                                 playbackRepository = playbackRepository,
                                 downloadRepository = downloadRepository,
-                                isDarkTheme = effectiveDarkTheme,
                                 colorScheme = scheme,
                                 isFullscreenVideo = isFullscreenVideo,
                                 onFullscreenVideoChange = { isFullscreenVideo = it },

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/UnifiedPlayerSheet.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/UnifiedPlayerSheet.kt
@@ -92,7 +92,6 @@ fun UnifiedPlayerSheet(
     expandTrigger: Long = 0L, // New param: timestamp to force expansion
     onEpisodeInfoClick: (cx.aswin.boxcast.core.model.Episode) -> Unit = {},
     onPodcastInfoClick: (cx.aswin.boxcast.core.model.Podcast) -> Unit = {},
-    isDarkTheme: Boolean,
     modifier: Modifier = Modifier
 ) {
     val state by playbackRepository.playerState.collectAsState()

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/UnifiedPlayerSheet.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/UnifiedPlayerSheet.kt
@@ -14,8 +14,8 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import cx.aswin.boxcast.core.designsystem.theme.generateBrandColorScheme
-import cx.aswin.boxcast.core.designsystem.theme.luminance
-import cx.aswin.boxcast.core.designsystem.theme.SurfaceStyles
+import cx.aswin.boxcast.core.designsystem.theme.LocalSurfaceStyle
+import cx.aswin.boxcast.core.designsystem.theme.LocalEffectiveDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -116,13 +116,8 @@ fun UnifiedPlayerSheet(
     val hasSeenTitleTapTip by userPrefs.hasSeenTitleTapTip.collectAsState(initial = true)
     val hasSeenSwipeMinimizeTip by userPrefs.hasSeenSwipeMinimizeTip.collectAsState(initial = true)
 
-    val surfaceStyle by userPrefs.surfaceStyleStream.collectAsState(initial = remember { userPrefs.cachedSurfaceStyle })
-
-    val effectiveDarkTheme = when (surfaceStyle) {
-        SurfaceStyles.AMOLED, SurfaceStyles.CLASSIC_DARK -> true
-        SurfaceStyles.PURE_WHITE, SurfaceStyles.CLASSIC_LIGHT -> false
-        else -> MaterialTheme.colorScheme.surface.luminance() < 0.5f
-    }
+    val surfaceStyle = LocalSurfaceStyle.current
+    val effectiveDarkTheme = LocalEffectiveDarkTheme.current
 
     SideEffect {
         window?.let { win ->
@@ -548,7 +543,7 @@ fun UnifiedPlayerSheet(
                             FullPlayerContent(
                                 playbackRepository = playbackRepository,
                                 downloadRepository = downloadRepository,
-                                isDarkTheme = isDarkTheme,
+                                isDarkTheme = effectiveDarkTheme,
                                 colorScheme = scheme,
                                 isFullscreenVideo = isFullscreenVideo,
                                 onFullscreenVideoChange = { isFullscreenVideo = it },


### PR DESCRIPTION
## What changed

Implements both Qodo review suggestions from PR #779:

1. **Extracted `computeEffectiveDarkTheme()` helper** in Theme.kt — eliminates the duplicated `when(surfaceStyle)` blocks that were copy-pasted across PlayerScreen, UnifiedPlayerSheet.

2. **Hoisted surfaceStyle & effectiveDarkTheme via CompositionLocals** (`LocalSurfaceStyle`, `LocalEffectiveDarkTheme`) — provided by `BoxCastTheme`, so every composable in the tree reads the single source of truth without creating independent `UserPreferencesRepository` instances.

## Why the previous fix (#779) didn't work

PR #779 correctly collected surfaceStyle in UnifiedPlayerSheet/PlayerScreen, but **FullPlayerContent** was still receiving the raw `isDarkTheme` parameter from MainActivity (which only respects the dark/light toggle, not surfaceStyle). The status bar icons and system bars were driven by that stale value.

## Files changed

- **Theme.kt** — Added `LocalSurfaceStyle`, `LocalEffectiveDarkTheme` CompositionLocals and `computeEffectiveDarkTheme()` helper. BoxCastTheme now wraps content in `CompositionLocalProvider`.
- **UnifiedPlayerSheet.kt** — Reads from CompositionLocals instead of collecting surfaceStyleStream independently. Passes `effectiveDarkTheme` to FullPlayerContent.
- **PlayerScreen.kt** — Same CompositionLocal pattern, removed UserPreferencesRepository instantiation.
- **FullPlayerContent.kt** — Status bar appearance now reads from `LocalEffectiveDarkTheme` instead of the passed isDarkTheme parameter.