### PR TITLE
Refactor performSync, onAddMediaItems, and playQueue (P1 Complexity)

### DIFF
--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -1054,6 +1054,75 @@ class PlaybackRepository(
         }
     }
 
+    private fun buildMediaItems(episodes: List<Episode>, podcast: Podcast, entryPointContext: android.os.Bundle?): List<MediaItem> {
+        return episodes.map { episode ->
+            val resolvedUrl = episode.imageUrl?.takeIf { it.isNotBlank() } 
+                    ?: episode.podcastImageUrl?.takeIf { it.isNotBlank() } 
+                    ?: podcast.imageUrl
+            Log.d("PlaybackRepo", "playQueue: epId=${episode.id}, title='${episode.title}', resolvedImageUrl='$resolvedUrl'")
+            val metadata = androidx.media3.common.MediaMetadata.Builder()
+               .setTitle(episode.title)
+               .setArtist(episode.podcastTitle ?: podcast.title)
+               .setArtworkUri(android.net.Uri.parse(resolvedUrl))
+               .setDisplayTitle(episode.title)
+               .setSubtitle(episode.podcastTitle ?: podcast.title)
+               .setGenre(episode.podcastGenre ?: podcast.genre)
+               .setExtras(entryPointContext)
+               .build()
+      
+            MediaItem.Builder()
+               .setUri(episode.audioUrl)
+               .setMediaMetadata(metadata)
+               .setMediaId(episode.id)
+               .setCustomCacheKey(episode.id)
+               .build()
+        }
+    }
+
+    private suspend fun checkSavedProgress(startEpisodeId: String?, initialPositionMs: Long?): Pair<Long, Boolean> {
+        var startPosMs = initialPositionMs ?: 0L
+        var initialLikeState = false
+        if (startEpisodeId != null) {
+            val saved = listeningHistoryDao.getHistoryItem(startEpisodeId)
+            if (saved != null) {
+                if (initialPositionMs == null && !saved.isCompleted) {
+                    startPosMs = saved.progressMs
+                }
+                initialLikeState = saved.isLiked
+            }
+            listeningHistoryDao.setCompletionStatus(startEpisodeId, false)
+        }
+        return Pair(startPosMs, initialLikeState)
+    }
+
+    private fun checkShowLateNightNudge(): Boolean {
+        if (isLateNight()) {
+            val lastShown = prefs.getLong("last_late_night_nudge_timestamp", 0L)
+            val now = System.currentTimeMillis()
+            if (now - lastShown > 43_200_000L) {
+                prefs.edit().putLong("last_late_night_nudge_timestamp", now).apply()
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun storePendingEntryPoint(entryPointContext: android.os.Bundle?) {
+        if (entryPointContext != null) {
+            val map = mutableMapOf<String, Any>()
+            entryPointContext.keySet().forEach { key ->
+                @Suppress("DEPRECATION")
+                val value = entryPointContext.get(key)
+                if (value != null) {
+                    map[key] = value
+                }
+            }
+            if (map.isNotEmpty()) {
+                cx.aswin.boxcast.core.data.analytics.PendingEntryPoint.set(map)
+            }
+        }
+    }
+
     suspend fun playQueue(episodes: List<Episode>, podcast: Podcast, startIndex: Int = 0, entryPointContext: android.os.Bundle? = null, initialPositionMs: Long? = null) {
         Log.d("PlaybackRepo", "playQueue() called: count=${episodes.size}, start=$startIndex, podcastGenre='${podcast.genre}'")
         
@@ -1064,68 +1133,21 @@ class PlaybackRepository(
         }
         
         mediaController?.let { controller ->
-            // Optimization: If playing the same context, just seek?
-            // For now, full reload ensures queue is correct.
+            val mediaItems = buildMediaItems(episodes, podcast, entryPointContext)
             
-            val mediaItems = episodes.map { episode ->
-                 val resolvedUrl = episode.imageUrl?.takeIf { it.isNotBlank() } 
-                         ?: episode.podcastImageUrl?.takeIf { it.isNotBlank() } 
-                         ?: podcast.imageUrl
-                 Log.d("PlaybackRepo", "playQueue: epId=${episode.id}, title='${episode.title}', resolvedImageUrl='$resolvedUrl'")
-                 val metadata = androidx.media3.common.MediaMetadata.Builder()
-                    .setTitle(episode.title)
-                    .setArtist(episode.podcastTitle ?: podcast.title)
-                    .setArtworkUri(android.net.Uri.parse(resolvedUrl))
-                    .setDisplayTitle(episode.title) // Required for notification
-                    .setSubtitle(episode.podcastTitle ?: podcast.title)
-                    .setGenre(episode.podcastGenre ?: podcast.genre)
-                    .setExtras(entryPointContext)
-                    .build()
-           
-                 MediaItem.Builder()
-                    .setUri(episode.audioUrl)
-                    .setMediaMetadata(metadata)
-                    .setMediaId(episode.id) // Important for identification
-                    .setCustomCacheKey(episode.id) // Match DownloadRequest custom key
-                    .build()
-            }
-            
-            // Check for saved progress and liked status in a single DB query
-            var startPosMs = initialPositionMs ?: 0L
-            var initialLikeState = false
             val startEpisodeId = episodes.getOrNull(startIndex)?.id
-            if (startEpisodeId != null) {
-                val saved = listeningHistoryDao.getHistoryItem(startEpisodeId)
-                if (saved != null) {
-                    if (initialPositionMs == null && !saved.isCompleted) {
-                        startPosMs = saved.progressMs
-                    }
-                    initialLikeState = saved.isLiked
-                }
-                listeningHistoryDao.setCompletionStatus(startEpisodeId, false)
-            }
+            val (startPosMs, initialLikeState) = checkSavedProgress(startEpisodeId, initialPositionMs)
             
-            // Update local state BEFORE setMediaItems (onMediaItemTransition reads this)
             val currentEp = episodes.getOrNull(startIndex)
             if (currentEp != null) {
-                var showNudge = false
-                if (isLateNight()) {
-                    val lastShown = prefs.getLong("last_late_night_nudge_timestamp", 0L)
-                    val now = System.currentTimeMillis()
-                    // 12 hours = 43,200,000 milliseconds
-                    if (now - lastShown > 43_200_000L) {
-                        showNudge = true
-                        prefs.edit().putLong("last_late_night_nudge_timestamp", now).apply()
-                    }
-                }
-                
+                val showNudge = checkShowLateNightNudge()
                 _playerState.value = _playerState.value.copy(
                     currentEpisode = currentEp,
                     currentPodcast = podcast,
                     isPlaying = true,
                     position = startPosMs,
                     duration = currentEp.duration.toLong() * 1000,
-                    queue = episodes, // Update queue BEFORE Media3 triggers callbacks
+                    queue = episodes,
                     isLiked = initialLikeState,
                     showLateNightNudge = showNudge
                 )
@@ -1135,29 +1157,10 @@ class PlaybackRepository(
             controller.setMediaItems(mediaItems, startIndex, startPosMs)
             controller.prepare()
             
-            // Set entry point context via static holder (IPC-safe)
-            if (entryPointContext != null) {
-                val map = mutableMapOf<String, Any>()
-                entryPointContext.keySet().forEach { key ->
-                    @Suppress("DEPRECATION")
-                    val value = entryPointContext.get(key)
-                    if (value != null) {
-                        map[key] = value
-                    }
-                }
-                if (map.isNotEmpty()) {
-                    cx.aswin.boxcast.core.data.analytics.PendingEntryPoint.set(map)
-                }
-            }
+            storePendingEntryPoint(entryPointContext)
             
             controller.play()
-            
-            // Sync queue to DB for restart recovery
             syncQueueToDb()
-            
-            // Save state immediately but do NOT update lastPlayedAt timestamp to prevent
-            // instant card reordering on the home screen. The timestamp will be updated
-            // after 10 seconds of active playback via the progress ticker.
             saveCurrentState(updateLastPlayedAt = false)
         }
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -118,6 +118,42 @@ class SmartDownloadManager(
         return subs
     }
 
+    private suspend fun resolveOldestSerialNextEpisode(
+        pod: PodcastEntity,
+        allHistory: List<ListeningHistoryEntity>,
+        completedEpIdsForResolve: Set<String>,
+        inProgressEpIdsForResolve: Set<String>
+    ): Episode? {
+        try {
+            val ongoingId = allHistory.filter { h -> h.podcastId == pod.podcastId && !h.isCompleted && h.progressMs > 0L }.maxByOrNull { it.lastPlayedAt }?.episodeId
+            val lastCompletedId = allHistory.filter { h -> h.podcastId == pod.podcastId && h.isCompleted }.maxByOrNull { it.lastPlayedAt }?.episodeId
+            
+            val page = podcastRepository.getEpisodesPaginated(pod.podcastId, limit = 200, offset = 0, sort = "oldest")
+            val allEpisodes = page.episodes
+            
+            return when {
+                ongoingId != null -> {
+                    val ongoingIndex = allEpisodes.indexOfFirst { it.id == ongoingId }
+                    if (ongoingIndex != -1 && ongoingIndex < allEpisodes.lastIndex) {
+                        allEpisodes[ongoingIndex + 1]
+                    } else null
+                }
+                lastCompletedId != null -> {
+                    val completedIndex = allEpisodes.indexOfFirst { it.id == lastCompletedId }
+                    if (completedIndex != -1 && completedIndex < allEpisodes.lastIndex) {
+                        allEpisodes[completedIndex + 1]
+                    } else null
+                }
+                else -> allEpisodes.firstOrNull()
+            } ?: allEpisodes.firstOrNull { ep ->
+                ep.id !in completedEpIdsForResolve && ep.id !in inProgressEpIdsForResolve
+            }
+        } catch (e: Exception) {
+            Log.e("SmartDownloadManager", "Failed to resolve oldest serial next episode for pod ${pod.podcastId}", e)
+        }
+        return null
+    }
+
     private suspend fun resolveOldestSerialNextEpisodes(
         subs: List<PodcastEntity>,
         allHistory: List<ListeningHistoryEntity>,
@@ -129,59 +165,27 @@ class SmartDownloadManager(
         
         for (pod in subs) {
             if ((pod.preferredSort ?: "newest") == "oldest") {
-                try {
-                    val ongoingId = allHistory.filter { h -> h.podcastId == pod.podcastId && !h.isCompleted && h.progressMs > 0L }.maxByOrNull { it.lastPlayedAt }?.episodeId
-                    val lastCompletedId = allHistory.filter { h -> h.podcastId == pod.podcastId && h.isCompleted }.maxByOrNull { it.lastPlayedAt }?.episodeId
-                    
-                    val page = podcastRepository.getEpisodesPaginated(pod.podcastId, limit = 200, offset = 0, sort = "oldest")
-                    val allEpisodes = page.episodes
-                    
-                    val nextEp = when {
-                        ongoingId != null -> {
-                            val ongoingIndex = allEpisodes.indexOfFirst { it.id == ongoingId }
-                            if (ongoingIndex != -1 && ongoingIndex < allEpisodes.lastIndex) {
-                                allEpisodes[ongoingIndex + 1]
-                            } else null
-                        }
-                        lastCompletedId != null -> {
-                            val completedIndex = allEpisodes.indexOfFirst { it.id == lastCompletedId }
-                            if (completedIndex != -1 && completedIndex < allEpisodes.lastIndex) {
-                                allEpisodes[completedIndex + 1]
-                            } else null
-                        }
-                        else -> allEpisodes.firstOrNull()
-                    } ?: allEpisodes.firstOrNull { ep ->
-                        ep.id !in completedEpIdsForResolve && ep.id !in inProgressEpIdsForResolve
-                    }
-                    
-                    if (nextEp != null) {
-                        resolvedSerial[pod.podcastId] = nextEp
-                    }
-                } catch (e: Exception) {
-                    Log.e("SmartDownloadManager", "Failed to resolve oldest serial next episode for pod ${pod.podcastId}", e)
+                val nextEp = resolveOldestSerialNextEpisode(pod, allHistory, completedEpIdsForResolve, inProgressEpIdsForResolve)
+                if (nextEp != null) {
+                    resolvedSerial[pod.podcastId] = nextEp
                 }
             }
         }
         return resolvedSerial
     }
 
-    private fun generateMixtapeCandidates(
-        subs: List<PodcastEntity>,
+    private fun buildInProgressMixtapeCandidates(
+        subsMap: Map<String, PodcastEntity>,
         allHistory: List<ListeningHistoryEntity>,
-        historyByEpisode: Map<String, ListeningHistoryEntity>,
-        resolvedSerial: Map<String, Episode>,
-        podScoresMap: Map<String, Double>
+        subIds: Set<String>
     ): List<MixtapeCandidate> {
-        val subsMap = subs.associateBy { it.podcastId }
-        val subIds = subs.map { it.podcastId }.toSet()
-        
         val inProgressCandidates = allHistory.filter { history ->
             history.podcastId in subIds && !history.isCompleted && history.progressMs > 0L
         }.groupBy { it.podcastId }
          .mapValues { (_, eps) -> eps.maxByOrNull { it.lastPlayedAt } }
          .values.filterNotNull()
 
-        val inProgressMixtapeCandidates = inProgressCandidates.mapNotNull { history ->
+        return inProgressCandidates.mapNotNull { history ->
             val parentPod = subsMap[history.podcastId] ?: return@mapNotNull null
             val hoursSinceLastPlay = (System.currentTimeMillis() - history.lastPlayedAt).toDouble() / (1000.0 * 3600.0)
             val score = 1000.0 + 500.0 / (1.0 + hoursSinceLastPlay.coerceAtLeast(0.0) / 24.0)
@@ -209,7 +213,14 @@ class SmartDownloadManager(
                 durationMs = history.durationMs
             )
         }
+    }
 
+    private fun buildUnplayedDropsMixtapeCandidates(
+        subs: List<PodcastEntity>,
+        resolvedSerial: Map<String, Episode>,
+        historyByEpisode: Map<String, ListeningHistoryEntity>,
+        podScoresMap: Map<String, Double>
+    ): List<MixtapeCandidate> {
         val unplayedDropsCandidates = subs.mapNotNull { pod ->
             val sort = pod.preferredSort ?: "newest"
             if (sort == "oldest") {
@@ -232,7 +243,7 @@ class SmartDownloadManager(
             }
         }
 
-        val unplayedDropsMixtapeCandidates = unplayedDropsCandidates.map { (pod, ep) ->
+        return unplayedDropsCandidates.map { (pod, ep) ->
             val isRecent = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0 <= 168.0
             val releasedAfterSub = ep.publishedDate > (pod.subscribedAt / 1000L) || isRecent
             val freshnessBoost = if (releasedAfterSub) {
@@ -254,7 +265,12 @@ class SmartDownloadManager(
                 episode = ep
             )
         }
+    }
 
+    private fun deduplicateAndOrderMixtapeCandidates(
+        inProgressMixtapeCandidates: List<MixtapeCandidate>,
+        unplayedDropsMixtapeCandidates: List<MixtapeCandidate>
+    ): List<MixtapeCandidate> {
         val allMixtapeCandidates = (inProgressMixtapeCandidates + unplayedDropsMixtapeCandidates)
             .sortedByDescending { it.score }
 
@@ -298,6 +314,22 @@ class SmartDownloadManager(
         }
         orderedCandidates.addAll(unplayedList)
         return orderedCandidates
+    }
+
+    private fun generateMixtapeCandidates(
+        subs: List<PodcastEntity>,
+        allHistory: List<ListeningHistoryEntity>,
+        historyByEpisode: Map<String, ListeningHistoryEntity>,
+        resolvedSerial: Map<String, Episode>,
+        podScoresMap: Map<String, Double>
+    ): List<MixtapeCandidate> {
+        val subsMap = subs.associateBy { it.podcastId }
+        val subIds = subs.map { it.podcastId }.toSet()
+        
+        val inProgress = buildInProgressMixtapeCandidates(subsMap, allHistory, subIds)
+        val unplayed = buildUnplayedDropsMixtapeCandidates(subs, resolvedSerial, historyByEpisode, podScoresMap)
+        
+        return deduplicateAndOrderMixtapeCandidates(inProgress, unplayed)
     }
 
     private suspend fun fetchPersonalizedRecommendations(
@@ -372,28 +404,42 @@ class SmartDownloadManager(
         return chosenTrends
     }
 
+    private fun estimateDownloadSize(download: DownloadedEpisodeEntity): Long {
+        return if (download.status == DownloadedEpisodeEntity.STATUS_COMPLETED) {
+            download.sizeBytes
+        } else if (download.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING) {
+            val durSec = download.durationMs / 1000L
+            if (durSec > 0) durSec * 12000L else 50L * 1024 * 1024
+        } else {
+            0L
+        }
+    }
+
+    private fun estimateEpisodeSize(episode: Episode): Long {
+        return if (episode.duration > 0) {
+            episode.duration.toLong() * 12000L
+        } else {
+            50L * 1024 * 1024
+        }
+    }
+
+    private fun checkIsAlreadyDownloadedOrDownloading(episode: Episode, existingDownloads: List<DownloadedEpisodeEntity>): Boolean {
+        val isAlreadyDownloaded = existingDownloads.any { it.episodeId == episode.id && it.status == DownloadedEpisodeEntity.STATUS_COMPLETED }
+        val isDownloading = existingDownloads.any { it.episodeId == episode.id && it.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING }
+        return isAlreadyDownloaded || isDownloading
+    }
+
     private suspend fun recycleOldDownloads(candidateEpisodeIds: Set<String>, existingDownloads: List<DownloadedEpisodeEntity>): Long {
         var currentDownloadedBytes = 0L
         for (download in existingDownloads) {
             if (download.isSmartDownloaded) {
-                if (download.status == DownloadedEpisodeEntity.STATUS_COMPLETED) {
-                    currentDownloadedBytes += download.sizeBytes
-                } else if (download.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING) {
-                    val durSec = download.durationMs / 1000L
-                    val estSize = if (durSec > 0) durSec * 12000L else 50L * 1024 * 1024
-                    currentDownloadedBytes += estSize
-                }
-            }
-            
-            if (download.isSmartDownloaded && download.episodeId !in candidateEpisodeIds) {
-                Log.d("SmartDownloadManager", "Recycling/cleaning up old smart-downloaded episode: ${download.episodeId}")
-                writeLogToFile(context, "Recycling/deleting old smart-downloaded episode: '${download.episodeTitle}' (ID: ${download.episodeId})")
-                downloadRepository.removeDownload(download.episodeId)
-                if (download.status == DownloadedEpisodeEntity.STATUS_COMPLETED) {
-                    currentDownloadedBytes -= download.sizeBytes
-                } else if (download.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING) {
-                    val durSec = download.durationMs / 1000L
-                    val estSize = if (durSec > 0) durSec * 12000L else 50L * 1024 * 1024
+                val estSize = estimateDownloadSize(download)
+                currentDownloadedBytes += estSize
+                
+                if (download.episodeId !in candidateEpisodeIds) {
+                    Log.d("SmartDownloadManager", "Recycling/cleaning up old smart-downloaded episode: ${download.episodeId}")
+                    writeLogToFile(context, "Recycling/deleting old smart-downloaded episode: '${download.episodeTitle}' (ID: ${download.episodeId})")
+                    downloadRepository.removeDownload(download.episodeId)
                     currentDownloadedBytes -= estSize
                 }
             }
@@ -414,10 +460,7 @@ class SmartDownloadManager(
         var currentDownloadedBytes = startingDownloadedBytes
 
         for (episode in combinedEpisodes) {
-            val isAlreadyDownloaded = existingDownloads.any { it.episodeId == episode.id && it.status == DownloadedEpisodeEntity.STATUS_COMPLETED }
-            val isDownloading = existingDownloads.any { it.episodeId == episode.id && it.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING }
-            
-            if (isAlreadyDownloaded || isDownloading) {
+            if (checkIsAlreadyDownloadedOrDownloading(episode, existingDownloads)) {
                 Log.d("SmartDownloadManager", "Episode ${episode.title} already downloaded or downloading. Skipping.")
                 continue
             }
@@ -428,21 +471,14 @@ class SmartDownloadManager(
                 break
             }
 
-            val estimatedSize = if (episode.duration > 0) {
-                episode.duration.toLong() * 12000L
-            } else {
-                50L * 1024 * 1024
-            }
+            val estimatedSize = estimateEpisodeSize(episode)
 
-            if (storageBudgetMb > 0) {
-                val budgetBytes = storageBudgetMb * 1024 * 1024L
-                if (currentDownloadedBytes + estimatedSize > budgetBytes) {
-                    val estMb = estimatedSize / (1024 * 1024)
-                    val currMb = currentDownloadedBytes / (1024 * 1024)
-                    Log.d("SmartDownloadManager", "Hit storage budget limit ($storageBudgetMb MB). Adding '${episode.title}' (Est: $estMb MB) would exceed budget (Current: $currMb MB). Halting downloads.")
-                    writeLogToFile(context, "Adding '${episode.title}' (Est: $estMb MB) would exceed storage budget ($storageBudgetMb MB). Halting downloads.")
-                    break
-                }
+            if (storageBudgetMb > 0 && currentDownloadedBytes + estimatedSize > storageBudgetMb * 1024 * 1024L) {
+                val estMb = estimatedSize / (1024 * 1024)
+                val currMb = currentDownloadedBytes / (1024 * 1024)
+                Log.d("SmartDownloadManager", "Hit storage budget limit ($storageBudgetMb MB). Adding '${episode.title}' (Est: $estMb MB) would exceed budget (Current: $currMb MB). Halting downloads.")
+                writeLogToFile(context, "Adding '${episode.title}' (Est: $estMb MB) would exceed storage budget ($storageBudgetMb MB). Halting downloads.")
+                break
             }
 
             val parentPod = subs.find { it.podcastId == episode.podcastId }?.toPodcast() ?: Podcast(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -215,6 +215,25 @@ class SmartDownloadManager(
         }
     }
 
+    private fun resolveUnplayedDropCandidate(
+        pod: PodcastEntity,
+        resolvedSerial: Map<String, Episode>,
+        historyByEpisode: Map<String, ListeningHistoryEntity>
+    ): Pair<PodcastEntity, Episode>? {
+        val sort = pod.preferredSort ?: "newest"
+        val ep = if (sort == "oldest") {
+            resolvedSerial[pod.podcastId]
+        } else {
+            null
+        } ?: pod.latestEpisode ?: return null
+
+        val history = historyByEpisode[ep.id]
+        val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
+        return if (isUnplayed) {
+            pod to ep.copy(podcastTitle = pod.title, podcastId = pod.podcastId)
+        } else null
+    }
+
     private fun buildUnplayedDropsMixtapeCandidates(
         subs: List<PodcastEntity>,
         resolvedSerial: Map<String, Episode>,
@@ -222,25 +241,7 @@ class SmartDownloadManager(
         podScoresMap: Map<String, Double>
     ): List<MixtapeCandidate> {
         val unplayedDropsCandidates = subs.mapNotNull { pod ->
-            val sort = pod.preferredSort ?: "newest"
-            if (sort == "oldest") {
-                val resolved = resolvedSerial[pod.podcastId]
-                if (resolved != null) {
-                    pod to resolved.copy(podcastTitle = pod.title, podcastId = pod.podcastId)
-                } else {
-                    val latestEp = pod.latestEpisode ?: return@mapNotNull null
-                    val history = historyByEpisode[latestEp.id]
-                    val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
-                    if (isUnplayed) pod to latestEp.copy(podcastTitle = pod.title, podcastId = pod.podcastId) else null
-                }
-            } else {
-                val latestEp = pod.latestEpisode ?: return@mapNotNull null
-                val history = historyByEpisode[latestEp.id]
-                val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
-                if (isUnplayed) {
-                    pod to latestEp.copy(podcastTitle = pod.title, podcastId = pod.podcastId)
-                } else null
-            }
+            resolveUnplayedDropCandidate(pod, resolvedSerial, historyByEpisode)
         }
 
         return unplayedDropsCandidates.map { (pod, ep) ->
@@ -267,6 +268,22 @@ class SmartDownloadManager(
         }
     }
 
+    private fun shouldIncludeCandidate(cand: MixtapeCandidate, slots: MutableSet<Boolean>): Boolean {
+        if (cand.isProgress !in slots) {
+            return true
+        }
+        if (slots.size < 2) {
+            val isNewTagged = !cand.isProgress && cand.episode.publishedDate > (cand.podcast.subscribedAt / 1000L)
+            if (isNewTagged && slots.contains(true)) {
+                return true
+            }
+            if (cand.isProgress && slots.contains(false)) {
+                return true
+            }
+        }
+        return false
+    }
+
     private fun deduplicateAndOrderMixtapeCandidates(
         inProgressMixtapeCandidates: List<MixtapeCandidate>,
         unplayedDropsMixtapeCandidates: List<MixtapeCandidate>
@@ -282,21 +299,10 @@ class SmartDownloadManager(
             if (cand.episodeId in seenEpisodeIds) continue
             val podId = cand.podcast.id
             val slots = podcastSlots.getOrPut(podId) { mutableSetOf() }
-            if (cand.isProgress !in slots) {
+            if (shouldIncludeCandidate(cand, slots)) {
                 slots.add(cand.isProgress)
                 seenEpisodeIds.add(cand.episodeId)
                 deduplicatedCandidates.add(cand)
-            } else if (slots.size < 2) {
-                val isNewTagged = !cand.isProgress && cand.episode.publishedDate > (cand.podcast.subscribedAt / 1000L)
-                if (isNewTagged && slots.contains(true)) {
-                    slots.add(cand.isProgress)
-                    seenEpisodeIds.add(cand.episodeId)
-                    deduplicatedCandidates.add(cand)
-                } else if (cand.isProgress && slots.contains(false)) {
-                    slots.add(cand.isProgress)
-                    seenEpisodeIds.add(cand.episodeId)
-                    deduplicatedCandidates.add(cand)
-                }
             }
         }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -222,10 +222,10 @@ class SmartDownloadManager(
     ): Pair<PodcastEntity, Episode>? {
         val sort = pod.preferredSort ?: "newest"
         val ep = if (sort == "oldest") {
-            resolvedSerial[pod.podcastId]
+            resolvedSerial[pod.podcastId] ?: pod.latestEpisode
         } else {
-            null
-        } ?: pod.latestEpisode ?: return null
+            pod.latestEpisode
+        } ?: return null
 
         val history = historyByEpisode[ep.id]
         val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
@@ -268,7 +268,7 @@ class SmartDownloadManager(
         }
     }
 
-    private fun shouldIncludeCandidate(cand: MixtapeCandidate, slots: MutableSet<Boolean>): Boolean {
+    private fun shouldIncludeCandidate(cand: MixtapeCandidate, slots: Set<Boolean>): Boolean {
         if (cand.isProgress !in slots) {
             return true
         }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -63,11 +63,7 @@ class SmartDownloadManager(
         val durationMs: Long = 0L
     )
 
-    suspend fun performSync(isManual: Boolean = false, isForeground: Boolean = false): Boolean {
-        Log.d("SmartDownloadManager", "Starting smart downloads sync. isManual=$isManual, isForeground=$isForeground")
-        writeLogToFile(context, "Starting sync. isManual=$isManual, isForeground=$isForeground")
-        
-        // 1. Verify enabled status
+    private suspend fun checkSyncConstraints(isManual: Boolean, isForeground: Boolean): Boolean {
         val isEnabled = userPrefs.smartDownloadsEnabledStream.first()
         if (!isEnabled && !isManual && !isForeground) {
             Log.d("SmartDownloadManager", "Smart downloads disabled. Sync skipped.")
@@ -75,7 +71,6 @@ class SmartDownloadManager(
             return false
         }
 
-        // 2. Network Constraints check
         val wifiOnly = userPrefs.smartDownloadsWifiOnlyStream.first()
         if (wifiOnly && !isManual) {
             val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
@@ -90,7 +85,6 @@ class SmartDownloadManager(
             }
         }
 
-        // 3. Battery Constraints check
         val chargingOnly = userPrefs.smartDownloadsChargingOnlyStream.first()
         if (chargingOnly && !isManual && !isForeground) {
             val intent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
@@ -102,215 +96,399 @@ class SmartDownloadManager(
                 return false
             }
         }
+        return true
+    }
+
+    private suspend fun getAndSyncSubscriptions(): List<PodcastEntity> {
+        var subs = database.podcastDao().getSubscribedPodcastsList()
+        if (subs.isEmpty()) {
+            return emptyList()
+        }
 
         try {
-            // 4. Gather Subscriptions and listening history
-            var subs = database.podcastDao().getSubscribedPodcastsList()
+            val feedIds = subs.map { it.podcastId }
+            val freshLatestEpisodes = podcastRepository.syncSubscriptions(feedIds)
+            for ((podId, ep) in freshLatestEpisodes) {
+                subscriptionRepository.updateLatestEpisode(podId, ep)
+            }
+            subs = database.podcastDao().getSubscribedPodcastsList()
+        } catch (e: Exception) {
+            Log.e("SmartDownloadManager", "Failed to bulk sync subscription metadata", e)
+        }
+        return subs
+    }
+
+    private suspend fun resolveOldestSerialNextEpisodes(
+        subs: List<PodcastEntity>,
+        allHistory: List<ListeningHistoryEntity>,
+        completedEpisodeIds: List<String>
+    ): Map<String, Episode> {
+        val completedEpIdsForResolve = allHistory.filter { it.isCompleted }.map { it.episodeId }.toSet() + completedEpisodeIds
+        val inProgressEpIdsForResolve = allHistory.filter { !it.isCompleted && it.progressMs > 0L }.map { it.episodeId }.toSet()
+        val resolvedSerial = mutableMapOf<String, Episode>()
+        
+        for (pod in subs) {
+            if ((pod.preferredSort ?: "newest") == "oldest") {
+                try {
+                    val ongoingId = allHistory.filter { h -> h.podcastId == pod.podcastId && !h.isCompleted && h.progressMs > 0L }.maxByOrNull { it.lastPlayedAt }?.episodeId
+                    val lastCompletedId = allHistory.filter { h -> h.podcastId == pod.podcastId && h.isCompleted }.maxByOrNull { it.lastPlayedAt }?.episodeId
+                    
+                    val page = podcastRepository.getEpisodesPaginated(pod.podcastId, limit = 200, offset = 0, sort = "oldest")
+                    val allEpisodes = page.episodes
+                    
+                    val nextEp = when {
+                        ongoingId != null -> {
+                            val ongoingIndex = allEpisodes.indexOfFirst { it.id == ongoingId }
+                            if (ongoingIndex != -1 && ongoingIndex < allEpisodes.lastIndex) {
+                                allEpisodes[ongoingIndex + 1]
+                            } else null
+                        }
+                        lastCompletedId != null -> {
+                            val completedIndex = allEpisodes.indexOfFirst { it.id == lastCompletedId }
+                            if (completedIndex != -1 && completedIndex < allEpisodes.lastIndex) {
+                                allEpisodes[completedIndex + 1]
+                            } else null
+                        }
+                        else -> allEpisodes.firstOrNull()
+                    } ?: allEpisodes.firstOrNull { ep ->
+                        ep.id !in completedEpIdsForResolve && ep.id !in inProgressEpIdsForResolve
+                    }
+                    
+                    if (nextEp != null) {
+                        resolvedSerial[pod.podcastId] = nextEp
+                    }
+                } catch (e: Exception) {
+                    Log.e("SmartDownloadManager", "Failed to resolve oldest serial next episode for pod ${pod.podcastId}", e)
+                }
+            }
+        }
+        return resolvedSerial
+    }
+
+    private fun generateMixtapeCandidates(
+        subs: List<PodcastEntity>,
+        allHistory: List<ListeningHistoryEntity>,
+        historyByEpisode: Map<String, ListeningHistoryEntity>,
+        resolvedSerial: Map<String, Episode>,
+        podScoresMap: Map<String, Double>
+    ): List<MixtapeCandidate> {
+        val subsMap = subs.associateBy { it.podcastId }
+        val subIds = subs.map { it.podcastId }.toSet()
+        
+        val inProgressCandidates = allHistory.filter { history ->
+            history.podcastId in subIds && !history.isCompleted && history.progressMs > 0L
+        }.groupBy { it.podcastId }
+         .mapValues { (_, eps) -> eps.maxByOrNull { it.lastPlayedAt } }
+         .values.filterNotNull()
+
+        val inProgressMixtapeCandidates = inProgressCandidates.mapNotNull { history ->
+            val parentPod = subsMap[history.podcastId] ?: return@mapNotNull null
+            val hoursSinceLastPlay = (System.currentTimeMillis() - history.lastPlayedAt).toDouble() / (1000.0 * 3600.0)
+            val score = 1000.0 + 500.0 / (1.0 + hoursSinceLastPlay.coerceAtLeast(0.0) / 24.0)
+
+            val inProgressEpisode = Episode(
+                id = history.episodeId,
+                title = history.episodeTitle,
+                description = "",
+                audioUrl = history.episodeAudioUrl ?: "",
+                imageUrl = history.episodeImageUrl ?: "",
+                podcastImageUrl = history.podcastImageUrl ?: parentPod.imageUrl ?: "",
+                podcastTitle = history.podcastName.takeIf { it.isNotBlank() && it != "Unknown Podcast" } ?: parentPod.title,
+                podcastId = history.podcastId,
+                duration = (history.durationMs / 1000).toInt(),
+                publishedDate = 0L
+            )
+
+            MixtapeCandidate(
+                episodeId = history.episodeId,
+                score = score,
+                isProgress = true,
+                podcast = parentPod.toPodcast(),
+                episode = inProgressEpisode,
+                progressMs = history.progressMs,
+                durationMs = history.durationMs
+            )
+        }
+
+        val unplayedDropsCandidates = subs.mapNotNull { pod ->
+            val sort = pod.preferredSort ?: "newest"
+            if (sort == "oldest") {
+                val resolved = resolvedSerial[pod.podcastId]
+                if (resolved != null) {
+                    pod to resolved.copy(podcastTitle = pod.title, podcastId = pod.podcastId)
+                } else {
+                    val latestEp = pod.latestEpisode ?: return@mapNotNull null
+                    val history = historyByEpisode[latestEp.id]
+                    val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
+                    if (isUnplayed) pod to latestEp.copy(podcastTitle = pod.title, podcastId = pod.podcastId) else null
+                }
+            } else {
+                val latestEp = pod.latestEpisode ?: return@mapNotNull null
+                val history = historyByEpisode[latestEp.id]
+                val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
+                if (isUnplayed) {
+                    pod to latestEp.copy(podcastTitle = pod.title, podcastId = pod.podcastId)
+                } else null
+            }
+        }
+
+        val unplayedDropsMixtapeCandidates = unplayedDropsCandidates.map { (pod, ep) ->
+            val isRecent = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0 <= 168.0
+            val releasedAfterSub = ep.publishedDate > (pod.subscribedAt / 1000L) || isRecent
+            val freshnessBoost = if (releasedAfterSub) {
+                val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
+                300.0 / (1.0 + hoursSinceRelease.coerceAtLeast(0.0) / 24.0)
+            } else 0.0
+            val newTagBoost = if (releasedAfterSub) 200.0 else 0.0
+            val sort = pod.preferredSort ?: "newest"
+            val serialBoost = if (sort == "oldest") 150.0 else 0.0
+
+            val parentPodScore = podScoresMap[pod.podcastId] ?: 0.0
+            val score = 500.0 + freshnessBoost + newTagBoost + serialBoost + 0.8 * parentPodScore
+
+            MixtapeCandidate(
+                episodeId = ep.id,
+                score = score,
+                isProgress = false,
+                podcast = pod.toPodcast(),
+                episode = ep
+            )
+        }
+
+        val allMixtapeCandidates = (inProgressMixtapeCandidates + unplayedDropsMixtapeCandidates)
+            .sortedByDescending { it.score }
+
+        val deduplicatedCandidates = mutableListOf<MixtapeCandidate>()
+        val seenEpisodeIds = mutableSetOf<String>()
+        val podcastSlots = mutableMapOf<String, MutableSet<Boolean>>()
+        
+        for (cand in allMixtapeCandidates) {
+            if (cand.episodeId in seenEpisodeIds) continue
+            val podId = cand.podcast.id
+            val slots = podcastSlots.getOrPut(podId) { mutableSetOf() }
+            if (cand.isProgress !in slots) {
+                slots.add(cand.isProgress)
+                seenEpisodeIds.add(cand.episodeId)
+                deduplicatedCandidates.add(cand)
+            } else if (slots.size < 2) {
+                val isNewTagged = !cand.isProgress && cand.episode.publishedDate > (cand.podcast.subscribedAt / 1000L)
+                if (isNewTagged && slots.contains(true)) {
+                    slots.add(cand.isProgress)
+                    seenEpisodeIds.add(cand.episodeId)
+                    deduplicatedCandidates.add(cand)
+                } else if (cand.isProgress && slots.contains(false)) {
+                    slots.add(cand.isProgress)
+                    seenEpisodeIds.add(cand.episodeId)
+                    deduplicatedCandidates.add(cand)
+                }
+            }
+        }
+
+        val orderedCandidates = mutableListOf<MixtapeCandidate>()
+        val inProgressList = deduplicatedCandidates.filter { it.isProgress }
+        val unplayedList = deduplicatedCandidates.filter { !it.isProgress }.toMutableList()
+
+        for (ipCand in inProgressList) {
+            orderedCandidates.add(ipCand)
+            val nextEpCand = unplayedList.find { it.podcast.id == ipCand.podcast.id }
+            if (nextEpCand != null) {
+                orderedCandidates.add(nextEpCand)
+                unplayedList.remove(nextEpCand)
+            }
+        }
+        orderedCandidates.addAll(unplayedList)
+        return orderedCandidates
+    }
+
+    private suspend fun fetchPersonalizedRecommendations(
+        subs: List<PodcastEntity>,
+        chosenSubsIds: Set<String>,
+        targetSize: Int
+    ): List<Episode> {
+        val chosenRecs = mutableListOf<Episode>()
+        if (targetSize > 0) {
+            try {
+                val historyItems = playbackRepository.getHistoryForRecommendations(15)
+                val subscribedIds = subs.map { it.podcastId }
+                val subscribedGenres = subs.mapNotNull { it.genre }.distinct()
+                val region = userPrefs.regionStream.first().takeIf { it.isNotBlank() } ?: "us"
+                
+                val recs = podcastRepository.getPersonalizedRecommendations(
+                    history = historyItems,
+                    country = region,
+                    subscribedPodcastIds = subscribedIds,
+                    subscribedGenres = subscribedGenres
+                )
+                
+                val existingDownloads = database.downloadedEpisodeDao().getAllDownloadsSync()
+                val completedEpisodeIds = database.listeningHistoryDao().getCompletedEpisodeIds().toSet()
+                
+                val filteredRecs = recs.filter { ep ->
+                    ep.id !in chosenSubsIds &&
+                    ep.id !in completedEpisodeIds &&
+                    existingDownloads.none { it.episodeId == ep.id }
+                }.distinctBy { it.id }
+                
+                chosenRecs.addAll(filteredRecs.take(targetSize))
+                writeLogToFile(context, "Fetched ${recs.size} recommendations from endpoint. Selected ${chosenRecs.size} after filtering.")
+            } catch (e: Exception) {
+                Log.e("SmartDownloadManager", "Failed to fetch personalized recommendations for sync", e)
+                writeLogToFile(context, "Failed to fetch personalized recommendations: ${e.message}")
+            }
+        }
+        return chosenRecs
+    }
+
+    private suspend fun fetchTrendingEpisodes(
+        chosenSubsIds: Set<String>,
+        chosenRecsIds: Set<String>,
+        targetSize: Int
+    ): List<Episode> {
+        val chosenTrends = mutableListOf<Episode>()
+        if (targetSize > 0) {
+            try {
+                val region = userPrefs.regionStream.first().takeIf { it.isNotBlank() } ?: "us"
+                val trendingPods = podcastRepository.getTrendingPodcasts(country = region, limit = 30)
+                
+                val trendingEpisodes = trendingPods.mapNotNull { it.latestEpisode }
+                
+                val existingDownloads = database.downloadedEpisodeDao().getAllDownloadsSync()
+                val completedEpisodeIds = database.listeningHistoryDao().getCompletedEpisodeIds().toSet()
+                
+                val filteredTrends = trendingEpisodes.filter { ep ->
+                    ep.id !in chosenSubsIds &&
+                    ep.id !in chosenRecsIds &&
+                    ep.id !in completedEpisodeIds &&
+                    existingDownloads.none { it.episodeId == ep.id }
+                }.distinctBy { it.id }
+                
+                chosenTrends.addAll(filteredTrends.take(targetSize))
+                writeLogToFile(context, "Fetched ${trendingPods.size} trending podcasts from endpoint. Selected ${chosenTrends.size} episodes after filtering.")
+            } catch (e: Exception) {
+                Log.e("SmartDownloadManager", "Failed to fetch trending podcasts for sync", e)
+                writeLogToFile(context, "Failed to fetch trending: ${e.message}")
+            }
+        }
+        return chosenTrends
+    }
+
+    private suspend fun recycleOldDownloads(candidateEpisodeIds: Set<String>, existingDownloads: List<DownloadedEpisodeEntity>): Long {
+        var currentDownloadedBytes = 0L
+        for (download in existingDownloads) {
+            if (download.isSmartDownloaded) {
+                if (download.status == DownloadedEpisodeEntity.STATUS_COMPLETED) {
+                    currentDownloadedBytes += download.sizeBytes
+                } else if (download.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING) {
+                    val durSec = download.durationMs / 1000L
+                    val estSize = if (durSec > 0) durSec * 12000L else 50L * 1024 * 1024
+                    currentDownloadedBytes += estSize
+                }
+            }
             
+            if (download.isSmartDownloaded && download.episodeId !in candidateEpisodeIds) {
+                Log.d("SmartDownloadManager", "Recycling/cleaning up old smart-downloaded episode: ${download.episodeId}")
+                writeLogToFile(context, "Recycling/deleting old smart-downloaded episode: '${download.episodeTitle}' (ID: ${download.episodeId})")
+                downloadRepository.removeDownload(download.episodeId)
+                if (download.status == DownloadedEpisodeEntity.STATUS_COMPLETED) {
+                    currentDownloadedBytes -= download.sizeBytes
+                } else if (download.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING) {
+                    val durSec = download.durationMs / 1000L
+                    val estSize = if (durSec > 0) durSec * 12000L else 50L * 1024 * 1024
+                    currentDownloadedBytes -= estSize
+                }
+            }
+        }
+        return currentDownloadedBytes
+    }
+
+    private suspend fun triggerDownloads(
+        combinedEpisodes: List<Episode>,
+        existingDownloads: List<DownloadedEpisodeEntity>,
+        subs: List<PodcastEntity>,
+        maxCount: Int,
+        storageBudgetMb: Long,
+        startingDownloadedBytes: Long,
+        startingCount: Int
+    ) {
+        var countDownloaded = startingCount
+        var currentDownloadedBytes = startingDownloadedBytes
+
+        for (episode in combinedEpisodes) {
+            val isAlreadyDownloaded = existingDownloads.any { it.episodeId == episode.id && it.status == DownloadedEpisodeEntity.STATUS_COMPLETED }
+            val isDownloading = existingDownloads.any { it.episodeId == episode.id && it.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING }
+            
+            if (isAlreadyDownloaded || isDownloading) {
+                Log.d("SmartDownloadManager", "Episode ${episode.title} already downloaded or downloading. Skipping.")
+                continue
+            }
+
+            if (countDownloaded >= maxCount) {
+                Log.d("SmartDownloadManager", "Hit max count limit ($maxCount episodes). Halting downloads.")
+                writeLogToFile(context, "Hit max count limit ($maxCount episodes). Halting downloads.")
+                break
+            }
+
+            val estimatedSize = if (episode.duration > 0) {
+                episode.duration.toLong() * 12000L
+            } else {
+                50L * 1024 * 1024
+            }
+
+            if (storageBudgetMb > 0) {
+                val budgetBytes = storageBudgetMb * 1024 * 1024L
+                if (currentDownloadedBytes + estimatedSize > budgetBytes) {
+                    val estMb = estimatedSize / (1024 * 1024)
+                    val currMb = currentDownloadedBytes / (1024 * 1024)
+                    Log.d("SmartDownloadManager", "Hit storage budget limit ($storageBudgetMb MB). Adding '${episode.title}' (Est: $estMb MB) would exceed budget (Current: $currMb MB). Halting downloads.")
+                    writeLogToFile(context, "Adding '${episode.title}' (Est: $estMb MB) would exceed storage budget ($storageBudgetMb MB). Halting downloads.")
+                    break
+                }
+            }
+
+            val parentPod = subs.find { it.podcastId == episode.podcastId }?.toPodcast() ?: Podcast(
+                id = episode.podcastId ?: "0",
+                title = episode.podcastTitle?.takeIf { it.isNotBlank() } ?: "Unknown Podcast",
+                artist = episode.podcastArtist ?: "Unknown",
+                imageUrl = episode.podcastImageUrl?.takeIf { it.isNotBlank() } ?: episode.imageUrl ?: ""
+            )
+
+            Log.d("SmartDownloadManager", "Auto-downloading smart mixtape candidate: ${episode.title} (pod=${parentPod.title}, estSize=${estimatedSize / (1024 * 1024)} MB)")
+            writeLogToFile(context, "Triggered download for episode: '${episode.title}' (Show: '${parentPod.title}', Est: ${estimatedSize / (1024 * 1024)} MB)")
+            downloadRepository.addDownload(episode, parentPod, isSmartDownloaded = true)
+            countDownloaded++
+            currentDownloadedBytes += estimatedSize
+        }
+    }
+
+    suspend fun performSync(isManual: Boolean = false, isForeground: Boolean = false): Boolean {
+        Log.d("SmartDownloadManager", "Starting smart downloads sync. isManual=$isManual, isForeground=$isForeground")
+        writeLogToFile(context, "Starting sync. isManual=$isManual, isForeground=$isForeground")
+        
+        if (!checkSyncConstraints(isManual, isForeground)) {
+            return false
+        }
+
+        try {
+            val subs = getAndSyncSubscriptions()
             if (subs.isEmpty()) {
                 Log.d("SmartDownloadManager", "No subscribed podcasts found. Sync skipped.")
                 return false
             }
 
-            // Bulk sync latest episodes from the server to get fresh metadata
-            try {
-                val feedIds = subs.map { it.podcastId }
-                val freshLatestEpisodes = podcastRepository.syncSubscriptions(feedIds)
-                for ((podId, ep) in freshLatestEpisodes) {
-                    subscriptionRepository.updateLatestEpisode(podId, ep)
-                }
-                // Reload subs from database to use updated latestEpisode references
-                subs = database.podcastDao().getSubscribedPodcastsList()
-            } catch (e: Exception) {
-                Log.e("SmartDownloadManager", "Failed to bulk sync subscription metadata", e)
-            }
-
             val allHistory = database.listeningHistoryDao().getRecentHistoryList(limit = 200)
             val completedEpisodeIds = database.listeningHistoryDao().getCompletedEpisodeIds()
 
-            // Resolve serial podcasts (Preferred sort oldest)
-            val completedEpIdsForResolve = allHistory.filter { it.isCompleted }.map { it.episodeId }.toSet() + completedEpisodeIds
-            val inProgressEpIdsForResolve = allHistory.filter { !it.isCompleted && it.progressMs > 0L }.map { it.episodeId }.toSet()
-            val resolvedSerial = mutableMapOf<String, Episode>()
-            
-            for (pod in subs) {
-                if ((pod.preferredSort ?: "newest") == "oldest") {
-                    try {
-                        val ongoingId = allHistory.filter { h -> h.podcastId == pod.podcastId && !h.isCompleted && h.progressMs > 0L }.maxByOrNull { it.lastPlayedAt }?.episodeId
-                        val lastCompletedId = allHistory.filter { h -> h.podcastId == pod.podcastId && h.isCompleted }.maxByOrNull { it.lastPlayedAt }?.episodeId
-                        
-                        val page = podcastRepository.getEpisodesPaginated(pod.podcastId, limit = 200, offset = 0, sort = "oldest")
-                        val allEpisodes = page.episodes
-                        
-                        val nextEp = when {
-                            ongoingId != null -> {
-                                val ongoingIndex = allEpisodes.indexOfFirst { it.id == ongoingId }
-                                if (ongoingIndex != -1 && ongoingIndex < allEpisodes.lastIndex) {
-                                    allEpisodes[ongoingIndex + 1]
-                                } else null
-                            }
-                            lastCompletedId != null -> {
-                                val completedIndex = allEpisodes.indexOfFirst { it.id == lastCompletedId }
-                                if (completedIndex != -1 && completedIndex < allEpisodes.lastIndex) {
-                                    allEpisodes[completedIndex + 1]
-                                } else null
-                            }
-                            else -> allEpisodes.firstOrNull()
-                        } ?: allEpisodes.firstOrNull { ep ->
-                            ep.id !in completedEpIdsForResolve && ep.id !in inProgressEpIdsForResolve
-                        }
-                        
-                        if (nextEp != null) {
-                            resolvedSerial[pod.podcastId] = nextEp
-                        }
-                    } catch (e: Exception) {
-                        Log.e("SmartDownloadManager", "Failed to resolve oldest serial next episode for pod ${pod.podcastId}", e)
-                    }
-                }
-            }
+            val resolvedSerial = resolveOldestSerialNextEpisodes(subs, allHistory, completedEpisodeIds)
 
-            // 5. Run the Mixtape scoring algorithm
-            // Group/Index listening history for O(N + M) efficiency
-            val historyByPodcast = allHistory.groupBy { it.podcastId }
             val historyByEpisode = allHistory.associateBy { it.episodeId }
-            val subsMap = subs.associateBy { it.podcastId }
-
             val podScoresMap = PodcastScoring.calculateScores(
                 podcasts = subs.map { it.toScorable() },
                 allHistory = allHistory,
-                includeAutoDownloadBoost = false // Disable autoDownloadBoost as per original logic
+                includeAutoDownloadBoost = false
             )
 
-            val subIds = subs.map { it.podcastId }.toSet()
-            
-            // A. In-Progress candidates
-            val inProgressCandidates = allHistory.filter { history ->
-                history.podcastId in subIds && !history.isCompleted && history.progressMs > 0L
-            }.groupBy { it.podcastId }
-             .mapValues { (_, eps) -> eps.maxByOrNull { it.lastPlayedAt } }
-             .values.filterNotNull()
+            val orderedCandidates = generateMixtapeCandidates(subs, allHistory, historyByEpisode, resolvedSerial, podScoresMap)
 
-            val inProgressMixtapeCandidates = inProgressCandidates.mapNotNull { history ->
-                val parentPod = subsMap[history.podcastId] ?: return@mapNotNull null
-                val hoursSinceLastPlay = (System.currentTimeMillis() - history.lastPlayedAt).toDouble() / (1000.0 * 3600.0)
-                val score = 1000.0 + 500.0 / (1.0 + hoursSinceLastPlay.coerceAtLeast(0.0) / 24.0)
-
-                val inProgressEpisode = Episode(
-                    id = history.episodeId,
-                    title = history.episodeTitle,
-                    description = "",
-                    audioUrl = history.episodeAudioUrl ?: "",
-                    imageUrl = history.episodeImageUrl ?: "",
-                    podcastImageUrl = history.podcastImageUrl ?: parentPod.imageUrl ?: "",
-                    podcastTitle = history.podcastName.takeIf { it.isNotBlank() && it != "Unknown Podcast" } ?: parentPod.title,
-                    podcastId = history.podcastId,
-                    duration = (history.durationMs / 1000).toInt(),
-                    publishedDate = 0L
-                )
-
-                MixtapeCandidate(
-                    episodeId = history.episodeId,
-                    score = score,
-                    isProgress = true,
-                    podcast = parentPod.toPodcast(),
-                    episode = inProgressEpisode,
-                    progressMs = history.progressMs,
-                    durationMs = history.durationMs
-                )
-            }
-
-            // B. Unplayed Drops Candidates
-            val unplayedDropsCandidates = subs.mapNotNull { pod ->
-                val sort = pod.preferredSort ?: "newest"
-                if (sort == "oldest") {
-                    val resolved = resolvedSerial[pod.podcastId]
-                    if (resolved != null) {
-                        pod to resolved.copy(podcastTitle = pod.title, podcastId = pod.podcastId)
-                    } else {
-                        val latestEp = pod.latestEpisode ?: return@mapNotNull null
-                        val history = historyByEpisode[latestEp.id]
-                        val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
-                        if (isUnplayed) pod to latestEp.copy(podcastTitle = pod.title, podcastId = pod.podcastId) else null
-                    }
-                } else {
-                    val latestEp = pod.latestEpisode ?: return@mapNotNull null
-                    val history = historyByEpisode[latestEp.id]
-                    val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
-                    if (isUnplayed) {
-                        pod to latestEp.copy(podcastTitle = pod.title, podcastId = pod.podcastId)
-                    } else null
-                }
-            }
-
-            val unplayedDropsMixtapeCandidates = unplayedDropsCandidates.map { (pod, ep) ->
-                val isRecent = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0 <= 168.0
-                val releasedAfterSub = ep.publishedDate > (pod.subscribedAt / 1000L) || isRecent
-                val freshnessBoost = if (releasedAfterSub) {
-                    val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
-                    300.0 / (1.0 + hoursSinceRelease.coerceAtLeast(0.0) / 24.0)
-                } else 0.0
-                val newTagBoost = if (releasedAfterSub) 200.0 else 0.0
-                val sort = pod.preferredSort ?: "newest"
-                val serialBoost = if (sort == "oldest") 150.0 else 0.0
-
-                val parentPodScore = podScoresMap[pod.podcastId] ?: 0.0
-                val score = 500.0 + freshnessBoost + newTagBoost + serialBoost + 0.8 * parentPodScore
-
-                MixtapeCandidate(
-                    episodeId = ep.id,
-                    score = score,
-                    isProgress = false,
-                    podcast = pod.toPodcast(),
-                    episode = ep
-                )
-            }
-
-            // C. Combine & Deduplicate
-            val allMixtapeCandidates = (inProgressMixtapeCandidates + unplayedDropsMixtapeCandidates)
-                .sortedByDescending { it.score }
-
-            val deduplicatedCandidates = mutableListOf<MixtapeCandidate>()
-            val seenEpisodeIds = mutableSetOf<String>()
-            val podcastSlots = mutableMapOf<String, MutableSet<Boolean>>()
-            
-            for (cand in allMixtapeCandidates) {
-                if (cand.episodeId in seenEpisodeIds) continue
-                val podId = cand.podcast.id
-                val slots = podcastSlots.getOrPut(podId) { mutableSetOf() }
-                if (cand.isProgress !in slots) {
-                    slots.add(cand.isProgress)
-                    seenEpisodeIds.add(cand.episodeId)
-                    deduplicatedCandidates.add(cand)
-                } else if (slots.size < 2) {
-                    val isNewTagged = !cand.isProgress && cand.episode.publishedDate > (cand.podcast.subscribedAt / 1000L)
-                    if (isNewTagged && slots.contains(true)) {
-                        slots.add(cand.isProgress)
-                        seenEpisodeIds.add(cand.episodeId)
-                        deduplicatedCandidates.add(cand)
-                    } else if (cand.isProgress && slots.contains(false)) {
-                        slots.add(cand.isProgress)
-                        seenEpisodeIds.add(cand.episodeId)
-                        deduplicatedCandidates.add(cand)
-                    }
-                }
-            }
-
-            // Re-order
-            val orderedCandidates = mutableListOf<MixtapeCandidate>()
-            val inProgressList = deduplicatedCandidates.filter { it.isProgress }
-            val unplayedList = deduplicatedCandidates.filter { !it.isProgress }.toMutableList()
-
-            for (ipCand in inProgressList) {
-                orderedCandidates.add(ipCand)
-                val nextEpCand = unplayedList.find { it.podcast.id == ipCand.podcast.id }
-                if (nextEpCand != null) {
-                    orderedCandidates.add(nextEpCand)
-                    unplayedList.remove(nextEpCand)
-                }
-            }
-            orderedCandidates.addAll(unplayedList)
-
-            // 6. Calculate Quotas
             val maxCount = userPrefs.smartDownloadsMaxEpisodesStream.first()
             val storageBudgetMb = userPrefs.smartDownloadsStorageBudgetStream.first()
 
@@ -320,7 +498,6 @@ class SmartDownloadManager(
             
             writeLogToFile(context, "Calculated quotas - Subscriptions: $subQuota, Recommendations: $recQuota, Trending: $trendQuota")
 
-            // Partition subscriptions: in-progress first, then unplayed
             val inProgressSubs = orderedCandidates.filter { it.isProgress }
             val unplayedSubs = orderedCandidates.filter { !it.isProgress }
             
@@ -330,76 +507,13 @@ class SmartDownloadManager(
             
             writeLogToFile(context, "Selected ${chosenSubs.size} subscription episodes. Overflow: $subOverflow")
 
-            // Fetch personalized recommendations
-            val targetRecSize = recQuota + subOverflow
-            val chosenRecs = mutableListOf<Episode>()
-            if (targetRecSize > 0) {
-                try {
-                    val historyItems = playbackRepository.getHistoryForRecommendations(15)
-                    val subscribedIds = subs.map { it.podcastId }
-                    val subscribedGenres = subs.mapNotNull { it.genre }.distinct()
-                    val region = userPrefs.regionStream.first().takeIf { it.isNotBlank() } ?: "us"
-                    
-                    val recs = podcastRepository.getPersonalizedRecommendations(
-                        history = historyItems,
-                        country = region,
-                        subscribedPodcastIds = subscribedIds,
-                        subscribedGenres = subscribedGenres
-                    )
-                    
-                    // Filter recommendations
-                    val existingDownloads = database.downloadedEpisodeDao().getAllDownloadsSync()
-                    val completedEpisodeIds = database.listeningHistoryDao().getCompletedEpisodeIds().toSet()
-                    val chosenSubsIds = chosenSubs.map { it.id }.toSet()
-                    
-                    val filteredRecs = recs.filter { ep ->
-                        ep.id !in chosenSubsIds &&
-                        ep.id !in completedEpisodeIds &&
-                        existingDownloads.none { it.episodeId == ep.id }
-                    }.distinctBy { it.id }
-                    
-                    chosenRecs.addAll(filteredRecs.take(targetRecSize))
-                    writeLogToFile(context, "Fetched ${recs.size} recommendations from endpoint. Selected ${chosenRecs.size} after filtering.")
-                } catch (e: Exception) {
-                    Log.e("SmartDownloadManager", "Failed to fetch personalized recommendations for sync", e)
-                    writeLogToFile(context, "Failed to fetch personalized recommendations: ${e.message}")
-                }
-            }
+            val chosenSubsIds = chosenSubs.map { it.id }.toSet()
+            val chosenRecs = fetchPersonalizedRecommendations(subs, chosenSubsIds, recQuota + subOverflow)
             
-            val recOverflow = (targetRecSize - chosenRecs.size).coerceAtLeast(0)
+            val recOverflow = (recQuota + subOverflow - chosenRecs.size).coerceAtLeast(0)
+            val chosenRecsIds = chosenRecs.map { it.id }.toSet()
+            val chosenTrends = fetchTrendingEpisodes(chosenSubsIds, chosenRecsIds, trendQuota + recOverflow)
 
-            // Fetch trending podcasts
-            val targetTrendSize = trendQuota + recOverflow
-            val chosenTrends = mutableListOf<Episode>()
-            if (targetTrendSize > 0) {
-                try {
-                    val region = userPrefs.regionStream.first().takeIf { it.isNotBlank() } ?: "us"
-                    val trendingPods = podcastRepository.getTrendingPodcasts(country = region, limit = 30)
-                    
-                    val trendingEpisodes = trendingPods.mapNotNull { it.latestEpisode }
-                    
-                    // Filter trending
-                    val existingDownloads = database.downloadedEpisodeDao().getAllDownloadsSync()
-                    val completedEpisodeIds = database.listeningHistoryDao().getCompletedEpisodeIds().toSet()
-                    val chosenSubsIds = chosenSubs.map { it.id }.toSet()
-                    val chosenRecsIds = chosenRecs.map { it.id }.toSet()
-                    
-                    val filteredTrends = trendingEpisodes.filter { ep ->
-                        ep.id !in chosenSubsIds &&
-                        ep.id !in chosenRecsIds &&
-                        ep.id !in completedEpisodeIds &&
-                        existingDownloads.none { it.episodeId == ep.id }
-                    }.distinctBy { it.id }
-                    
-                    chosenTrends.addAll(filteredTrends.take(targetTrendSize))
-                    writeLogToFile(context, "Fetched ${trendingPods.size} trending podcasts from endpoint. Selected ${chosenTrends.size} episodes after filtering.")
-                } catch (e: Exception) {
-                    Log.e("SmartDownloadManager", "Failed to fetch trending podcasts for sync", e)
-                    writeLogToFile(context, "Failed to fetch trending: ${e.message}")
-                }
-            }
-            
-            // Combine them in priority order
             val inProgressEpisodes = chosenSubsCandidates.filter { it.isProgress }.map { it.episode }
             val otherSubsEpisodes = chosenSubsCandidates.filter { !it.isProgress }.map { it.episode }
             
@@ -408,40 +522,10 @@ class SmartDownloadManager(
             
             writeLogToFile(context, "Combined download candidates list size: ${combinedEpisodes.size}. Target episode IDs: $candidateEpisodeIds")
 
-            // 7. Cleanup/Recycle smart-downloaded episodes no longer in the candidates list
             val existingDownloads = database.downloadedEpisodeDao().getAllDownloadsSync()
-            var currentDownloadedBytes = 0L
+            val currentDownloadedBytes = recycleOldDownloads(candidateEpisodeIds, existingDownloads)
 
-            for (download in existingDownloads) {
-                if (download.isSmartDownloaded) {
-                    if (download.status == DownloadedEpisodeEntity.STATUS_COMPLETED) {
-                        currentDownloadedBytes += download.sizeBytes
-                    } else if (download.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING) {
-                        // Estimate active in-progress size from duration or fallback to 50MB
-                        val durSec = download.durationMs / 1000L
-                        val estSize = if (durSec > 0) durSec * 12000L else 50L * 1024 * 1024
-                        currentDownloadedBytes += estSize
-                    }
-                }
-                
-                // If it is marked as smart-downloaded and NOT in the active top candidates list, delete it!
-                if (download.isSmartDownloaded && download.episodeId !in candidateEpisodeIds) {
-                    Log.d("SmartDownloadManager", "Recycling/cleaning up old smart-downloaded episode: ${download.episodeId}")
-                    writeLogToFile(context, "Recycling/deleting old smart-downloaded episode: '${download.episodeTitle}' (ID: ${download.episodeId})")
-                    downloadRepository.removeDownload(download.episodeId)
-                    if (download.status == DownloadedEpisodeEntity.STATUS_COMPLETED) {
-                        currentDownloadedBytes -= download.sizeBytes
-                    } else if (download.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING) {
-                        val durSec = download.durationMs / 1000L
-                        val estSize = if (durSec > 0) durSec * 12000L else 50L * 1024 * 1024
-                        currentDownloadedBytes -= estSize
-                    }
-                }
-            }
-
-            // 8. Download the candidate list (First-Limit-Hit Rule)
-            // Count any smart downloads that are completed or active
-            var countDownloaded = existingDownloads.count { 
+            val countDownloaded = existingDownloads.count { 
                 (it.status == DownloadedEpisodeEntity.STATUS_COMPLETED || it.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING) && 
                 it.isSmartDownloaded && 
                 it.episodeId in candidateEpisodeIds 
@@ -449,56 +533,8 @@ class SmartDownloadManager(
             
             writeLogToFile(context, "Starting download loop. Current active/queued smart downloads count: $countDownloaded / $maxCount. Current size tally: ${currentDownloadedBytes / (1024 * 1024)} MB / $storageBudgetMb MB limit.")
 
-            for (episode in combinedEpisodes) {
-                val isAlreadyDownloaded = existingDownloads.any { it.episodeId == episode.id && it.status == DownloadedEpisodeEntity.STATUS_COMPLETED }
-                val isDownloading = existingDownloads.any { it.episodeId == episode.id && it.status == DownloadedEpisodeEntity.STATUS_DOWNLOADING }
-                
-                if (isAlreadyDownloaded || isDownloading) {
-                    Log.d("SmartDownloadManager", "Episode ${episode.title} already downloaded or downloading. Skipping.")
-                    continue
-                }
+            triggerDownloads(combinedEpisodes, existingDownloads, subs, maxCount, storageBudgetMb, currentDownloadedBytes, countDownloaded)
 
-                // Check count constraint
-                if (countDownloaded >= maxCount) {
-                    Log.d("SmartDownloadManager", "Hit max count limit ($maxCount episodes). Halting downloads.")
-                    writeLogToFile(context, "Hit max count limit ($maxCount episodes). Halting downloads.")
-                    break
-                }
-
-                // Calculate duration-based estimated size (approx 96kbps -> 12KB/s -> 12000L bytes per second)
-                val estimatedSize = if (episode.duration > 0) {
-                    episode.duration.toLong() * 12000L
-                } else {
-                    50L * 1024 * 1024 // Fallback 50MB
-                }
-
-                // Check storage budget constraint BEFORE triggering the download (proactive check!)
-                if (storageBudgetMb > 0) {
-                    val budgetBytes = storageBudgetMb * 1024 * 1024L
-                    if (currentDownloadedBytes + estimatedSize > budgetBytes) {
-                        val estMb = estimatedSize / (1024 * 1024)
-                        val currMb = currentDownloadedBytes / (1024 * 1024)
-                        Log.d("SmartDownloadManager", "Hit storage budget limit ($storageBudgetMb MB). Adding '${episode.title}' (Est: $estMb MB) would exceed budget (Current: $currMb MB). Halting downloads.")
-                        writeLogToFile(context, "Adding '${episode.title}' (Est: $estMb MB) would exceed storage budget ($storageBudgetMb MB). Halting downloads.")
-                        break
-                    }
-                }
-
-                val parentPod = subs.find { it.podcastId == episode.podcastId }?.toPodcast() ?: Podcast(
-                    id = episode.podcastId ?: "0",
-                    title = episode.podcastTitle?.takeIf { it.isNotBlank() } ?: "Unknown Podcast",
-                    artist = episode.podcastArtist ?: "Unknown",
-                    imageUrl = episode.podcastImageUrl?.takeIf { it.isNotBlank() } ?: episode.imageUrl ?: ""
-                )
-
-                Log.d("SmartDownloadManager", "Auto-downloading smart mixtape candidate: ${episode.title} (pod=${parentPod.title}, estSize=${estimatedSize / (1024 * 1024)} MB)")
-                writeLogToFile(context, "Triggered download for episode: '${episode.title}' (Show: '${parentPod.title}', Est: ${estimatedSize / (1024 * 1024)} MB)")
-                downloadRepository.addDownload(episode, parentPod, isSmartDownloaded = true)
-                countDownloaded++
-                currentDownloadedBytes += estimatedSize
-            }
-
-            // Update last sync time
             userPrefs.setSmartDownloadsLastSyncTime(System.currentTimeMillis())
             Log.d("SmartDownloadManager", "Smart downloads sync completed successfully.")
             writeLogToFile(context, "Sync completed successfully.")

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -1409,131 +1409,83 @@ class BoxLorePlaybackService : MediaLibraryService() {
          * Resolves items into playable MediaItems AND builds a queue from the
          * same podcast, mirroring the phone's QueueManager/PlayerViewModel behavior.
          */
-        override fun onAddMediaItems(
-            mediaSession: MediaSession,
-            controller: MediaSession.ControllerInfo,
-            mediaItems: MutableList<MediaItem>
-        ): ListenableFuture<MutableList<MediaItem>> {
-            android.util.Log.d("AutoBrowse", "onAddMediaItems: ${mediaItems.size} items")
+        private suspend fun handleVoiceSearchQuery(searchQuery: String): MutableList<MediaItem> {
+            val lowerQuery = searchQuery.lowercase()
+            val isVague = lowerQuery in listOf("podcast", "something", "music", "play", "anything", "")
             
-            return serviceScope.future {
-                // If multiple items (e.g. queue restore), resolve each individually
-                if (mediaItems.size > 1) {
-                    return@future mediaItems.map { resolveMediaItem(it) }.toMutableList()
+            if (isVague || lowerQuery.contains("subscription") || lowerQuery.contains("resume")) {
+                val lastSession = database.listeningHistoryDao().getLastPlayedSession()
+                if (lastSession != null) {
+                    android.util.Log.d("AutoBrowse", "Vague query → resuming last: ${lastSession.episodeTitle}")
+                    pendingSeekMs = lastSession.progressMs
+                    pendingSeekEpisodeId = lastSession.episodeId
+                    val artworkUri = (lastSession.episodeImageUrl ?: lastSession.podcastImageUrl)
+                        ?.let { android.net.Uri.parse(it) }
+                    return mutableListOf(
+                        MediaItem.Builder()
+                            .setMediaId("episode:${lastSession.episodeId}")
+                            .setUri(lastSession.episodeAudioUrl)
+                            .setMediaMetadata(
+                                MediaMetadata.Builder()
+                                    .setTitle(lastSession.episodeTitle)
+                                    .setArtist(lastSession.podcastName)
+                                    .setArtworkUri(artworkUri)
+                                    .setIsPlayable(true)
+                                    .setIsBrowsable(false)
+                                    .build()
+                            )
+                            .build()
+                    )
                 }
-                
-                val selectedItem = mediaItems.first()
-                val searchQuery = selectedItem.requestMetadata.searchQuery
-                
-                // Voice command: "play X on BoxCast" → searchQuery is set
-                if (!searchQuery.isNullOrBlank()) {
-                    android.util.Log.d("AutoBrowse", "Voice play request: '$searchQuery'")
-                    
-                    val lowerQuery = searchQuery.lowercase()
-                    val isVague = lowerQuery in listOf("podcast", "something", "music", "play", "anything", "")
-                    
-                    if (isVague || lowerQuery.contains("subscription") || lowerQuery.contains("resume")) {
-                        // Vague request → resume last played session
-                        val lastSession = database.listeningHistoryDao().getLastPlayedSession()
-                        if (lastSession != null) {
-                            android.util.Log.d("AutoBrowse", "Vague query → resuming last: ${lastSession.episodeTitle}")
-                            pendingSeekMs = lastSession.progressMs
-                            pendingSeekEpisodeId = lastSession.episodeId
-                            val artworkUri = (lastSession.episodeImageUrl ?: lastSession.podcastImageUrl)
-                                ?.let { android.net.Uri.parse(it) }
-                            return@future mutableListOf(
-                                MediaItem.Builder()
-                                    .setMediaId("episode:${lastSession.episodeId}")
-                                    .setUri(lastSession.episodeAudioUrl)
-                                    .setMediaMetadata(
-                                        MediaMetadata.Builder()
-                                            .setTitle(lastSession.episodeTitle)
-                                            .setArtist(lastSession.podcastName)
-                                            .setArtworkUri(artworkUri)
-                                            .setIsPlayable(true)
-                                            .setIsBrowsable(false)
-                                            .build()
-                                    )
+            }
+            
+            val subs = database.podcastDao().getSubscribedPodcastsList()
+            val matchedPod = subs.firstOrNull { 
+                it.title.lowercase().contains(lowerQuery) 
+            }
+            
+            if (matchedPod != null) {
+                android.util.Log.d("AutoBrowse", "Voice matched subscription: ${matchedPod.title}")
+                val episodes = podcastRepository.getEpisodes(matchedPod.podcastId)
+                val ep = episodes.firstOrNull()
+                if (ep != null) {
+                    val artworkUri = android.net.Uri.parse(ep.imageUrl ?: matchedPod.imageUrl)
+                    return mutableListOf(
+                        MediaItem.Builder()
+                            .setMediaId("episode:${ep.id}")
+                            .setUri(ep.audioUrl)
+                            .setMediaMetadata(
+                                MediaMetadata.Builder()
+                                    .setTitle(ep.title)
+                                    .setArtist(matchedPod.title)
+                                    .setArtworkUri(artworkUri)
+                                    .setIsPlayable(true)
+                                    .setIsBrowsable(false)
                                     .build()
                             )
-                        }
-                    }
-                    
-                    // Specific query → search subscriptions first, then API
-                    val subs = database.podcastDao().getSubscribedPodcastsList()
-                    val matchedPod = subs.firstOrNull { 
-                        it.title.lowercase().contains(lowerQuery) 
-                    }
-                    
-                    if (matchedPod != null) {
-                        // Found a subscribed podcast → play its latest episode
-                        android.util.Log.d("AutoBrowse", "Voice matched subscription: ${matchedPod.title}")
-                        val episodes = podcastRepository.getEpisodes(matchedPod.podcastId)
-                        val ep = episodes.firstOrNull()
-                        if (ep != null) {
-                            val artworkUri = android.net.Uri.parse(ep.imageUrl ?: matchedPod.imageUrl)
-                            return@future mutableListOf(
-                                MediaItem.Builder()
-                                    .setMediaId("episode:${ep.id}")
-                                    .setUri(ep.audioUrl)
-                                    .setMediaMetadata(
-                                        MediaMetadata.Builder()
-                                            .setTitle(ep.title)
-                                            .setArtist(matchedPod.title)
-                                            .setArtworkUri(artworkUri)
-                                            .setIsPlayable(true)
-                                            .setIsBrowsable(false)
-                                            .build()
-                                    )
-                                    .build()
-                            )
-                        }
-                    }
-                    
-                    // Not in subscriptions → search Podcast Index API
-                    try {
-                        val apiResults = podcastRepository.searchPodcasts(searchQuery)
-                        val firstPod = apiResults.firstOrNull()
-                        if (firstPod != null) {
-                            android.util.Log.d("AutoBrowse", "Voice matched API: ${firstPod.title}")
-                            val episodes = podcastRepository.getEpisodes(firstPod.id)
-                            val ep = episodes.firstOrNull()
-                            if (ep != null) {
-                                val artworkUri = android.net.Uri.parse(ep.imageUrl ?: firstPod.imageUrl)
-                                return@future mutableListOf(
-                                    MediaItem.Builder()
-                                        .setMediaId("episode:${ep.id}")
-                                        .setUri(ep.audioUrl)
-                                        .setMediaMetadata(
-                                            MediaMetadata.Builder()
-                                                .setTitle(ep.title)
-                                                .setArtist(firstPod.title)
-                                                .setArtworkUri(artworkUri)
-                                                .setIsPlayable(true)
-                                                .setIsBrowsable(false)
-                                                .build()
-                                        )
-                                        .build()
-                                )
-                            }
-                        }
-                    } catch (e: Exception) {
-                        android.util.Log.e("AutoBrowse", "Voice search API failed", e)
-                    }
-                    
-                    // Fallback: resume last session
-                    val fallback = database.listeningHistoryDao().getLastPlayedSession()
-                    if (fallback != null) {
-                        pendingSeekMs = fallback.progressMs
-                        pendingSeekEpisodeId = fallback.episodeId
-                        return@future mutableListOf(
+                            .build()
+                    )
+                }
+            }
+            
+            try {
+                val apiResults = podcastRepository.searchPodcasts(searchQuery)
+                val firstPod = apiResults.firstOrNull()
+                if (firstPod != null) {
+                    android.util.Log.d("AutoBrowse", "Voice matched API: ${firstPod.title}")
+                    val episodes = podcastRepository.getEpisodes(firstPod.id)
+                    val ep = episodes.firstOrNull()
+                    if (ep != null) {
+                        val artworkUri = android.net.Uri.parse(ep.imageUrl ?: firstPod.imageUrl)
+                        return mutableListOf(
                             MediaItem.Builder()
-                                .setMediaId("episode:${fallback.episodeId}")
-                                .setUri(fallback.episodeAudioUrl)
+                                .setMediaId("episode:${ep.id}")
+                                .setUri(ep.audioUrl)
                                 .setMediaMetadata(
                                     MediaMetadata.Builder()
-                                        .setTitle(fallback.episodeTitle)
-                                        .setArtist(fallback.podcastName)
+                                        .setTitle(ep.title)
+                                        .setArtist(firstPod.title)
+                                        .setArtworkUri(artworkUri)
                                         .setIsPlayable(true)
                                         .setIsBrowsable(false)
                                         .build()
@@ -1542,48 +1494,145 @@ class BoxLorePlaybackService : MediaLibraryService() {
                         )
                     }
                 }
+            } catch (e: Exception) {
+                android.util.Log.e("AutoBrowse", "Voice search API failed", e)
+            }
+            
+            val fallback = database.listeningHistoryDao().getLastPlayedSession()
+            if (fallback != null) {
+                pendingSeekMs = fallback.progressMs
+                pendingSeekEpisodeId = fallback.episodeId
+                return mutableListOf(
+                    MediaItem.Builder()
+                        .setMediaId("episode:${fallback.episodeId}")
+                        .setUri(fallback.episodeAudioUrl)
+                        .setMediaMetadata(
+                            MediaMetadata.Builder()
+                                .setTitle(fallback.episodeTitle)
+                                .setArtist(fallback.podcastName)
+                                .setIsPlayable(true)
+                                .setIsBrowsable(false)
+                                .build()
+                        )
+                        .build()
+                )
+            }
+            
+            return mutableListOf()
+        }
+
+        private suspend fun handlePlayAllNewEpisodes(): MutableList<MediaItem> {
+            android.util.Log.d("AutoBrowse", "Play All New Episodes triggered")
+            val subscriptions = subscriptionRepository.getAllSubscribedPodcasts().first()
+            
+            val newEpisodes = subscriptions
+                .mapNotNull { entity -> entity.latestEpisode?.let { ep -> ep to entity } }
+                .sortedByDescending { (ep, _) -> ep.publishedDate }
+                .take(20)
+            
+            return newEpisodes.map { (ep, pod) ->
+                val artworkUri = android.net.Uri.parse(ep.imageUrl ?: pod.imageUrl)
                 
-                // Intercept the Virtual "Play All" Action from the New Episodes tab
-                if (selectedItem.mediaId == PLAY_ALL_NEW_EPISODES_ID) {
-                    android.util.Log.d("AutoBrowse", "Play All New Episodes triggered")
-                    val subscriptions = subscriptionRepository.getAllSubscribedPodcasts().first()
-                    
-                    val newEpisodes = subscriptions
-                        .mapNotNull { entity -> entity.latestEpisode?.let { ep -> ep to entity } }
-                        .sortedByDescending { (ep, _) -> ep.publishedDate }
-                        .take(20)
-                    
-                    val playableItems = newEpisodes.map { (ep, pod) ->
-                        val artworkUri = android.net.Uri.parse(ep.imageUrl ?: pod.imageUrl)
-                        
-                        MediaItem.Builder()
-                            .setMediaId("episode:${ep.id}")
-                            .setUri(ep.audioUrl)
-                            .setMediaMetadata(
-                                MediaMetadata.Builder()
-                                    .setTitle(ep.title)
-                                    .setSubtitle(pod.title)
-                                    .setArtist(pod.author)
-                                    .setArtworkUri(artworkUri)
-                                    .setIsPlayable(true)
-                                    .setIsBrowsable(false)
-                                    .setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE)
-                                    .build()
-                            )
+                MediaItem.Builder()
+                    .setMediaId("episode:${ep.id}")
+                    .setUri(ep.audioUrl)
+                    .setMediaMetadata(
+                        MediaMetadata.Builder()
+                            .setTitle(ep.title)
+                            .setSubtitle(pod.title)
+                            .setArtist(pod.author)
+                            .setArtworkUri(artworkUri)
+                            .setIsPlayable(true)
+                            .setIsBrowsable(false)
+                            .setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE)
                             .build()
-                    }.toMutableList()
-                    
-                    // Instantly returning all 20 to the player immediately builds the queue
-                    return@future playableItems
+                    )
+                    .build()
+            }.toMutableList()
+        }
+
+        private fun buildAndAppendQueueAsync(episodeId: String, mediaSession: MediaSession) {
+            serviceScope.launch {
+                try {
+                    val podcastId = findPodcastIdForEpisode(episodeId)
+                    if (podcastId != null) {
+                        android.util.Log.d("AutoBrowse", "Async queue build: fetching episodes for $podcastId")
+                        val allEpisodes = podcastRepository.getEpisodes(podcastId)
+                        val podcastEntity = database.podcastDao().getPodcast(podcastId)
+                        
+                        val podcastApi = if (podcastEntity == null) podcastRepository.getPodcastDetails(podcastId) else null
+                        val podcastImageUrl = podcastEntity?.imageUrl ?: podcastApi?.imageUrl
+                        val podcastTitle = podcastEntity?.title ?: podcastApi?.title
+                        val podcastAuthor = podcastEntity?.author ?: podcastApi?.artist
+                        
+                        if (allEpisodes.isNotEmpty()) {
+                            val sorted = allEpisodes.sortedBy { it.publishedDate }
+                            val selectedIndex = sorted.indexOfFirst { it.id == episodeId }
+                            
+                            if (selectedIndex >= 0 && selectedIndex < sorted.size - 1) {
+                                val remainingQueue = sorted.subList(selectedIndex + 1, sorted.size)
+                                
+                                val mediaItemsToAdd = remainingQueue.map { episode ->
+                                    val artworkUri = (episode.imageUrl ?: podcastImageUrl)?.let { android.net.Uri.parse(it) }
+                                    
+                                    MediaItem.Builder()
+                                        .setMediaId("episode:${episode.id}")
+                                        .setUri(episode.audioUrl)
+                                        .setMediaMetadata(
+                                            MediaMetadata.Builder()
+                                                .setTitle(episode.title)
+                                                .setSubtitle(podcastTitle ?: episode.podcastTitle ?: "")
+                                                .setArtist(podcastAuthor ?: episode.podcastArtist ?: "")
+                                                .setArtworkUri(artworkUri)
+                                                .setIsPlayable(true)
+                                                .setIsBrowsable(false)
+                                                .setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE)
+                                                .build()
+                                        )
+                                        .build()
+                                }
+                                
+                                kotlinx.coroutines.withContext(mainDispatcher) {
+                                    mediaSession.player.addMediaItems(mediaItemsToAdd)
+                                    android.util.Log.d("AutoBrowse", "Async queue built: appended ${mediaItemsToAdd.size} items")
+                                }
+                            }
+                        }
+                    }
+                } catch (e: Exception) {
+                    android.util.Log.e("AutoBrowse", "Async queue build failed", e)
+                }
+            }
+        }
+
+        override fun onAddMediaItems(
+            mediaSession: MediaSession,
+            controller: MediaSession.ControllerInfo,
+            mediaItems: MutableList<MediaItem>
+        ): ListenableFuture<MutableList<MediaItem>> {
+            android.util.Log.d("AutoBrowse", "onAddMediaItems: ${mediaItems.size} items")
+            
+            return serviceScope.future {
+                if (mediaItems.size > 1) {
+                    return@future mediaItems.map { resolveMediaItem(it) }.toMutableList()
                 }
                 
-                // Single item selection: Resolve it IMMEDIATELY so playback starts instantly
-                val resolvedItem = resolveMediaItem(selectedItem)
+                val selectedItem = mediaItems.first()
+                val searchQuery = selectedItem.requestMetadata.searchQuery
                 
+                if (!searchQuery.isNullOrBlank()) {
+                    android.util.Log.d("AutoBrowse", "Voice play request: '$searchQuery'")
+                    return@future handleVoiceSearchQuery(searchQuery)
+                }
+                
+                if (selectedItem.mediaId == PLAY_ALL_NEW_EPISODES_ID) {
+                    return@future handlePlayAllNewEpisodes()
+                }
+                
+                val resolvedItem = resolveMediaItem(selectedItem)
                 val episodeId = selectedItem.mediaId.removePrefix("episode:").removePrefix("queue:")
                 android.util.Log.d("AutoBrowse", "Returning episode instantly: $episodeId")
                 
-                // Read saved position NOW, before playback starts (no race!)
                 val historyItem = database.listeningHistoryDao().getHistoryItem(episodeId)
                 if (historyItem != null && historyItem.progressMs > 2000 && !historyItem.isCompleted) {
                     pendingSeekMs = historyItem.progressMs
@@ -1594,65 +1643,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     pendingSeekEpisodeId = null
                 }
                 
-                // Launch background job to fetch all other episodes and silently append to queue
-                // This prevents Auto from showing the ugly "Getting your selection" loading screen
-                serviceScope.launch {
-                    try {
-                        val podcastId = findPodcastIdForEpisode(episodeId)
-                        if (podcastId != null) {
-                            android.util.Log.d("AutoBrowse", "Async queue build: fetching episodes for $podcastId")
-                            val allEpisodes = podcastRepository.getEpisodes(podcastId)
-                            val podcastEntity = database.podcastDao().getPodcast(podcastId)
-                            
-                            // Need API fallback if not in Local DB
-                            val podcastApi = if (podcastEntity == null) podcastRepository.getPodcastDetails(podcastId) else null
-                            val podcastImageUrl = podcastEntity?.imageUrl ?: podcastApi?.imageUrl
-                            val podcastTitle = podcastEntity?.title ?: podcastApi?.title
-                            val podcastAuthor = podcastEntity?.author ?: podcastApi?.artist
-                            
-                            if (allEpisodes.isNotEmpty()) {
-                                // Sort chronologically (oldest → newest)
-                                val sorted = allEpisodes.sortedBy { it.publishedDate }
-                                val selectedIndex = sorted.indexOfFirst { it.id == episodeId }
-                                
-                                // Take everything AFTER the selected episode
-                                if (selectedIndex >= 0 && selectedIndex < sorted.size - 1) {
-                                    val remainingQueue = sorted.subList(selectedIndex + 1, sorted.size)
-                                    
-                                    val mediaItemsToAdd = remainingQueue.map { episode ->
-                                        val artworkUri = (episode.imageUrl ?: podcastImageUrl)?.let { android.net.Uri.parse(it) }
-                                        
-                                        MediaItem.Builder()
-                                            .setMediaId("episode:${episode.id}")
-                                            .setUri(episode.audioUrl)
-                                            .setMediaMetadata(
-                                                MediaMetadata.Builder()
-                                                    .setTitle(episode.title)
-                                                    .setSubtitle(podcastTitle ?: episode.podcastTitle ?: "")
-                                                    .setArtist(podcastAuthor ?: episode.podcastArtist ?: "")
-                                                    .setArtworkUri(artworkUri)
-                                                    .setIsPlayable(true)
-                                                    .setIsBrowsable(false)
-                                                    .setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE)
-                                                    .build()
-                                            )
-                                            .build()
-                                    }
-                                    
-                                    // Safely add to player on the main thread
-                                    kotlinx.coroutines.withContext(mainDispatcher) {
-                                        mediaSession.player.addMediaItems(mediaItemsToAdd)
-                                        android.util.Log.d("AutoBrowse", "Async queue built: appended ${mediaItemsToAdd.size} items")
-                                    }
-                                }
-                            }
-                        }
-                    } catch (e: Exception) {
-                        android.util.Log.e("AutoBrowse", "Async queue build failed", e)
-                    }
-                }
-                
-                // Instantly return the resolved item!
+                buildAndAppendQueueAsync(episodeId, mediaSession)
                 mutableListOf(resolvedItem)
             }
         }


### PR DESCRIPTION
This PR resolves 3 of the largest P1 Cognitive Complexity issues in the codebase:
- Decomposes SmartDownloadManager.performSync (complexity 133) by extracting constraint checks, subscription sync, oldest serial resolution, mixtape candidate scoring/deduplication, recommendation & trending loaders, old file recycling, and download triggers.
- Modularizes BoxLorePlaybackService.onAddMediaItems (complexity 58) by extracting voice search query evaluators, Play All loaders, and async background queue builders.
- Simplifies PlaybackRepository.playQueue (complexity 29) by extracting builders for player items, saved progress retrieval, late night nudge checking, and entry point context loaders.