### PR TITLE
fix: resolve SonarCloud useless null-safe access warning

### DIFF
--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoViewModel.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoViewModel.kt
@@ -284,7 +284,7 @@ class PodcastInfoViewModel(
                     isLoadingMore = true
                 )
                 if (isSubscribed) {
-                    currentPodcast?.let { podcast ->
+                    currentPodcast.let { podcast ->
                         podcast.latestEpisode?.id?.let { episodeId ->
                             launch {
                                 userPrefs.setLastSeenEpisodeId(podcast.id, episodeId)


### PR DESCRIPTION
Removes redundant null-safe operator ?. on smart-cast variable currentPodcast inside PodcastInfoViewModel.