### PR TITLE
Home Screen: Auto-Dismiss 'NEW' Podcast Badges on Filter/Visit

### DIFF
--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
@@ -15,6 +15,8 @@ import java.io.IOException
 
 val Context.userPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(name = "user_preferences")
 
+private const val LAST_SEEN_EPISODE_ID_PREFIX = "last_seen_episode_id_"
+
 class UserPreferencesRepository(context: Context) {
     private val dataStore = context.userPreferencesDataStore
     private val syncPrefs = context.getSharedPreferences("boxcast_theme_fast_cache", Context.MODE_PRIVATE)
@@ -745,20 +747,26 @@ class UserPreferencesRepository(context: Context) {
         }
         .map { preferences ->
             preferences.asMap().entries
-                .filter { it.key.name.startsWith("last_seen_episode_id_") }
-                .associate { it.key.name.removePrefix("last_seen_episode_id_") to (it.value as String) }
+                .filter { it.key.name.startsWith(LAST_SEEN_EPISODE_ID_PREFIX) }
+                .mapNotNull { entry ->
+                    val value = entry.value as? String
+                    if (value != null) {
+                        entry.key.name.removePrefix(LAST_SEEN_EPISODE_ID_PREFIX) to value
+                    } else null
+                }
+                .toMap()
         }
         .distinctUntilChanged()
 
     suspend fun setLastSeenEpisodeId(podcastId: String, episodeId: String) {
         dataStore.edit { preferences ->
-            preferences[stringPreferencesKey("last_seen_episode_id_$podcastId")] = episodeId
+            preferences[stringPreferencesKey("$LAST_SEEN_EPISODE_ID_PREFIX$podcastId")] = episodeId
         }
     }
 
     suspend fun removeLastSeenEpisodeId(podcastId: String) {
         dataStore.edit { preferences ->
-            preferences.remove(stringPreferencesKey("last_seen_episode_id_$podcastId"))
+            preferences.remove(stringPreferencesKey("$LAST_SEEN_EPISODE_ID_PREFIX$podcastId"))
         }
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
@@ -755,5 +755,11 @@ class UserPreferencesRepository(context: Context) {
             preferences[stringPreferencesKey("last_seen_episode_id_$podcastId")] = episodeId
         }
     }
+
+    suspend fun removeLastSeenEpisodeId(podcastId: String) {
+        dataStore.edit { preferences ->
+            preferences.remove(stringPreferencesKey("last_seen_episode_id_$podcastId"))
+        }
+    }
 }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
@@ -738,5 +738,22 @@ class UserPreferencesRepository(context: Context) {
             preferences[Keys.AUTO_DOWNLOAD_DELETE_COMPLETED] = deleteCompleted
         }
     }
+
+    val lastSeenEpisodesStream: Flow<Map<String, String>> = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) emit(emptyPreferences()) else throw exception
+        }
+        .map { preferences ->
+            preferences.asMap().entries
+                .filter { it.key.name.startsWith("last_seen_episode_id_") }
+                .associate { it.key.name.removePrefix("last_seen_episode_id_") to (it.value as String) }
+        }
+        .distinctUntilChanged()
+
+    suspend fun setLastSeenEpisodeId(podcastId: String, episodeId: String) {
+        dataStore.edit { preferences ->
+            preferences[stringPreferencesKey("last_seen_episode_id_$podcastId")] = episodeId
+        }
+    }
 }
 

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -51,6 +51,7 @@ import cx.aswin.boxcast.feature.home.components.GridSkeletonItem
 import cx.aswin.boxcast.feature.home.components.GridSkeletonItems
 import cx.aswin.boxcast.feature.home.components.YourShowsSkeleton
 import cx.aswin.boxcast.feature.home.components.TimeBlockSkeleton
+import cx.aswin.boxcast.feature.home.components.LocalLastSeenEpisodes
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.offset
@@ -201,66 +202,76 @@ fun HomeRoute(
     val candidatePodcasts by viewModel.candidatePodcasts.collectAsState(initial = emptyList())
 
     val downloadedEpisodeIds by viewModel.downloadedEpisodeIds.collectAsState(initial = emptySet())
+    val lastSeenEpisodes by viewModel.lastSeenEpisodes.collectAsState()
 
-    HomeScreen(
-        uiState = uiState,
-        downloadedEpisodeIds = downloadedEpisodeIds,
-        currentPlayingPodcastId = currentPlayingPodcastId,
-        currentPlayingEpisodeId = currentPlayingEpisodeId,
-        isPlaying = isPlaying,
-        isPlayerLoading = isPlayerLoading,
-        debugHistory = debugHistory,
-        debugPodcasts = debugPodcasts,
-        candidatePodcasts = candidatePodcasts,
-        onOverrideRecommendationPodcast = viewModel::setOverriddenRecPodcast,
-        onPodcastClick = onPodcastClick,
-        onHeroArrowClick = onHeroArrowClick,
-        onEpisodeClick = onEpisodeClick,
-        onCuratedEpisodeClick = onCuratedEpisodeClick,
-        onCuratedImpression = viewModel::trackCuratedImpressionOnce,
-        onPlayClick = onPlayClick,
-        onNavigateToLibrary = onNavigateToLibrary,
-        onNavigateToLatestEpisodes = onNavigateToLatestEpisodes,
-        onNavigateToExplore = onNavigateToExplore,
-        onToggleSubscription = viewModel::toggleSubscription,
-        onTogglePlayback = viewModel::togglePlayback,
-        onSelectCategory = viewModel::selectCategory,
-        onPodcastSelected = viewModel::selectPodcast,
-        onPlayMix = viewModel::playUnplayedMix,
-        onPlayEpisode = viewModel::playEpisode,
-        onDeleteHistoryItem = viewModel::deleteHistoryItem,
-        onNavigateToSettings = onNavigateToSettings,
-        onFeedbackClick = viewModel::triggerFeedback,
-        onForceReviewPrompt = viewModel::forceReviewPrompt,
-        showReviewPrompt = showReviewPrompt,
-        showPostReview = showPostReview,
-        showFeedback = showFeedback,
-        onDismissReviewPrompt = {
-            viewModel.markReviewPromptShown()
-            viewModel.dismissReviewPrompt()
-        },
-        onDismissPostReview = viewModel::dismissPostReview,
-        onDismissFeedback = viewModel::dismissFeedback,
-        onNavigateToPlayStoreReview = {
-            viewModel.markReviewed()
-            viewModel.triggerPostReview()
-            onNavigateToPlayStoreReview()
-        },
-        onSubmitFeedback = onSubmitFeedback,
-        onResetFeatureFlag = viewModel::resetFeatureFlag,
-        onResetSleepNudge = onResetSleepNudge,
-        onClearSleepTimer = onClearSleepTimer,
-        onSwitchRegion = viewModel::setRegion,
-        onDismissNudge = viewModel::dismissRegionNudge,
-        onImportClick = onImportClick,
-        onAiOnboardingClick = onAiOnboardingClick,
-        onDismissImportBanner = viewModel::dismissHomeImportBanner,
-        onBriefingClick = onBriefingClick,
-        onDismissBriefing = viewModel::dismissBriefingForToday,
-        onDismissBriefingForever = viewModel::dismissBriefingForever,
+    androidx.compose.runtime.CompositionLocalProvider(
+        LocalLastSeenEpisodes provides lastSeenEpisodes
+    ) {
+        HomeScreen(
+            uiState = uiState,
+            downloadedEpisodeIds = downloadedEpisodeIds,
+            currentPlayingPodcastId = currentPlayingPodcastId,
+            currentPlayingEpisodeId = currentPlayingEpisodeId,
+            isPlaying = isPlaying,
+            isPlayerLoading = isPlayerLoading,
+            debugHistory = debugHistory,
+            debugPodcasts = debugPodcasts,
+            candidatePodcasts = candidatePodcasts,
+            onOverrideRecommendationPodcast = viewModel::setOverriddenRecPodcast,
+            onPodcastClick = { podcast, entryPoint, category, index ->
+                podcast.latestEpisode?.id?.let { episodeId ->
+                    viewModel.markPodcastEpisodeAsSeen(podcast.id, episodeId)
+                }
+                onPodcastClick(podcast, entryPoint, category, index)
+            },
+            onHeroArrowClick = onHeroArrowClick,
+            onEpisodeClick = onEpisodeClick,
+            onCuratedEpisodeClick = onCuratedEpisodeClick,
+            onCuratedImpression = viewModel::trackCuratedImpressionOnce,
+            onPlayClick = onPlayClick,
+            onNavigateToLibrary = onNavigateToLibrary,
+            onNavigateToLatestEpisodes = onNavigateToLatestEpisodes,
+            onNavigateToExplore = onNavigateToExplore,
+            onToggleSubscription = viewModel::toggleSubscription,
+            onTogglePlayback = viewModel::togglePlayback,
+            onSelectCategory = viewModel::selectCategory,
+            onPodcastSelected = viewModel::selectPodcast,
+            onPlayMix = viewModel::playUnplayedMix,
+            onPlayEpisode = viewModel::playEpisode,
+            onDeleteHistoryItem = viewModel::deleteHistoryItem,
+            onNavigateToSettings = onNavigateToSettings,
+            onFeedbackClick = viewModel::triggerFeedback,
+            onForceReviewPrompt = viewModel::forceReviewPrompt,
+            showReviewPrompt = showReviewPrompt,
+            showPostReview = showPostReview,
+            showFeedback = showFeedback,
+            onDismissReviewPrompt = {
+                viewModel.markReviewPromptShown()
+                viewModel.dismissReviewPrompt()
+            },
+            onDismissPostReview = viewModel::dismissPostReview,
+            onDismissFeedback = viewModel::dismissFeedback,
+            onNavigateToPlayStoreReview = {
+                viewModel.markReviewed()
+                viewModel.triggerPostReview()
+                onNavigateToPlayStoreReview()
+            },
+            onSubmitFeedback = onSubmitFeedback,
+            onResetFeatureFlag = viewModel::resetFeatureFlag,
+            onResetSleepNudge = onResetSleepNudge,
+            onClearSleepTimer = onClearSleepTimer,
+            onSwitchRegion = viewModel::setRegion,
+            onDismissNudge = viewModel::dismissRegionNudge,
+            onImportClick = onImportClick,
+            onAiOnboardingClick = onAiOnboardingClick,
+            onDismissImportBanner = viewModel::dismissHomeImportBanner,
+            onBriefingClick = onBriefingClick,
+            onDismissBriefing = viewModel::dismissBriefingForToday,
+            onDismissBriefingForever = viewModel::dismissBriefingForever,
 
-        modifier = modifier
-    )
+            modifier = modifier
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -1687,6 +1687,8 @@ mixtapePodcasts = cachedMix
                             e.printStackTrace()
                         }
                     }
+                } else {
+                    userPrefs.removeLastSeenEpisodeId(podcastId)
                 }
             }
         }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -221,6 +221,19 @@ class HomeViewModel(
 
     private val userPrefs = cx.aswin.boxcast.core.data.UserPreferencesRepository(application)
 
+    val lastSeenEpisodes: StateFlow<Map<String, String>> = userPrefs.lastSeenEpisodesStream
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyMap()
+        )
+
+    fun markPodcastEpisodeAsSeen(podcastId: String, episodeId: String) {
+        viewModelScope.launch {
+            userPrefs.setLastSeenEpisodeId(podcastId, episodeId)
+        }
+    }
+
     val candidatePodcasts: Flow<List<Podcast>> = combine(
         subscriptionRepository.subscribedPodcasts,
         playbackRepository.getAllHistory()
@@ -382,8 +395,14 @@ class HomeViewModel(
     fun selectPodcast(podcastId: String?) {
         _selectedPodcastId.value = podcastId
         if (podcastId != null) {
-            val title = uiState.value.subscribedPodcasts.find { it.id == podcastId }?.title ?: ""
+            val podcast = uiState.value.subscribedPodcasts.find { it.id == podcastId }
+            val title = podcast?.title ?: ""
             cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackHomePodcastFiltered(podcastId, title)
+            
+            // Mark as seen when filtered in "Your Shows"
+            podcast?.latestEpisode?.id?.let { episodeId ->
+                markPodcastEpisodeAsSeen(podcastId, episodeId)
+            }
         }
     }
 

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/LibrarySection.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/LibrarySection.kt
@@ -118,6 +118,8 @@ import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.EpisodeStatus
 import cx.aswin.boxcast.core.model.Podcast
 
+val LocalLastSeenEpisodes = androidx.compose.runtime.compositionLocalOf<Map<String, String>> { emptyMap() }
+
 @Composable
 fun YourShowsSection(
     subscribedPodcasts: StablePodcastList,
@@ -382,18 +384,10 @@ fun YourShowsSection(
                                     modifier = itemModifier
                                 )
                             } else if (item is Podcast) {
-                                val hasRecentNew = remember(item.subscribedAt, item.latestEpisode?.publishedDate) {
-                                    val ep = item.latestEpisode
-                                    if (ep != null && item.subscribedAt > 0L && ep.publishedDate > (item.subscribedAt / 1000L)) {
-                                        val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
-                                        hoursSinceRelease <= 48.0
-                                    } else false
-                                }
                                 SelectorCover(
                                     podcast = item,
                                     isSelected = selectedPodcastId == item.id,
                                     isAnyPodcastSelected = selectedPodcastId != null,
-                                    hasRecentNew = hasRecentNew,
                                     onClick = {
                                         onPodcastSelected(if (selectedPodcastId == item.id) null else item.id)
                                     },
@@ -410,18 +404,10 @@ fun YourShowsSection(
                         row2Items.forEach { item ->
                             val itemModifier = Modifier.size(itemSize)
                             if (item is Podcast) {
-                                val hasRecentNew = remember(item.subscribedAt, item.latestEpisode?.publishedDate) {
-                                    val ep = item.latestEpisode
-                                    if (ep != null && item.subscribedAt > 0L && ep.publishedDate > (item.subscribedAt / 1000L)) {
-                                        val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
-                                        hoursSinceRelease <= 48.0
-                                    } else false
-                                }
                                 SelectorCover(
                                     podcast = item,
                                     isSelected = selectedPodcastId == item.id,
                                     isAnyPodcastSelected = selectedPodcastId != null,
-                                    hasRecentNew = hasRecentNew,
                                     onClick = {
                                         onPodcastSelected(if (selectedPodcastId == item.id) null else item.id)
                                     },
@@ -451,18 +437,10 @@ fun YourShowsSection(
                     )
                 }
                 items(interleavedPodcasts, key = { it.id }) { podcast ->
-                    val hasRecentNew = remember(podcast.subscribedAt, podcast.latestEpisode?.publishedDate) {
-                        val ep = podcast.latestEpisode
-                        if (ep != null && podcast.subscribedAt > 0L && ep.publishedDate > (podcast.subscribedAt / 1000L)) {
-                            val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
-                            hoursSinceRelease <= 48.0
-                        } else false
-                    }
                     SelectorCover(
                         podcast = podcast,
                         isSelected = selectedPodcastId == podcast.id,
                         isAnyPodcastSelected = selectedPodcastId != null,
-                        hasRecentNew = hasRecentNew,
                         onClick = {
                             onPodcastSelected(if (selectedPodcastId == podcast.id) null else podcast.id)
                         },
@@ -865,10 +843,21 @@ private fun SelectorCover(
     podcast: Podcast,
     isSelected: Boolean,
     isAnyPodcastSelected: Boolean,
-    hasRecentNew: Boolean = false,
     onClick: () -> Unit,
     modifier: Modifier = Modifier.size(60.dp)
 ) {
+    val lastSeenEpisodes = LocalLastSeenEpisodes.current
+    val hasRecentNew = remember(podcast.subscribedAt, podcast.latestEpisode, lastSeenEpisodes) {
+        val ep = podcast.latestEpisode
+        if (ep != null && podcast.subscribedAt > 0L && ep.publishedDate > (podcast.subscribedAt / 1000L)) {
+            val lastSeenId = lastSeenEpisodes[podcast.id]
+            if (ep.id != lastSeenId) {
+                val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
+                hoursSinceRelease <= 48.0
+            } else false
+        } else false
+    }
+
     val scale by animateFloatAsState(targetValue = if (isSelected) 1.05f else 0.95f, label = "scale")
     val alpha by animateFloatAsState(targetValue = if (isSelected) 1f else if (isAnyPodcastSelected) 0.6f else 1f, label = "alpha")
     val cornerRadius by animateDpAsState(targetValue = if (isSelected) 16.dp else 12.dp, label = "cornerRadius")

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/LibrarySection.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/LibrarySection.kt
@@ -141,6 +141,7 @@ fun YourShowsSection(
 ) {
     LogRecomposition(name = "YourShowsSection")
     if (subscribedPodcasts.list.isEmpty()) return
+    val lastSeenEpisodes = LocalLastSeenEpisodes.current
 
 
     val interleavedPodcasts = remember(subscribedPodcasts) {
@@ -314,6 +315,7 @@ fun YourShowsSection(
                 items(subscribedPodcasts.list, key = { it.id }) { podcast ->
                     SelectorCover(
                         podcast = podcast,
+                        lastSeenId = lastSeenEpisodes[podcast.id],
                         isSelected = selectedPodcastId == podcast.id,
                         isAnyPodcastSelected = selectedPodcastId != null,
                         onClick = {
@@ -386,6 +388,7 @@ fun YourShowsSection(
                             } else if (item is Podcast) {
                                 SelectorCover(
                                     podcast = item,
+                                    lastSeenId = lastSeenEpisodes[item.id],
                                     isSelected = selectedPodcastId == item.id,
                                     isAnyPodcastSelected = selectedPodcastId != null,
                                     onClick = {
@@ -406,6 +409,7 @@ fun YourShowsSection(
                             if (item is Podcast) {
                                 SelectorCover(
                                     podcast = item,
+                                    lastSeenId = lastSeenEpisodes[item.id],
                                     isSelected = selectedPodcastId == item.id,
                                     isAnyPodcastSelected = selectedPodcastId != null,
                                     onClick = {
@@ -439,6 +443,7 @@ fun YourShowsSection(
                 items(interleavedPodcasts, key = { it.id }) { podcast ->
                     SelectorCover(
                         podcast = podcast,
+                        lastSeenId = lastSeenEpisodes[podcast.id],
                         isSelected = selectedPodcastId == podcast.id,
                         isAnyPodcastSelected = selectedPodcastId != null,
                         onClick = {
@@ -838,24 +843,33 @@ fun YourShowsSection(
     }
 }
 
+private fun isEpisodeNew(
+    subscribedAt: Long,
+    latestEpisode: Episode?,
+    lastSeenId: String?
+): Boolean {
+    if (latestEpisode == null) return false
+    if (subscribedAt <= 0L) return false
+    if (latestEpisode.publishedDate <= (subscribedAt / 1000L)) return false
+    if (latestEpisode.id == lastSeenId) return false
+    val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - latestEpisode.publishedDate) / 3600.0
+    return hoursSinceRelease <= 48.0
+}
+
 @Composable
 private fun SelectorCover(
     podcast: Podcast,
+    lastSeenId: String?,
     isSelected: Boolean,
     isAnyPodcastSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier.size(60.dp)
 ) {
-    val lastSeenEpisodes = LocalLastSeenEpisodes.current
-    val hasRecentNew = remember(podcast.subscribedAt, podcast.latestEpisode, lastSeenEpisodes) {
-        val ep = podcast.latestEpisode
-        if (ep != null && podcast.subscribedAt > 0L && ep.publishedDate > (podcast.subscribedAt / 1000L)) {
-            val lastSeenId = lastSeenEpisodes[podcast.id]
-            if (ep.id != lastSeenId) {
-                val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
-                hoursSinceRelease <= 48.0
-            } else false
-        } else false
+    val latestEpisodeId = podcast.latestEpisode?.id
+    val latestEpisodePubDate = podcast.latestEpisode?.publishedDate ?: 0L
+    
+    val hasRecentNew = remember(podcast.subscribedAt, latestEpisodeId, latestEpisodePubDate, lastSeenId) {
+        isEpisodeNew(podcast.subscribedAt, podcast.latestEpisode, lastSeenId)
     }
 
     val scale by animateFloatAsState(targetValue = if (isSelected) 1.05f else 0.95f, label = "scale")

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoViewModel.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoViewModel.kt
@@ -282,7 +282,7 @@ class PodcastInfoViewModel(
                     hasMoreEpisodes = true,
                     isLoadingMore = true
                 )
-                currentPodcast?.let { podcast ->
+                currentPodcast.let { podcast ->
                     podcast.latestEpisode?.id?.let { episodeId ->
                         launch {
                             userPrefs.setLastSeenEpisodeId(podcast.id, episodeId)

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoViewModel.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoViewModel.kt
@@ -282,6 +282,13 @@ class PodcastInfoViewModel(
                     hasMoreEpisodes = true,
                     isLoadingMore = true
                 )
+                currentPodcast?.let { podcast ->
+                    podcast.latestEpisode?.id?.let { episodeId ->
+                        launch {
+                            userPrefs.setLastSeenEpisodeId(podcast.id, episodeId)
+                        }
+                    }
+                }
             } else {
                 _uiState.value = PodcastInfoUiState.Loading
             }
@@ -315,6 +322,12 @@ class PodcastInfoViewModel(
                         currentSort = initialSort,
                         isLoadingMore = false
                     )
+
+                    apiPodcastWithFallback.latestEpisode?.id?.let { episodeId ->
+                        launch {
+                            userPrefs.setLastSeenEpisodeId(apiPodcastWithFallback.id, episodeId)
+                        }
+                    }
 
                     launch {
                         fetchAndApplyPodcastMeta(podcastId, apiPodcast.id, isSubscribed, localPodcastEntity)
@@ -638,7 +651,7 @@ class PodcastInfoViewModel(
                         }
                     }
                 } else if (!isSubscribed && wasSubscribed) {
-
+                    userPrefs.removeLastSeenEpisodeId(currentState.podcast.id)
                 }
             }
         }

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
@@ -44,6 +44,13 @@ class LibraryViewModel(
     private val userPreferencesRepository: cx.aswin.boxcast.core.data.UserPreferencesRepository
 ) : ViewModel() {
 
+    val lastSeenEpisodes: StateFlow<Map<String, String>> = userPreferencesRepository.lastSeenEpisodesStream
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyMap()
+        )
+
     private val _downloadsSortOrder = MutableStateFlow(DownloadsSortOrder.RECENT)
     val downloadsSortOrder = _downloadsSortOrder.asStateFlow()
 

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
@@ -781,8 +781,10 @@ private fun ShowsTabContent(
                 }
 
                 items(items = distinctPodcasts, key = { it.id }) { podcast ->
+                    val lastSeenEpisodes = LocalLastSeenEpisodes.current
                     SubscriptionGridCard(
                         podcast = podcast,
+                        lastSeenId = lastSeenEpisodes[podcast.id],
                         onClick = { onPodcastClick(podcast.id) }
                     )
                 }
@@ -1251,22 +1253,31 @@ private fun LatestEpisodeRow(
     }
 }
 
+private fun isEpisodeNew(
+    subscribedAt: Long,
+    latestEpisode: Episode?,
+    lastSeenId: String?
+): Boolean {
+    if (latestEpisode == null) return false
+    if (subscribedAt <= 0L) return false
+    if (latestEpisode.publishedDate <= (subscribedAt / 1000L)) return false
+    if (latestEpisode.id == lastSeenId) return false
+    val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - latestEpisode.publishedDate) / 3600.0
+    return hoursSinceRelease <= 48.0
+}
+
 @Composable
 private fun SubscriptionGridCard(
     podcast: Podcast,
+    lastSeenId: String?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val lastSeenEpisodes = LocalLastSeenEpisodes.current
-    val hasRecentNew = remember(podcast.subscribedAt, podcast.latestEpisode, lastSeenEpisodes) {
-        val ep = podcast.latestEpisode
-        if (ep != null && podcast.subscribedAt > 0L && ep.publishedDate > (podcast.subscribedAt / 1000L)) {
-            val lastSeenId = lastSeenEpisodes[podcast.id]
-            if (ep.id != lastSeenId) {
-                val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
-                hoursSinceRelease <= 48.0
-            } else false
-        } else false
+    val latestEpisodeId = podcast.latestEpisode?.id
+    val latestEpisodePubDate = podcast.latestEpisode?.publishedDate ?: 0L
+    
+    val hasRecentNew = remember(podcast.subscribedAt, latestEpisodeId, latestEpisodePubDate, lastSeenId) {
+        isEpisodeNew(podcast.subscribedAt, podcast.latestEpisode, lastSeenId)
     }
 
     // Slow shimmer animation across the NEW badge background (4 seconds loop)

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
@@ -102,6 +102,16 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.ui.graphics.Color
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -118,6 +128,8 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+
+val LocalLastSeenEpisodes = compositionLocalOf<Map<String, String>> { emptyMap() }
 
 /**
  * Unified Subscriptions screen with M3 Expressive tab switcher.
@@ -139,6 +151,11 @@ fun SubscriptionsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val pagerState = rememberPagerState(initialPage = initialTab) { 2 }
+    val lastSeenEpisodes by viewModel.lastSeenEpisodes.collectAsStateWithLifecycle()
+
+    androidx.compose.runtime.CompositionLocalProvider(
+        LocalLastSeenEpisodes provides lastSeenEpisodes
+    ) {
     val coroutineScope = rememberCoroutineScope()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
     
@@ -469,6 +486,7 @@ fun SubscriptionsScreen(
             }
         }
     }
+}
 }
 
 // ─── M3 Expressive Tab Switcher ─────────────────────────────────────────────
@@ -1239,10 +1257,44 @@ private fun SubscriptionGridCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val latestEp = podcast.latestEpisode
-    val hasNewEpisode = latestEp != null &&
-                        podcast.episodeStatus == EpisodeStatus.UNPLAYED &&
-                        latestEp.publishedDate > (podcast.subscribedAt / 1000L)
+    val lastSeenEpisodes = LocalLastSeenEpisodes.current
+    val hasRecentNew = remember(podcast.subscribedAt, podcast.latestEpisode, lastSeenEpisodes) {
+        val ep = podcast.latestEpisode
+        if (ep != null && podcast.subscribedAt > 0L && ep.publishedDate > (podcast.subscribedAt / 1000L)) {
+            val lastSeenId = lastSeenEpisodes[podcast.id]
+            if (ep.id != lastSeenId) {
+                val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - ep.publishedDate) / 3600.0
+                hoursSinceRelease <= 48.0
+            } else false
+        } else false
+    }
+
+    // Slow shimmer animation across the NEW badge background (4 seconds loop)
+    val infiniteTransition = rememberInfiniteTransition(label = "shimmer")
+    val shimmerOffset by infiniteTransition.animateFloat(
+        initialValue = -100f,
+        targetValue = 200f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 4000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmerOffset"
+    )
+
+    val baseColor = MaterialTheme.colorScheme.primary
+    val shimmerColor = MaterialTheme.colorScheme.primaryContainer
+    
+    val brush = remember(shimmerOffset, baseColor, shimmerColor) {
+        Brush.linearGradient(
+            colors = listOf(
+                baseColor,
+                shimmerColor,
+                baseColor
+            ),
+            start = Offset(shimmerOffset, 0f),
+            end = Offset(shimmerOffset + 80f, 0f)
+        )
+    }
 
     Box(
         modifier = modifier
@@ -1265,16 +1317,29 @@ private fun SubscriptionGridCard(
                 )
         )
 
-        // New Episode Badge (Vibrant solid blue dot on the top right)
-        if (hasNewEpisode) {
-            Box(
+        // New episode "NEW" text chip indicator (overlapping the top right corner) with a slow shimmer effect
+        if (hasRecentNew) {
+            Surface(
+                shape = RoundedCornerShape(6.dp),
+                color = Color.Transparent,
+                border = BorderStroke(1.2.dp, MaterialTheme.colorScheme.surface),
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .padding(8.dp)
-                    .size(10.dp)
-                    .background(MaterialTheme.colorScheme.primary, CircleShape)
-                    .border(1.5.dp, MaterialTheme.colorScheme.surface, CircleShape)
-            )
+                    .padding(top = 4.dp, end = 4.dp)
+                    .background(brush, RoundedCornerShape(6.dp))
+            ) {
+                Text(
+                    text = "NEW",
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        fontSize = 7.sp,
+                        fontWeight = FontWeight.Black,
+                        letterSpacing = 0.5.sp,
+                        lineHeight = 8.sp
+                    ),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
This PR implements automatic dismissal of the 'NEW' episode badges/tags on the Home Screen's Your Shows podcast chips. The latest episode is marked as seen in user preferences when the user clicks a podcast chip to filter by it or clicks to open its details page, clearing the badge.