### PR TITLE
fix: onboarding improvements and top app bar theme invalidation

### DIFF
--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/TopControlBar.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/TopControlBar.kt
@@ -98,11 +98,15 @@ fun TopControlBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .drawBehind {
-                val fraction = scrollFractionProvider().coerceIn(0f, 1f)
-                val color = lerp(expandedColor, collapsedColor, fraction)
-                drawRect(color)
-            }
+            .then(
+                remember(expandedColor, collapsedColor) {
+                    Modifier.drawBehind {
+                        val fraction = scrollFractionProvider().coerceIn(0f, 1f)
+                        val color = lerp(expandedColor, collapsedColor, fraction)
+                        drawRect(color)
+                    }
+                }
+            )
             .statusBarsPadding()
             .layout { measurable, constraints ->
                 val fraction = scrollFractionProvider().coerceIn(0f, 1f)

--- a/feature/onboarding/src/main/java/cx/aswin/boxcast/feature/onboarding/AiOnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxcast/feature/onboarding/AiOnboardingScreen.kt
@@ -105,7 +105,7 @@ private fun AiChatOnboardingScreen(
         
         list.add(
             ChatMessage.ModelMessage(
-                text = "Hi! I'm boxcast. To start, what kind of a listener are you?",
+                text = "Hi! I'm boxlore. To start, what kind of a listener are you?",
                 key = "init_model"
             )
         )
@@ -621,7 +621,7 @@ private fun AiChatOnboardingScreen(
                     } else {
                         // Conversational Turn (Options & Custom Input Bar)
                         AnimatedVisibility(
-                            visible = suggestionsVisible,
+                            visible = suggestionsVisible && !isKeyboardVisible && !isTextFieldFocused,
                             enter = fadeIn(animationSpec = tween(300)) + expandVertically(animationSpec = tween(300)),
                             exit = fadeOut(animationSpec = tween(250)) + shrinkVertically(animationSpec = tween(250))
                         ) {

--- a/feature/onboarding/src/main/java/cx/aswin/boxcast/feature/onboarding/OnboardingViewModel.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxcast/feature/onboarding/OnboardingViewModel.kt
@@ -53,7 +53,7 @@ data class OnboardingUiState(
     val selectedPodcasts: Map<String, Podcast> = emptyMap(),
     // AI Onboarding fields
     val aiHistory: List<OnboardingHistoryEntry> = emptyList(),
-    val aiAssistantMessage: String = "Hi! I'm boxcast. To start, what kind of a listener are you?",
+    val aiAssistantMessage: String = "Hi! I'm boxlore. To start, what kind of a listener are you?",
     val aiOptions: List<String> = listOf(
         "Storyseeker | Serialized narratives, investigative series, and immersive audio dramas",
         "Deep Diver | Detailed analysis, long-form research, and intellectual essays",


### PR DESCRIPTION
Updates AI onboarding greeting to 'boxlore', auto-hides suggested choices when typing/keyboard is visible, and forces immediate top app bar background draw layer invalidation on dark/light theme switch.