### PR TITLE
Refactor DailyBriefingCard, ShareManager, and HomeViewModel to resolve P1 Cognitive Complexity

### DIFF
--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ShareManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ShareManager.kt
@@ -95,157 +95,16 @@ object ShareManager {
                         val mutableBitmap = originalBitmap.copy(android.graphics.Bitmap.Config.ARGB_8888, true)
                         val canvas = android.graphics.Canvas(mutableBitmap)
                         
-                        // Extract color palette dynamically from the artwork bitmap
-                        val palette = androidx.palette.graphics.Palette.from(originalBitmap).generate()
-                        val swatch = palette.dominantSwatch ?: palette.vibrantSwatch ?: palette.mutedSwatch
-                        val bgColor = swatch?.rgb ?: android.graphics.Color.parseColor("#0F0C20")
+                        val (adjustedBgColor, logoColor) = resolveContrastColors(originalBitmap)
                         
-                        // Calculate relative luminance to guarantee maximum text and logo visibility
-                        val bgLuminance = getRelativeLuminance(bgColor)
-                        val darkColorVal = android.graphics.Color.parseColor("#0F0C20")
-                        val darkLuminance = getRelativeLuminance(darkColorVal)
-                        
-                        val contrastWithWhite = (1.0 + 0.05) / (bgLuminance + 0.05)
-                        val contrastWithDark = (bgLuminance + 0.05) / (darkLuminance + 0.05)
-                        
-                        var logoColor = android.graphics.Color.WHITE
-                        var adjustedBgColor = bgColor
-                        
-                        if (contrastWithWhite >= contrastWithDark) {
-                            logoColor = android.graphics.Color.WHITE
-                            // If contrast with white is less than 4.5 (WCAG AA), darken the background slightly
-                            if (contrastWithWhite < 4.5) {
-                                val hsl = FloatArray(3)
-                                androidx.core.graphics.ColorUtils.colorToHSL(bgColor, hsl)
-                                hsl[2] = (hsl[2] - 0.15f).coerceAtLeast(0.12f) // Darken to safe range
-                                adjustedBgColor = androidx.core.graphics.ColorUtils.HSLToColor(hsl)
-                            }
-                        } else {
-                            logoColor = darkColorVal
-                            // If contrast with dark is less than 4.5 (WCAG AA), lighten the background slightly
-                            if (contrastWithDark < 4.5) {
-                                val hsl = FloatArray(3)
-                                androidx.core.graphics.ColorUtils.colorToHSL(bgColor, hsl)
-                                hsl[2] = (hsl[2] + 0.15f).coerceAtMost(0.88f) // Lighten to safe range
-                                adjustedBgColor = androidx.core.graphics.ColorUtils.HSLToColor(hsl)
-                            }
-                        }
-                        
-                        // Draw a custom corner badge at the bottom-right corner
-                        // Load Google Sans typeface from resources and make it BOLD (Product Sans style)
-                        val googleSansTypeface = try {
-                            val baseFont = androidx.core.content.res.ResourcesCompat.getFont(
-                                context,
-                                cx.aswin.boxcast.core.designsystem.R.font.google_sans_variable
-                            )
-                            if (baseFont != null) {
-                                android.graphics.Typeface.create(baseFont, android.graphics.Typeface.BOLD)
-                            } else {
-                                android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.BOLD)
-                            }
-                        } catch (e: Exception) {
-                            android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.BOLD)
-                        }
-                        
-                        val text = "listen on"
-                        
-                        // Keep text and logo size exactly identical to previous version (referenced to image height)
-                        val targetTextSize = (height * 0.0396f).coerceAtLeast(20f)
-                        val targetLogoHeight = (height * 0.077f).coerceAtLeast(38f)
-                        
-                        // Set up text paint for "listen on" (Google Sans Bold)
-                        val textPaint = android.graphics.Paint().apply {
-                            color = logoColor
-                            textSize = targetTextSize
-                            typeface = googleSansTypeface
-                            isAntiAlias = true
-                        }
-                        
-                        val fontMetrics = textPaint.fontMetrics
-                        val textHeight = fontMetrics.descent - fontMetrics.ascent
-                        
-                        // Tight vertical spacing and padding to eliminate wasted space
-                        var paddingTop = targetTextSize * 0.35f
-                        var paddingBottom = targetLogoHeight * 0.20f
-                        var spacing = targetLogoHeight * 0.12f
-                        
-                        var pillHeight = paddingTop + textHeight + spacing + targetLogoHeight + paddingBottom
-                        var logoHeight = targetLogoHeight
-                        
-                        // Calculate logo width (aspect ratio is 778f / 112f)
-                        var logoWidth = logoHeight * (778f / 112f)
-                        
-                        var radius = pillHeight * 0.40f
-                        
-                        // Tight horizontal padding to eliminate wasted horizontal space
-                        var paddingLeft = radius + logoHeight * 0.10f
-                        var paddingRight = logoHeight * 0.30f
-                        var textWidth = textPaint.measureText(text)
-                        var maxContentWidth = maxOf(textWidth, logoWidth)
-                        var pillWidth = maxContentWidth + paddingLeft + paddingRight
-                        
-                        // Ensure badge doesn't overflow small images (scale down proportionally if needed)
-                        if (pillWidth > width * 0.9f) {
-                            val scale = (width * 0.9f) / pillWidth
-                            val finalScale = scale.coerceAtLeast(0.5f)
-                            
-                            pillHeight *= finalScale
-                            textPaint.textSize = textPaint.textSize * finalScale
-                            logoHeight *= finalScale
-                            logoWidth = logoHeight * (778f / 112f)
-                            paddingLeft *= finalScale
-                            paddingRight *= finalScale
-                            paddingTop *= finalScale
-                            paddingBottom *= finalScale
-                            spacing *= finalScale
-                            
-                            // Recalculate text metrics after scaling
-                            val scaledFontMetrics = textPaint.fontMetrics
-                            val scaledTextHeight = scaledFontMetrics.descent - scaledFontMetrics.ascent
-                            textWidth = textPaint.measureText(text)
-                            maxContentWidth = maxOf(textWidth, logoWidth)
-                            pillWidth = maxContentWidth + paddingLeft + paddingRight
-                        }
-                        
-                        val pillLeft = width - pillWidth
-                        
-                        val paintBack = android.graphics.Paint().apply {
-                            color = adjustedBgColor
-                            style = android.graphics.Paint.Style.FILL
-                            isAntiAlias = true
-                        }
-                        
-                        val path = android.graphics.Path().apply {
-                            moveTo(pillLeft, height.toFloat()) // bottom-left of badge
-                            lineTo(pillLeft, height - pillHeight + radius) // start of top-left curve
-                            quadTo(pillLeft, height - pillHeight, pillLeft + radius, height - pillHeight) // top-left curve
-                            lineTo(width.toFloat(), height - pillHeight) // top-right (sharp)
-                            lineTo(width.toFloat(), height.toFloat()) // bottom-right (sharp)
-                            close()
-                        }
-                        canvas.drawPath(path, paintBack)
-                        
-                        // Draw "listen on" text and logo right-aligned with each other
-                        val contentEndX = width - paddingRight
-                        val textX = contentEndX - textWidth
-                        val textY = (height - pillHeight + paddingTop) - fontMetrics.ascent
-                        canvas.drawText(text, textX, textY, textPaint)
-                        
-                        // Draw the logo inside the capsule (below "listen on", right-aligned)
-                        val drawable = androidx.core.content.ContextCompat.getDrawable(
-                            context,
-                            cx.aswin.boxcast.core.designsystem.R.drawable.ic_boxlore_logo
-                        )?.mutate()
-                        if (drawable != null) {
-                            val logoLeft = contentEndX - logoWidth
-                            val logoTop = height - pillHeight + paddingTop + (fontMetrics.descent - fontMetrics.ascent) + spacing
-                            val logoRight = contentEndX
-                            val logoBottom = logoTop + logoHeight
-                            
-                            drawable.setBounds(logoLeft.toInt(), logoTop.toInt(), logoRight.toInt(), logoBottom.toInt())
-                            drawable.setTint(logoColor)
-                            drawable.draw(canvas)
-                        }
+                        drawCustomBadge(
+                            context = context,
+                            canvas = canvas,
+                            width = width,
+                            height = height,
+                            adjustedBgColor = adjustedBgColor,
+                            logoColor = logoColor
+                        )
                         
                         // Save bitmap to cache directory
                         val cacheFile = java.io.File(context.cacheDir, "shared_artwork.jpg")
@@ -306,5 +165,153 @@ object ShareManager {
         val bL = if (b <= 0.03928) b / 12.92 else Math.pow((b + 0.055) / 1.055, 2.4)
         
         return 0.2126 * rL + 0.7152 * gL + 0.0722 * bL
+    }
+
+    private fun resolveContrastColors(bitmap: android.graphics.Bitmap): Pair<Int, Int> {
+        val palette = androidx.palette.graphics.Palette.from(bitmap).generate()
+        val swatch = palette.dominantSwatch ?: palette.vibrantSwatch ?: palette.mutedSwatch
+        val bgColor = swatch?.rgb ?: android.graphics.Color.parseColor("#0F0C20")
+        
+        val bgLuminance = getRelativeLuminance(bgColor)
+        val darkColorVal = android.graphics.Color.parseColor("#0F0C20")
+        val darkLuminance = getRelativeLuminance(darkColorVal)
+        
+        val contrastWithWhite = (1.0 + 0.05) / (bgLuminance + 0.05)
+        val contrastWithDark = (bgLuminance + 0.05) / (darkLuminance + 0.05)
+        
+        var logoColor = android.graphics.Color.WHITE
+        var adjustedBgColor = bgColor
+        
+        if (contrastWithWhite >= contrastWithDark) {
+            logoColor = android.graphics.Color.WHITE
+            if (contrastWithWhite < 4.5) {
+                val hsl = FloatArray(3)
+                androidx.core.graphics.ColorUtils.colorToHSL(bgColor, hsl)
+                hsl[2] = (hsl[2] - 0.15f).coerceAtLeast(0.12f)
+                adjustedBgColor = androidx.core.graphics.ColorUtils.HSLToColor(hsl)
+            }
+        } else {
+            logoColor = darkColorVal
+            if (contrastWithDark < 4.5) {
+                val hsl = FloatArray(3)
+                androidx.core.graphics.ColorUtils.colorToHSL(bgColor, hsl)
+                hsl[2] = (hsl[2] + 0.15f).coerceAtMost(0.88f)
+                adjustedBgColor = androidx.core.graphics.ColorUtils.HSLToColor(hsl)
+            }
+        }
+        return Pair(adjustedBgColor, logoColor)
+    }
+
+    private fun drawCustomBadge(
+        context: Context,
+        canvas: android.graphics.Canvas,
+        width: Int,
+        height: Int,
+        adjustedBgColor: Int,
+        logoColor: Int
+    ) {
+        val googleSansTypeface = try {
+            val baseFont = androidx.core.content.res.ResourcesCompat.getFont(
+                context,
+                cx.aswin.boxcast.core.designsystem.R.font.google_sans_variable
+            )
+            if (baseFont != null) {
+                android.graphics.Typeface.create(baseFont, android.graphics.Typeface.BOLD)
+            } else {
+                android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.BOLD)
+            }
+        } catch (e: Exception) {
+            android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.BOLD)
+        }
+        
+        val text = "listen on"
+        
+        val targetTextSize = (height * 0.0396f).coerceAtLeast(20f)
+        val targetLogoHeight = (height * 0.077f).coerceAtLeast(38f)
+        
+        val textPaint = android.graphics.Paint().apply {
+            color = logoColor
+            textSize = targetTextSize
+            typeface = googleSansTypeface
+            isAntiAlias = true
+        }
+        
+        val fontMetrics = textPaint.fontMetrics
+        val textHeight = fontMetrics.descent - fontMetrics.ascent
+        
+        var paddingTop = targetTextSize * 0.35f
+        var paddingBottom = targetLogoHeight * 0.20f
+        var spacing = targetLogoHeight * 0.12f
+        
+        var pillHeight = paddingTop + textHeight + spacing + targetLogoHeight + paddingBottom
+        var logoHeight = targetLogoHeight
+        
+        var logoWidth = logoHeight * (778f / 112f)
+        var radius = pillHeight * 0.40f
+        
+        var paddingLeft = radius + logoHeight * 0.10f
+        var paddingRight = logoHeight * 0.30f
+        var textWidth = textPaint.measureText(text)
+        var maxContentWidth = maxOf(textWidth, logoWidth)
+        var pillWidth = maxContentWidth + paddingLeft + paddingRight
+        
+        if (pillWidth > width * 0.9f) {
+            val scale = (width * 0.9f) / pillWidth
+            val finalScale = scale.coerceAtLeast(0.5f)
+            
+            pillHeight *= finalScale
+            textPaint.textSize = textPaint.textSize * finalScale
+            logoHeight *= finalScale
+            logoWidth = logoHeight * (778f / 112f)
+            paddingLeft *= finalScale
+            paddingRight *= finalScale
+            paddingTop *= finalScale
+            paddingBottom *= finalScale
+            spacing *= finalScale
+            
+            // Recalculate text metrics after scaling
+            textPaint.fontMetrics
+            textWidth = textPaint.measureText(text)
+            maxContentWidth = maxOf(textWidth, logoWidth)
+            pillWidth = maxContentWidth + paddingLeft + paddingRight
+        }
+        
+        val pillLeft = width - pillWidth
+        
+        val paintBack = android.graphics.Paint().apply {
+            color = adjustedBgColor
+            style = android.graphics.Paint.Style.FILL
+            isAntiAlias = true
+        }
+        
+        val path = android.graphics.Path().apply {
+            moveTo(pillLeft, height.toFloat()) // bottom-left of badge
+            lineTo(pillLeft, height - pillHeight + radius) // start of top-left curve
+            quadTo(pillLeft, height - pillHeight, pillLeft + radius, height - pillHeight) // top-left curve
+            lineTo(width.toFloat(), height - pillHeight) // top-right (sharp)
+            lineTo(width.toFloat(), height.toFloat()) // bottom-right (sharp)
+            close()
+        }
+        canvas.drawPath(path, paintBack)
+        
+        val contentEndX = width - paddingRight
+        val textX = contentEndX - textWidth
+        val textY = (height - pillHeight + paddingTop) - fontMetrics.ascent
+        canvas.drawText(text, textX, textY, textPaint)
+        
+        val drawable = androidx.core.content.ContextCompat.getDrawable(
+            context,
+            cx.aswin.boxcast.core.designsystem.R.drawable.ic_boxlore_logo
+        )?.mutate()
+        if (drawable != null) {
+            val logoLeft = contentEndX - logoWidth
+            val logoTop = height - pillHeight + paddingTop + textHeight + spacing
+            val logoRight = contentEndX
+            val logoBottom = logoTop + logoHeight
+            
+            drawable.setBounds(logoLeft.toInt(), logoTop.toInt(), logoRight.toInt(), logoBottom.toInt())
+            drawable.setTint(logoColor)
+            drawable.draw(canvas)
+        }
     }
 }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -1857,6 +1857,23 @@ class HomeViewModel(
         )
     }
 
+    private fun getHistoryScoreIncrement(history: ListeningHistoryEntity): Int {
+        var score = 0
+        if (history.isCompleted) {
+            score += 20
+        } else {
+            if (history.progressMs >= 300_000L) {
+                score += 15
+            } else if (history.progressMs >= 60_000L) {
+                score += 5
+            }
+        }
+        if (history.isLiked) {
+            score += 40
+        }
+        return score
+    }
+
     private fun calculatePodcastAffinityScores(
         subscriptions: List<Podcast>,
         historyList: List<ListeningHistoryEntity>,
@@ -1877,19 +1894,7 @@ class HomeViewModel(
                     lastPlayedMap[podId] = history.lastPlayedAt
                 }
 
-                var score = scores.getOrDefault(podId, 0)
-                if (history.isCompleted) {
-                    score += 20
-                } else {
-                    if (history.progressMs >= 300_000L) {
-                        score += 15
-                    } else if (history.progressMs >= 60_000L) {
-                        score += 5
-                    }
-                }
-                if (history.isLiked) {
-                    score += 40
-                }
+                val score = scores.getOrDefault(podId, 0) + getHistoryScoreIncrement(history)
                 scores[podId] = score
             }
         }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -415,11 +415,7 @@ class HomeViewModel(
                 val completedEpIdsForResolve = allHistory.filter { it.isCompleted }.map { it.episodeId }.toSet() + completedEpisodeIds
                 val inProgressEpIdsForResolve = allHistory.filter { !it.isCompleted && it.progressMs > 0L }.map { it.episodeId }.toSet()
 
-                val serialPodsToResolve = subs.filter { (it.preferredSort ?: "newest") == "oldest" }.filter { pod ->
-                    val currentResolved = _resolvedSerialEpisodes.value[pod.id]
-                    val needsResolve = currentResolved == null || currentResolved.id in completedEpIdsForResolve || currentResolved.id in inProgressEpIdsForResolve
-                    needsResolve && pod.id !in inFlightResolutions
-                }
+                val serialPodsToResolve = findPendingSerialPodcasts(subs, allHistory, completedEpisodeIds)
 
                 if (serialPodsToResolve.isNotEmpty()) {
                     serialPodsToResolve.forEach { inFlightResolutions.add(it.id) }
@@ -439,29 +435,13 @@ class HomeViewModel(
                                         val page = podcastRepository.getEpisodesPaginated(pod.id, limit = 200, offset = 0, sort = "oldest")
                                         val allEpisodes = page.episodes
                                         
-                                        val nextEp = when {
-                                            ongoingId != null -> {
-                                                val ongoingIndex = allEpisodes.indexOfFirst { it.id == ongoingId }
-                                                if (ongoingIndex != -1 && ongoingIndex < allEpisodes.lastIndex) {
-                                                    allEpisodes[ongoingIndex + 1]
-                                                } else {
-                                                    null
-                                                }
-                                            }
-                                            lastCompletedId != null -> {
-                                                val completedIndex = allEpisodes.indexOfFirst { it.id == lastCompletedId }
-                                                if (completedIndex != -1 && completedIndex < allEpisodes.lastIndex) {
-                                                    allEpisodes[completedIndex + 1]
-                                                } else {
-                                                    null
-                                                }
-                                            }
-                                            else -> {
-                                                allEpisodes.firstOrNull()
-                                            }
-                                        } ?: allEpisodes.firstOrNull { ep ->
-                                            ep.id !in completedEpIdsForResolve && ep.id !in inProgressEpIdsForResolve
-                                        }
+                                        val nextEp = resolveNextSerialEpisode(
+                                            allEpisodes = allEpisodes,
+                                            ongoingId = ongoingId,
+                                            lastCompletedId = lastCompletedId,
+                                            completedEpIdsForResolve = completedEpIdsForResolve,
+                                            inProgressEpIdsForResolve = inProgressEpIdsForResolve
+                                        )
                                         
                                         if (nextEp != null) {
                                             pod.id to nextEp
@@ -487,6 +467,54 @@ class HomeViewModel(
                     }
                 }
             }
+        }
+    }
+
+    private fun findPendingSerialPodcasts(
+        subs: List<Podcast>,
+        allHistory: List<cx.aswin.boxcast.core.data.database.ListeningHistoryEntity>,
+        completedEpisodeIds: Set<String>
+    ): List<Podcast> {
+        val completedEpIdsForResolve = allHistory.filter { it.isCompleted }.map { it.episodeId }.toSet() + completedEpisodeIds
+        val inProgressEpIdsForResolve = allHistory.filter { !it.isCompleted && it.progressMs > 0L }.map { it.episodeId }.toSet()
+
+        return subs.filter { (it.preferredSort ?: "newest") == "oldest" }.filter { pod ->
+            val currentResolved = _resolvedSerialEpisodes.value[pod.id]
+            val needsResolve = currentResolved == null || currentResolved.id in completedEpIdsForResolve || currentResolved.id in inProgressEpIdsForResolve
+            needsResolve && pod.id !in inFlightResolutions
+        }
+    }
+
+    private fun resolveNextSerialEpisode(
+        allEpisodes: List<Episode>,
+        ongoingId: String?,
+        lastCompletedId: String?,
+        completedEpIdsForResolve: Set<String>,
+        inProgressEpIdsForResolve: Set<String>
+    ): Episode? {
+        val nextEp = when {
+            ongoingId != null -> {
+                val ongoingIndex = allEpisodes.indexOfFirst { it.id == ongoingId }
+                if (ongoingIndex != -1 && ongoingIndex < allEpisodes.lastIndex) {
+                    allEpisodes[ongoingIndex + 1]
+                } else {
+                    null
+                }
+            }
+            lastCompletedId != null -> {
+                val completedIndex = allEpisodes.indexOfFirst { it.id == lastCompletedId }
+                if (completedIndex != -1 && completedIndex < allEpisodes.lastIndex) {
+                    allEpisodes[completedIndex + 1]
+                } else {
+                    null
+                }
+            }
+            else -> {
+                allEpisodes.firstOrNull()
+            }
+        }
+        return nextEp ?: allEpisodes.firstOrNull { ep ->
+            ep.id !in completedEpIdsForResolve && ep.id !in inProgressEpIdsForResolve
         }
     }
 
@@ -1780,48 +1808,17 @@ class HomeViewModel(
 
         if (subscriptions.isEmpty() && historyList.isEmpty()) return null
 
-        val scores = mutableMapOf<String, Int>()
         val lastPlayedMap = mutableMapOf<String, Long>()
         val podcastNameMap = mutableMapOf<String, String>()
         val podcastImageMap = mutableMapOf<String, String>()
 
-        historyList.forEach { history ->
-            val podId = history.podcastId
-            if (podId.isNotEmpty()) {
-                podcastNameMap[podId] = history.podcastName
-                podcastImageMap[podId] = history.podcastImageUrl ?: ""
-                
-                val currentLastPlayed = lastPlayedMap.getOrDefault(podId, 0L)
-                if (history.lastPlayedAt > currentLastPlayed) {
-                    lastPlayedMap[podId] = history.lastPlayedAt
-                }
-
-                var score = scores.getOrDefault(podId, 0)
-                if (history.isCompleted) {
-                    score += 20
-                } else {
-                    // In-progress scoring based on significance:
-                    // - 5+ minutes played: +15 points (significant enough to trigger on its own)
-                    // - 1+ minute played: +5 points (requires multiple episodes to trigger)
-                    if (history.progressMs >= 300_000L) {
-                        score += 15
-                    } else if (history.progressMs >= 60_000L) {
-                        score += 5
-                    }
-                }
-                if (history.isLiked) {
-                    score += 40
-                }
-                scores[podId] = score
-            }
-        }
-
-        subscriptions.forEach { sub ->
-            val score = scores.getOrDefault(sub.id, 0) + 100
-            scores[sub.id] = score
-            podcastNameMap[sub.id] = sub.title
-            podcastImageMap[sub.id] = sub.imageUrl
-        }
+        val scores = calculatePodcastAffinityScores(
+            subscriptions = subscriptions,
+            historyList = historyList,
+            lastPlayedMap = lastPlayedMap,
+            podcastNameMap = podcastNameMap,
+            podcastImageMap = podcastImageMap
+        )
 
         if (scores.isEmpty()) return null
 
@@ -1858,6 +1855,53 @@ class HomeViewModel(
             fallbackImageUrl = "",
             description = ""
         )
+    }
+
+    private fun calculatePodcastAffinityScores(
+        subscriptions: List<Podcast>,
+        historyList: List<ListeningHistoryEntity>,
+        lastPlayedMap: MutableMap<String, Long>,
+        podcastNameMap: MutableMap<String, String>,
+        podcastImageMap: MutableMap<String, String>
+    ): Map<String, Int> {
+        val scores = mutableMapOf<String, Int>()
+
+        historyList.forEach { history ->
+            val podId = history.podcastId
+            if (podId.isNotEmpty()) {
+                podcastNameMap[podId] = history.podcastName
+                podcastImageMap[podId] = history.podcastImageUrl ?: ""
+                
+                val currentLastPlayed = lastPlayedMap.getOrDefault(podId, 0L)
+                if (history.lastPlayedAt > currentLastPlayed) {
+                    lastPlayedMap[podId] = history.lastPlayedAt
+                }
+
+                var score = scores.getOrDefault(podId, 0)
+                if (history.isCompleted) {
+                    score += 20
+                } else {
+                    if (history.progressMs >= 300_000L) {
+                        score += 15
+                    } else if (history.progressMs >= 60_000L) {
+                        score += 5
+                    }
+                }
+                if (history.isLiked) {
+                    score += 40
+                }
+                scores[podId] = score
+            }
+        }
+
+        subscriptions.forEach { sub ->
+            val score = scores.getOrDefault(sub.id, 0) + 100
+            scores[sub.id] = score
+            podcastNameMap[sub.id] = sub.title
+            podcastImageMap[sub.id] = sub.imageUrl
+        }
+        
+        return scores
     }
 
     private fun fetchBecauseYouLikeRecommendations(podcast: Podcast, region: String) {

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DailyBriefingCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DailyBriefingCard.kt
@@ -291,14 +291,16 @@ fun DailyBriefingCard(
                 when (state) {
                     DailyBriefingCardState.NORMAL -> {
                         DailyBriefingNormalContent(
-                            briefing = briefing,
-                            chapters = chapters,
-                            isPlaying = isPlaying,
+                            state = DailyBriefingVisualState(
+                                briefing = briefing,
+                                chapters = chapters,
+                                isPlaying = isPlaying,
+                                isBuffering = isBuffering,
+                                playbackStatus = playbackStatus,
+                                durationMin = durationMin,
+                                timeLeftMin = timeLeftMin
+                            ),
                             onPlayPauseClick = onPlayPauseClick,
-                            playbackStatus = playbackStatus,
-                            timeLeftMin = timeLeftMin,
-                            durationMin = durationMin,
-                            isBuffering = isBuffering,
                             expanded = expanded,
                             onExpandedChange = { expanded = it }
                         )
@@ -323,23 +325,102 @@ fun DailyBriefingCard(
     }
 }
 
+private data class DailyBriefingVisualState(
+    val briefing: Briefing,
+    val chapters: List<cx.aswin.boxcast.core.model.Chapter>,
+    val isPlaying: Boolean,
+    val isBuffering: Boolean,
+    val playbackStatus: EpisodeStatus?,
+    val durationMin: Int,
+    val timeLeftMin: Int
+)
+
+@Composable
+private fun DailyBriefingChapterRow(
+    chapter: cx.aswin.boxcast.core.model.Chapter,
+    index: Int,
+    totalChapters: Int,
+    expanded: Boolean,
+    onToggleExpanded: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .then(
+                if ((index == 2 && !expanded && totalChapters > 3) || 
+                    (index == totalChapters - 1 && expanded && totalChapters > 3)) {
+                    Modifier.clickable { onToggleExpanded() }
+                } else {
+                    Modifier
+                }
+            )
+            .padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        val mins = chapter.startTime.toLong() / 60
+        val secs = chapter.startTime.toLong() % 60
+        val timeStr = String.format(java.util.Locale.US, "%d:%02d", mins, secs)
+        Text(
+            text = timeStr,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+            modifier = Modifier.width(36.dp)
+        )
+        Text(
+            text = chapter.title,
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White.copy(alpha = 0.85f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
+        )
+        
+        // Inline expand/collapse indicator
+        if (index == 2 && !expanded && totalChapters > 3) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                modifier = Modifier.padding(start = 4.dp)
+            ) {
+                Text(
+                    text = "+${totalChapters - 3}",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White.copy(alpha = 0.6f)
+                )
+                Icon(
+                    imageVector = Icons.Rounded.ExpandMore,
+                    contentDescription = "Show more",
+                    tint = Color.White.copy(alpha = 0.6f),
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        } else if (index == totalChapters - 1 && expanded && totalChapters > 3) {
+            Icon(
+                imageVector = Icons.Rounded.ExpandLess,
+                contentDescription = "Show less",
+                tint = Color.White.copy(alpha = 0.6f),
+                modifier = Modifier.size(16.dp).padding(start = 4.dp)
+            )
+        }
+    }
+}
+
 @Composable
 private fun DailyBriefingNormalContent(
-    briefing: Briefing,
-    chapters: List<cx.aswin.boxcast.core.model.Chapter>,
-    isPlaying: Boolean,
+    state: DailyBriefingVisualState,
     onPlayPauseClick: () -> Unit,
-    playbackStatus: EpisodeStatus?,
-    timeLeftMin: Int,
-    durationMin: Int,
-    isBuffering: Boolean,
     expanded: Boolean,
     onExpandedChange: (Boolean) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         // Title
         Text(
-            text = briefing.title,
+            text = state.briefing.title,
             fontFamily = SectionHeaderFontFamily,
             fontSize = 22.sp,
             fontWeight = FontWeight.Bold,
@@ -369,15 +450,15 @@ private fun DailyBriefingNormalContent(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center
             ) {
-                if (isBuffering) {
+                if (state.isBuffering) {
                     BoxLoreLoader.CircularWavy(
                         size = 20.dp,
                         color = MaterialTheme.colorScheme.onPrimary
                     )
                 } else {
                     Icon(
-                        imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause briefing" else "Play briefing",
+                        imageVector = if (state.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                        contentDescription = if (state.isPlaying) "Pause briefing" else "Play briefing",
                         tint = MaterialTheme.colorScheme.onPrimary,
                         modifier = Modifier.size(20.dp)
                     )
@@ -385,9 +466,9 @@ private fun DailyBriefingNormalContent(
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = when {
-                        isPlaying -> "Playing"
-                        playbackStatus == EpisodeStatus.IN_PROGRESS -> "Resume · ${timeLeftMin} min left"
-                        else -> "Listen Now · ${durationMin} min"
+                        state.isPlaying -> "Playing"
+                        state.playbackStatus == EpisodeStatus.IN_PROGRESS -> "Resume · ${state.timeLeftMin} min left"
+                        else -> "Listen Now · ${state.durationMin} min"
                     },
                     style = MaterialTheme.typography.labelLarge,
                     fontWeight = FontWeight.Bold,
@@ -398,7 +479,7 @@ private fun DailyBriefingNormalContent(
         }
 
         // Vertical chapters list (showing 3 by default, max 1 line per chapter)
-        if (chapters.isNotEmpty()) {
+        if (state.chapters.isNotEmpty()) {
             Spacer(modifier = Modifier.height(16.dp))
             Column(
                 modifier = Modifier
@@ -406,80 +487,23 @@ private fun DailyBriefingNormalContent(
                     .padding(horizontal = 20.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                val visibleChapters = if (expanded) chapters else chapters.take(3)
+                val visibleChapters = if (expanded) state.chapters else state.chapters.take(3)
                 visibleChapters.forEachIndexed { index, chapter ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(6.dp))
-                            .then(
-                                if ((index == 2 && !expanded && chapters.size > 3) || 
-                                    (index == chapters.size - 1 && expanded && chapters.size > 3)) {
-                                    Modifier.clickable {
-                                        val nextExpanded = !expanded
-                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingCardChaptersToggled(
-                                            region = briefing.region,
-                                            date = briefing.date,
-                                            expanded = nextExpanded
-                                        )
-                                        onExpandedChange(nextExpanded)
-                                    }
-                                } else {
-                                    Modifier
-                                }
+                    DailyBriefingChapterRow(
+                        chapter = chapter,
+                        index = index,
+                        totalChapters = state.chapters.size,
+                        expanded = expanded,
+                        onToggleExpanded = {
+                            val nextExpanded = !expanded
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingCardChaptersToggled(
+                                region = state.briefing.region,
+                                date = state.briefing.date,
+                                expanded = nextExpanded
                             )
-                            .padding(vertical = 2.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        val mins = chapter.startTime.toLong() / 60
-                        val secs = chapter.startTime.toLong() % 60
-                        val timeStr = String.format(java.util.Locale.US, "%d:%02d", mins, secs)
-                        Text(
-                            text = timeStr,
-                            fontSize = 11.sp,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
-                            modifier = Modifier.width(36.dp)
-                        )
-                        Text(
-                            text = chapter.title,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = Color.White.copy(alpha = 0.85f),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f)
-                        )
-                        
-                        // Inline expand/collapse indicator
-                        if (index == 2 && !expanded && chapters.size > 3) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(2.dp),
-                                modifier = Modifier.padding(start = 4.dp)
-                            ) {
-                                Text(
-                                    text = "+${chapters.size - 3}",
-                                    style = MaterialTheme.typography.labelSmall,
-                                    fontWeight = FontWeight.Bold,
-                                    color = Color.White.copy(alpha = 0.6f)
-                                )
-                                Icon(
-                                    imageVector = Icons.Rounded.ExpandMore,
-                                    contentDescription = "Show more",
-                                    tint = Color.White.copy(alpha = 0.6f),
-                                    modifier = Modifier.size(16.dp)
-                                )
-                            }
-                        } else if (index == chapters.size - 1 && expanded && chapters.size > 3) {
-                            Icon(
-                                imageVector = Icons.Rounded.ExpandLess,
-                                contentDescription = "Show less",
-                                tint = Color.White.copy(alpha = 0.6f),
-                                modifier = Modifier.size(16.dp).padding(start = 4.dp)
-                            )
+                            onExpandedChange(nextExpanded)
                         }
-                    }
+                    )
                 }
             }
         }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DailyBriefingCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DailyBriefingCard.kt
@@ -290,320 +290,373 @@ fun DailyBriefingCard(
             ) { state ->
                 when (state) {
                     DailyBriefingCardState.NORMAL -> {
-                        Column(modifier = Modifier.fillMaxWidth()) {
-                            // Title
-                            Text(
-                                text = briefing.title,
-                                fontFamily = SectionHeaderFontFamily,
-                                fontSize = 22.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White,
-                                maxLines = 3,
-                                overflow = TextOverflow.Ellipsis,
-                                lineHeight = 26.sp,
-                                modifier = Modifier.padding(horizontal = 20.dp)
-                            )
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            // Listen Now / Playing pill button
-                            Surface(
-                                shape = RoundedCornerShape(24.dp),
-                                color = MaterialTheme.colorScheme.primary,
-                                contentColor = MaterialTheme.colorScheme.onPrimary,
-                                modifier = Modifier
-                                    .padding(horizontal = 20.dp)
-                                    .height(48.dp)
-                                    .widthIn(min = 180.dp)
-                                    .clip(RoundedCornerShape(24.dp))
-                                    .expressiveClickable(onClick = onPlayPauseClick)
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(horizontal = 24.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.Center
-                                ) {
-                                    if (isBuffering) {
-                                        BoxLoreLoader.CircularWavy(
-                                            size = 20.dp,
-                                            color = MaterialTheme.colorScheme.onPrimary
-                                        )
-                                    } else {
-                                        Icon(
-                                            imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                                            contentDescription = if (isPlaying) "Pause briefing" else "Play briefing",
-                                            tint = MaterialTheme.colorScheme.onPrimary,
-                                            modifier = Modifier.size(20.dp)
-                                        )
-                                    }
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    Text(
-                                        text = when {
-                                            isPlaying -> "Playing"
-                                            playbackStatus == EpisodeStatus.IN_PROGRESS -> "Resume · ${timeLeftMin} min left"
-                                            else -> "Listen Now · ${durationMin} min"
-                                        },
-                                        style = MaterialTheme.typography.labelLarge,
-                                        fontWeight = FontWeight.Bold,
-                                        color = MaterialTheme.colorScheme.onPrimary,
-                                        letterSpacing = 0.3.sp
-                                    )
-                                }
-                            }
-
-                            // Vertical chapters list (showing 3 by default, max 1 line per chapter)
-                            if (chapters.isNotEmpty()) {
-                                Spacer(modifier = Modifier.height(16.dp))
-                                Column(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 20.dp),
-                                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                                ) {
-                                    val visibleChapters = if (expanded) chapters else chapters.take(3)
-                                    visibleChapters.forEachIndexed { index, chapter ->
-                                        Row(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .clip(RoundedCornerShape(6.dp))
-                                                .then(
-                                                    if ((index == 2 && !expanded && chapters.size > 3) || 
-                                                        (index == chapters.size - 1 && expanded && chapters.size > 3)) {
-                                                        Modifier.clickable {
-                                                            val nextExpanded = !expanded
-                                                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingCardChaptersToggled(
-                                                                region = briefing.region,
-                                                                date = briefing.date,
-                                                                expanded = nextExpanded
-                                                            )
-                                                            expanded = nextExpanded
-                                                        }
-                                                    } else {
-                                                        Modifier
-                                                    }
-                                                )
-                                                .padding(vertical = 2.dp),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                                        ) {
-                                            val mins = chapter.startTime.toLong() / 60
-                                            val secs = chapter.startTime.toLong() % 60
-                                            val timeStr = String.format(java.util.Locale.US, "%d:%02d", mins, secs)
-                                            Text(
-                                                text = timeStr,
-                                                fontSize = 11.sp,
-                                                fontWeight = FontWeight.Bold,
-                                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
-                                                modifier = Modifier.width(36.dp)
-                                            )
-                                            Text(
-                                                text = chapter.title,
-                                                style = MaterialTheme.typography.labelMedium,
-                                                color = Color.White.copy(alpha = 0.85f),
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                                modifier = Modifier.weight(1f)
-                                            )
-                                            
-                                            // Inline expand/collapse indicator
-                                            if (index == 2 && !expanded && chapters.size > 3) {
-                                                Row(
-                                                    verticalAlignment = Alignment.CenterVertically,
-                                                    horizontalArrangement = Arrangement.spacedBy(2.dp),
-                                                    modifier = Modifier.padding(start = 4.dp)
-                                                ) {
-                                                    Text(
-                                                        text = "+${chapters.size - 3}",
-                                                        style = MaterialTheme.typography.labelSmall,
-                                                        fontWeight = FontWeight.Bold,
-                                                        color = Color.White.copy(alpha = 0.6f)
-                                                    )
-                                                    Icon(
-                                                        imageVector = Icons.Rounded.ExpandMore,
-                                                        contentDescription = "Show more",
-                                                        tint = Color.White.copy(alpha = 0.6f),
-                                                        modifier = Modifier.size(16.dp)
-                                                    )
-                                                }
-                                            } else if (index == chapters.size - 1 && expanded && chapters.size > 3) {
-                                                Icon(
-                                                    imageVector = Icons.Rounded.ExpandLess,
-                                                    contentDescription = "Show less",
-                                                    tint = Color.White.copy(alpha = 0.6f),
-                                                    modifier = Modifier.size(16.dp).padding(start = 4.dp)
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            // Bottom padding
-                            Spacer(modifier = Modifier.height(16.dp))
-                        }
+                        DailyBriefingNormalContent(
+                            briefing = briefing,
+                            chapters = chapters,
+                            isPlaying = isPlaying,
+                            onPlayPauseClick = onPlayPauseClick,
+                            playbackStatus = playbackStatus,
+                            timeLeftMin = timeLeftMin,
+                            durationMin = durationMin,
+                            isBuffering = isBuffering,
+                            expanded = expanded,
+                            onExpandedChange = { expanded = it }
+                        )
                     }
                     DailyBriefingCardState.CONFIRM_DISMISS -> {
-                        Column(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            // Dismiss for Today Button (styled exactly like the Listen Now button for visual consistency)
-                            Surface(
-                                shape = RoundedCornerShape(24.dp),
-                                color = MaterialTheme.colorScheme.primary,
-                                contentColor = MaterialTheme.colorScheme.onPrimary,
-                                modifier = Modifier
-                                    .padding(horizontal = 20.dp)
-                                    .height(48.dp)
-                                    .widthIn(min = 180.dp)
-                                    .clip(RoundedCornerShape(24.dp))
-                                    .clickable {
-                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingDismissedToday(
-                                            region = briefing.region,
-                                            date = briefing.date
-                                        )
-                                        onDismiss()
-                                    }
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(horizontal = 24.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.Center
-                                ) {
-                                    Text(
-                                        text = "Dismiss for Today",
-                                        style = MaterialTheme.typography.labelLarge,
-                                        fontWeight = FontWeight.Bold,
-                                        color = MaterialTheme.colorScheme.onPrimary,
-                                        letterSpacing = 0.3.sp
-                                    )
-                                }
-                            }
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            Text(
-                                text = "Dismiss forever",
-                                style = MaterialTheme.typography.labelMedium.copy(
-                                    textDecoration = androidx.compose.ui.text.style.TextDecoration.Underline
-                                ),
-                                fontWeight = FontWeight.SemiBold,
-                                color = Color.White.copy(alpha = 0.6f),
-                                modifier = Modifier
-                                    .padding(horizontal = 20.dp)
-                                    .clickable {
-                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingDismissForeverInitiated(
-                                            region = briefing.region,
-                                            date = briefing.date
-                                        )
-                                        cardState = DailyBriefingCardState.CONFIRM_FOREVER
-                                    }
-                            )
-
-                            Spacer(modifier = Modifier.height(16.dp))
-                        }
+                        DailyBriefingDismissContent(
+                            briefing = briefing,
+                            onDismiss = onDismiss,
+                            onDismissForeverClick = { cardState = DailyBriefingCardState.CONFIRM_FOREVER }
+                        )
                     }
                     DailyBriefingCardState.CONFIRM_FOREVER -> {
-                        Column(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            // Title
-                            Text(
-                                text = "Are you sure?",
-                                fontFamily = SectionHeaderFontFamily,
-                                fontSize = 22.sp,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White,
-                                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-                                modifier = Modifier.padding(horizontal = 20.dp)
+                        DailyBriefingForeverContent(
+                            briefing = briefing,
+                            onFeedbackClick = onFeedbackClick,
+                            onDismissForever = onDismissForever
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DailyBriefingNormalContent(
+    briefing: Briefing,
+    chapters: List<cx.aswin.boxcast.core.model.Chapter>,
+    isPlaying: Boolean,
+    onPlayPauseClick: () -> Unit,
+    playbackStatus: EpisodeStatus?,
+    timeLeftMin: Int,
+    durationMin: Int,
+    isBuffering: Boolean,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // Title
+        Text(
+            text = briefing.title,
+            fontFamily = SectionHeaderFontFamily,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+            lineHeight = 26.sp,
+            modifier = Modifier.padding(horizontal = 20.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Listen Now / Playing pill button
+        Surface(
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .height(48.dp)
+                .widthIn(min = 180.dp)
+                .clip(RoundedCornerShape(24.dp))
+                .expressiveClickable(onClick = onPlayPauseClick)
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 24.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                if (isBuffering) {
+                    BoxLoreLoader.CircularWavy(
+                        size = 20.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                } else {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause briefing" else "Play briefing",
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = when {
+                        isPlaying -> "Playing"
+                        playbackStatus == EpisodeStatus.IN_PROGRESS -> "Resume · ${timeLeftMin} min left"
+                        else -> "Listen Now · ${durationMin} min"
+                    },
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    letterSpacing = 0.3.sp
+                )
+            }
+        }
+
+        // Vertical chapters list (showing 3 by default, max 1 line per chapter)
+        if (chapters.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(16.dp))
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                val visibleChapters = if (expanded) chapters else chapters.take(3)
+                visibleChapters.forEachIndexed { index, chapter ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(6.dp))
+                            .then(
+                                if ((index == 2 && !expanded && chapters.size > 3) || 
+                                    (index == chapters.size - 1 && expanded && chapters.size > 3)) {
+                                    Modifier.clickable {
+                                        val nextExpanded = !expanded
+                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingCardChaptersToggled(
+                                            region = briefing.region,
+                                            date = briefing.date,
+                                            expanded = nextExpanded
+                                        )
+                                        onExpandedChange(nextExpanded)
+                                    }
+                                } else {
+                                    Modifier
+                                }
                             )
-
-                            Spacer(modifier = Modifier.height(12.dp))
-
-                            Text(
-                                text = "We would love to hear your feedback and improve the brief.",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = Color.White.copy(alpha = 0.8f),
-                                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
-                                modifier = Modifier.padding(horizontal = 20.dp)
-                            )
-
-                            Spacer(modifier = Modifier.height(16.dp))
-
-                            // Buttons side by side (using standard M3 48.dp height & 24.dp shape)
+                            .padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        val mins = chapter.startTime.toLong() / 60
+                        val secs = chapter.startTime.toLong() % 60
+                        val timeStr = String.format(java.util.Locale.US, "%d:%02d", mins, secs)
+                        Text(
+                            text = timeStr,
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                            modifier = Modifier.width(36.dp)
+                        )
+                        Text(
+                            text = chapter.title,
+                            style = MaterialTheme.typography.labelMedium,
+                            color = Color.White.copy(alpha = 0.85f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                        
+                        // Inline expand/collapse indicator
+                        if (index == 2 && !expanded && chapters.size > 3) {
                             Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 20.dp),
-                                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                                modifier = Modifier.padding(start = 4.dp)
                             ) {
-                                Surface(
-                                    shape = RoundedCornerShape(24.dp),
-                                    color = MaterialTheme.colorScheme.primary,
-                                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                                    modifier = Modifier
-                                        .height(48.dp)
-                                        .weight(1f)
-                                        .clip(RoundedCornerShape(24.dp))
-                                        .clickable {
-                                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingFeedbackClicked(
-                                                region = briefing.region,
-                                                date = briefing.date
-                                            )
-                                            onFeedbackClick()
-                                        }
-                                ) {
-                                    Box(
-                                        contentAlignment = Alignment.Center,
-                                        modifier = Modifier.fillMaxSize()
-                                    ) {
-                                        Text(
-                                            text = "Send Feedback",
-                                            style = MaterialTheme.typography.labelLarge,
-                                            fontWeight = FontWeight.Bold,
-                                            color = MaterialTheme.colorScheme.onPrimary
-                                        )
-                                    }
-                                }
-
-                                Surface(
-                                    shape = RoundedCornerShape(24.dp),
-                                    color = Color.White.copy(alpha = 0.15f),
-                                    border = androidx.compose.foundation.BorderStroke(1.dp, Color.White.copy(alpha = 0.25f)),
-                                    contentColor = Color.White,
-                                    modifier = Modifier
-                                        .height(48.dp)
-                                        .weight(1f)
-                                        .clip(RoundedCornerShape(24.dp))
-                                        .clickable {
-                                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingDismissedForever(
-                                                region = briefing.region,
-                                                date = briefing.date
-                                            )
-                                            onDismissForever()
-                                        }
-                                ) {
-                                    Box(
-                                        contentAlignment = Alignment.Center,
-                                        modifier = Modifier.fillMaxSize()
-                                    ) {
-                                        Text(
-                                            text = "I'm Sure",
-                                            style = MaterialTheme.typography.labelLarge,
-                                            fontWeight = FontWeight.Bold,
-                                            color = Color.White
-                                        )
-                                    }
-                                }
+                                Text(
+                                    text = "+${chapters.size - 3}",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color.White.copy(alpha = 0.6f)
+                                )
+                                Icon(
+                                    imageVector = Icons.Rounded.ExpandMore,
+                                    contentDescription = "Show more",
+                                    tint = Color.White.copy(alpha = 0.6f),
+                                    modifier = Modifier.size(16.dp)
+                                )
                             }
-
-                            Spacer(modifier = Modifier.height(16.dp))
+                        } else if (index == chapters.size - 1 && expanded && chapters.size > 3) {
+                            Icon(
+                                imageVector = Icons.Rounded.ExpandLess,
+                                contentDescription = "Show less",
+                                tint = Color.White.copy(alpha = 0.6f),
+                                modifier = Modifier.size(16.dp).padding(start = 4.dp)
+                            )
                         }
                     }
                 }
             }
         }
+
+        // Bottom padding
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun DailyBriefingDismissContent(
+    briefing: Briefing,
+    onDismiss: () -> Unit,
+    onDismissForeverClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Dismiss for Today Button (styled exactly like the Listen Now button for visual consistency)
+        Surface(
+            shape = RoundedCornerShape(24.dp),
+            color = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .height(48.dp)
+                .widthIn(min = 180.dp)
+                .clip(RoundedCornerShape(24.dp))
+                .clickable {
+                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingDismissedToday(
+                        region = briefing.region,
+                        date = briefing.date
+                    )
+                    onDismiss()
+                }
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 24.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = "Dismiss for Today",
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    letterSpacing = 0.3.sp
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Dismiss forever",
+            style = MaterialTheme.typography.labelMedium.copy(
+                textDecoration = androidx.compose.ui.text.style.TextDecoration.Underline
+            ),
+            fontWeight = FontWeight.SemiBold,
+            color = Color.White.copy(alpha = 0.6f),
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .clickable {
+                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingDismissForeverInitiated(
+                        region = briefing.region,
+                        date = briefing.date
+                    )
+                    onDismissForeverClick()
+                }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun DailyBriefingForeverContent(
+    briefing: Briefing,
+    onFeedbackClick: () -> Unit,
+    onDismissForever: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Title
+        Text(
+            text = "Are you sure?",
+            fontFamily = SectionHeaderFontFamily,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 20.dp)
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "We would love to hear your feedback and improve the brief.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = Color.White.copy(alpha = 0.8f),
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 20.dp)
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Buttons side by side (using standard M3 48.dp height & 24.dp shape)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Surface(
+                shape = RoundedCornerShape(24.dp),
+                color = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier
+                    .height(48.dp)
+                    .weight(1f)
+                    .clip(RoundedCornerShape(24.dp))
+                    .clickable {
+                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingFeedbackClicked(
+                            region = briefing.region,
+                            date = briefing.date
+                        )
+                        onFeedbackClick()
+                    }
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Text(
+                        text = "Send Feedback",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                }
+            }
+
+            Surface(
+                shape = RoundedCornerShape(24.dp),
+                color = Color.White.copy(alpha = 0.15f),
+                border = androidx.compose.foundation.BorderStroke(1.dp, Color.White.copy(alpha = 0.25f)),
+                contentColor = Color.White,
+                modifier = Modifier
+                    .height(48.dp)
+                    .weight(1f)
+                    .clip(RoundedCornerShape(24.dp))
+                    .clickable {
+                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingDismissedForever(
+                            region = briefing.region,
+                            date = briefing.date
+                        )
+                        onDismissForever()
+                    }
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Text(
+                        text = "I'm Sure",
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
     }
 }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DailyBriefingCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DailyBriefingCard.kt
@@ -411,6 +411,98 @@ private fun DailyBriefingChapterRow(
 }
 
 @Composable
+private fun DailyBriefingPlayButton(
+    isPlaying: Boolean,
+    isBuffering: Boolean,
+    playbackStatus: EpisodeStatus?,
+    timeLeftMin: Int,
+    durationMin: Int,
+    onClick: () -> Unit
+) {
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+        modifier = Modifier
+            .padding(horizontal = 20.dp)
+            .height(48.dp)
+            .widthIn(min = 180.dp)
+            .clip(RoundedCornerShape(24.dp))
+            .expressiveClickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            if (isBuffering) {
+                BoxLoreLoader.CircularWavy(
+                    size = 20.dp,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            } else {
+                Icon(
+                    imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                    contentDescription = if (isPlaying) "Pause briefing" else "Play briefing",
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = when {
+                    isPlaying -> "Playing"
+                    playbackStatus == EpisodeStatus.IN_PROGRESS -> "Resume · ${timeLeftMin} min left"
+                    else -> "Listen Now · ${durationMin} min"
+                },
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onPrimary,
+                letterSpacing = 0.3.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun DailyBriefingChaptersList(
+    chapters: List<cx.aswin.boxcast.core.model.Chapter>,
+    briefingRegion: String,
+    briefingDate: String,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit
+) {
+    if (chapters.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(16.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            val visibleChapters = if (expanded) chapters else chapters.take(3)
+            visibleChapters.forEachIndexed { index, chapter ->
+                DailyBriefingChapterRow(
+                    chapter = chapter,
+                    index = index,
+                    totalChapters = chapters.size,
+                    expanded = expanded,
+                    onToggleExpanded = {
+                        val nextExpanded = !expanded
+                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingCardChaptersToggled(
+                            region = briefingRegion,
+                            date = briefingDate,
+                            expanded = nextExpanded
+                        )
+                        onExpandedChange(nextExpanded)
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun DailyBriefingNormalContent(
     state: DailyBriefingVisualState,
     onPlayPauseClick: () -> Unit,
@@ -433,80 +525,22 @@ private fun DailyBriefingNormalContent(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Listen Now / Playing pill button
-        Surface(
-            shape = RoundedCornerShape(24.dp),
-            color = MaterialTheme.colorScheme.primary,
-            contentColor = MaterialTheme.colorScheme.onPrimary,
-            modifier = Modifier
-                .padding(horizontal = 20.dp)
-                .height(48.dp)
-                .widthIn(min = 180.dp)
-                .clip(RoundedCornerShape(24.dp))
-                .expressiveClickable(onClick = onPlayPauseClick)
-        ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 24.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                if (state.isBuffering) {
-                    BoxLoreLoader.CircularWavy(
-                        size = 20.dp,
-                        color = MaterialTheme.colorScheme.onPrimary
-                    )
-                } else {
-                    Icon(
-                        imageVector = if (state.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                        contentDescription = if (state.isPlaying) "Pause briefing" else "Play briefing",
-                        tint = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = when {
-                        state.isPlaying -> "Playing"
-                        state.playbackStatus == EpisodeStatus.IN_PROGRESS -> "Resume · ${state.timeLeftMin} min left"
-                        else -> "Listen Now · ${state.durationMin} min"
-                    },
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    letterSpacing = 0.3.sp
-                )
-            }
-        }
+        DailyBriefingPlayButton(
+            isPlaying = state.isPlaying,
+            isBuffering = state.isBuffering,
+            playbackStatus = state.playbackStatus,
+            timeLeftMin = state.timeLeftMin,
+            durationMin = state.durationMin,
+            onClick = onPlayPauseClick
+        )
 
-        // Vertical chapters list (showing 3 by default, max 1 line per chapter)
-        if (state.chapters.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(16.dp))
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                val visibleChapters = if (expanded) state.chapters else state.chapters.take(3)
-                visibleChapters.forEachIndexed { index, chapter ->
-                    DailyBriefingChapterRow(
-                        chapter = chapter,
-                        index = index,
-                        totalChapters = state.chapters.size,
-                        expanded = expanded,
-                        onToggleExpanded = {
-                            val nextExpanded = !expanded
-                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackDailyBriefingCardChaptersToggled(
-                                region = state.briefing.region,
-                                date = state.briefing.date,
-                                expanded = nextExpanded
-                            )
-                            onExpandedChange(nextExpanded)
-                        }
-                    )
-                }
-            }
-        }
+        DailyBriefingChaptersList(
+            chapters = state.chapters,
+            briefingRegion = state.briefing.region,
+            briefingDate = state.briefing.date,
+            expanded = expanded,
+            onExpandedChange = onExpandedChange
+        )
 
         // Bottom padding
         Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
Resolves open P1 cognitive complexity code smells by modularizing deep nested rendering layouts and logic blocks into focused private helpers. Specifically:
- **DailyBriefingCard.kt**: Extracted normal content, temporary dismissal, and feedback/forever dismissal rendering layouts into distinct sub-Composables.
- **ShareManager.kt**: Split custom composite share image generation to isolate color contrast/luminance and badge canvas drawing logic.
- **HomeViewModel.kt**: Modularized oldest sort feed resolution and favorite podcast score calculations into decoupled helper functions.