### PR TITLE
design: transform Play All Downloads button into bottom-right FAB

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -1656,6 +1656,7 @@ class MainActivity : ComponentActivity() {
                                     userPrefs = userPrefs,
                                     isOffline = !isOnline,
                                     onBack = { navController.popBackStack() },
+                                    isPlayerActive = currentEpisode != null,
                                     onPodcastShowClick = { podcastId, podcastTitle ->
                                         android.util.Log.d("MainActivityNav", "onPodcastShowClick invoked with id: $podcastId, title: $podcastTitle")
                                         val encodedTitle = android.net.Uri.encode(podcastTitle.ifEmpty { "_" })
@@ -1732,6 +1733,7 @@ class MainActivity : ComponentActivity() {
                                     podcastId = podcastId,
                                     podcastTitle = podcastTitle,
                                     onBack = { navController.popBackStack() },
+                                     isPlayerActive = currentEpisode != null,
                                     onEpisodeClick = { episode, podcast ->
                                         fun encode(s: String?) = android.net.Uri.encode(s?.ifEmpty { "_" } ?: "_")
                                         navController.navigate(

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/DownloadedEpisodesScreen.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/DownloadedEpisodesScreen.kt
@@ -167,7 +167,8 @@ fun DownloadedEpisodesScreen(
     onPodcastShowClick: (String, String) -> Unit, // Navigation callback
     onSettingsClick: () -> Unit = {},
     onSyncNow: () -> Unit = {},
-    isSyncing: Boolean = false
+    isSyncing: Boolean = false,
+    isPlayerActive: Boolean = false
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
@@ -225,6 +226,23 @@ fun DownloadedEpisodesScreen(
     var deleteConfirmSelectedDialog by rememberSaveable { mutableStateOf(false) }
 
     val totalSizeBytes = remember(downloads) { downloads.sumOf { it.sizeBytes } }
+
+    val bottomBarPadding by animateDpAsState(
+        targetValue = if (isPlayerActive) 154.dp else 88.dp,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "bottomBarClearance"
+    )
+
+    val listBottomPadding = remember(downloads, isSelectionMode, isPlayerActive) {
+        if (downloads.isNotEmpty() && !isSelectionMode) {
+            if (isPlayerActive) 240.dp else 160.dp
+        } else {
+            if (isPlayerActive) 150.dp else 80.dp
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -337,60 +355,9 @@ fun DownloadedEpisodesScreen(
                 }
             }
         },
-        bottomBar = {
-            if (downloads.isNotEmpty() && !isSelectionMode) {
-                Surface(
-                    tonalElevation = 8.dp,
-                    shadowElevation = 8.dp,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Button(
-                            onClick = {
-                                val episodes = downloads.map { it.toEpisode() }
-                                val dummyPodcast = Podcast(
-                                    id = "downloads_all",
-                                    title = "All Downloads",
-                                    artist = "",
-                                    imageUrl = "",
-                                    description = "",
-                                    genre = ""
-                                )
-                                viewModel.playQueue(episodes, dummyPodcast)
-                            },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(48.dp),
-                            shape = RoundedCornerShape(50),
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.PlayArrow,
-                                contentDescription = null,
-                                modifier = Modifier.size(24.dp)
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(
-                                text = "Play All Downloads (${downloads.size})",
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.Bold
-                            )
-                        }
-                    }
-                }
-            }
-        },
         containerColor = MaterialTheme.colorScheme.surface
     ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding)) {
+        Box(modifier = Modifier.padding(innerPadding).fillMaxSize()) {
             when (uiState) {
                 is LibraryUiState.Loading -> {
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -404,7 +371,7 @@ fun DownloadedEpisodesScreen(
                 }
                 is LibraryUiState.Success -> {
                     LazyColumn(
-                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 100.dp, top = 8.dp),
+                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = listBottomPadding, top = 8.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                         modifier = Modifier.fillMaxSize()
                     ) {
@@ -465,6 +432,55 @@ fun DownloadedEpisodesScreen(
                 }
             }
 
+            // Play All FAB aligned to bottom right
+            if (downloads.isNotEmpty() && !isSelectionMode) {
+                Surface(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(bottom = bottomBarPadding, end = 16.dp)
+                        .expressiveClickable(
+                            shape = CircleShape,
+                            onClick = {
+                                val episodes = downloads.map { it.toEpisode() }
+                                val dummyPodcast = Podcast(
+                                    id = "downloads_all",
+                                    title = "All Downloads",
+                                    artist = "",
+                                    imageUrl = "",
+                                    description = "",
+                                    genre = ""
+                                )
+                                viewModel.playQueue(episodes, dummyPodcast)
+                            }
+                        ),
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    tonalElevation = 6.dp,
+                    shadowElevation = 6.dp
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .height(56.dp)
+                            .padding(horizontal = 20.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Rounded.PlayArrow,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "Play All",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+
             if (deleteConfirmSelectedDialog) {
                 AlertDialog(
                     onDismissRequest = { deleteConfirmSelectedDialog = false },
@@ -511,7 +527,8 @@ fun DownloadedShowEpisodesScreen(
     podcastId: String,
     podcastTitle: String,
     onBack: () -> Unit,
-    onEpisodeClick: (Episode, Podcast) -> Unit
+    onEpisodeClick: (Episode, Podcast) -> Unit,
+    isPlayerActive: Boolean = false
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val downloads = (uiState as? LibraryUiState.Success)?.downloadedEpisodes ?: emptyList()
@@ -677,7 +694,7 @@ fun DownloadedShowEpisodesScreen(
 
                     LazyColumn(
                         state = listState,
-                        contentPadding = PaddingValues(bottom = 120.dp, top = 8.dp),
+                        contentPadding = PaddingValues(bottom = if (isPlayerActive) 150.dp else 80.dp, top = 8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         // Compact, Space-Efficient Left-Aligned Header Row

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/DownloadedEpisodesScreen.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/DownloadedEpisodesScreen.kt
@@ -227,14 +227,6 @@ fun DownloadedEpisodesScreen(
 
     val totalSizeBytes = remember(downloads) { downloads.sumOf { it.sizeBytes } }
 
-    val bottomBarPadding by animateDpAsState(
-        targetValue = if (isPlayerActive) 154.dp else 88.dp,
-        animationSpec = spring(
-            dampingRatio = Spring.DampingRatioLowBouncy,
-            stiffness = Spring.StiffnessMediumLow
-        ),
-        label = "bottomBarClearance"
-    )
 
     val listBottomPadding = remember(downloads, isSelectionMode, isPlayerActive) {
         if (downloads.isNotEmpty() && !isSelectionMode) {
@@ -434,51 +426,21 @@ fun DownloadedEpisodesScreen(
 
             // Play All FAB aligned to bottom right
             if (downloads.isNotEmpty() && !isSelectionMode) {
-                Surface(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(bottom = bottomBarPadding, end = 16.dp)
-                        .expressiveClickable(
-                            shape = CircleShape,
-                            onClick = {
-                                val episodes = downloads.map { it.toEpisode() }
-                                val dummyPodcast = Podcast(
-                                    id = "downloads_all",
-                                    title = "All Downloads",
-                                    artist = "",
-                                    imageUrl = "",
-                                    description = "",
-                                    genre = ""
-                                )
-                                viewModel.playQueue(episodes, dummyPodcast)
-                            }
-                        ),
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    tonalElevation = 6.dp,
-                    shadowElevation = 6.dp
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .height(56.dp)
-                            .padding(horizontal = 20.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.PlayArrow,
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp)
+                PlayAllFab(
+                    isPlayerActive = isPlayerActive,
+                    onClick = {
+                        val episodes = downloads.map { it.toEpisode() }
+                        val dummyPodcast = Podcast(
+                            id = "downloads_all",
+                            title = "All Downloads",
+                            artist = "",
+                            imageUrl = "",
+                            description = "",
+                            genre = ""
                         )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = "Play All",
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.Bold
-                        )
+                        viewModel.playQueue(episodes, dummyPodcast)
                     }
-                }
+                )
             }
 
             if (deleteConfirmSelectedDialog) {

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/PlayAllFab.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/PlayAllFab.kt
@@ -1,0 +1,78 @@
+package cx.aswin.boxcast.feature.library
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
+
+@Composable
+fun BoxScope.PlayAllFab(
+    onClick: () -> Unit,
+    isPlayerActive: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val bottomPadding by animateDpAsState(
+        targetValue = if (isPlayerActive) 154.dp else 88.dp,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMediumLow
+        ),
+        label = "playAllFabBottomPadding"
+    )
+
+    Surface(
+        modifier = modifier
+            .align(Alignment.BottomEnd)
+            .padding(bottom = bottomPadding, end = 16.dp)
+            .expressiveClickable(
+                shape = CircleShape,
+                onClick = onClick
+            ),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        tonalElevation = 6.dp,
+        shadowElevation = 6.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .height(56.dp)
+                .padding(horizontal = 20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.PlayArrow,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Play All",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
@@ -960,56 +960,17 @@ private fun LatestTabContent(
                 }
             }
 
-            val bottomPadding by animateDpAsState(
-                targetValue = if (isPlayerActive) 154.dp else 88.dp,
-                animationSpec = spring(
-                    dampingRatio = Spring.DampingRatioLowBouncy,
-                    stiffness = Spring.StiffnessMediumLow
-                ),
-                label = "fabBottomPadding"
-            )
-
             if (displayPodcasts.isNotEmpty()) {
-                Surface(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(bottom = bottomPadding, end = 16.dp)
-                        .expressiveClickable(
-                            shape = CircleShape,
-                            onClick = {
-                                val episodesToPlay = displayPodcasts.map { it.latestEpisode!! }
-                                val firstPodcast = displayPodcasts.firstOrNull()
-                                if (firstPodcast != null && onPlayEpisodes != null) {
-                                    onPlayEpisodes(episodesToPlay, firstPodcast)
-                                }
-                            }
-                        ),
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    tonalElevation = 6.dp,
-                    shadowElevation = 6.dp
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .height(56.dp)
-                            .padding(horizontal = 20.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.PlayArrow,
-                            contentDescription = null,
-                            modifier = Modifier.size(24.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = "Play All",
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.Bold
-                        )
+                PlayAllFab(
+                    isPlayerActive = isPlayerActive,
+                    onClick = {
+                        val episodesToPlay = displayPodcasts.map { it.latestEpisode!! }
+                        val firstPodcast = displayPodcasts.firstOrNull()
+                        if (firstPodcast != null && onPlayEpisodes != null) {
+                            onPlayEpisodes(episodesToPlay, firstPodcast)
+                        }
                     }
-                }
+                )
             }
         }
     }


### PR DESCRIPTION
Removes scaffold bottomBar from DownloadedEpisodesScreen and converts Play All Downloads to a bottom-right FAB with animated bottom clearances, matching the New Episodes tab design.