### PR TITLE
feat: visual card deck fanning and daily curiosity optimization

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -1314,6 +1314,15 @@ class MainActivity : ComponentActivity() {
                                             "${encode(episode.podcastTitle ?: "Podcast")}?entryPoint=learn"
                                         navController.navigate(route)
                                     },
+                                    onQueueEpisode = { episode ->
+                                        val podcast = cx.aswin.boxcast.core.model.Podcast(
+                                            id = episode.podcastId ?: "unknown",
+                                            title = episode.podcastTitle ?: "Unknown Podcast",
+                                            artist = episode.podcastTitle ?: "Unknown",
+                                            imageUrl = episode.podcastImageUrl ?: episode.imageUrl ?: ""
+                                        )
+                                        queueManager.addToQueue(episode, podcast)
+                                    },
                                     onPodcastClick = { feedId, itunesId, feedUrl, title ->
                                         fun encode(s: String?) = android.net.Uri.encode(s?.ifEmpty { "_" } ?: "_")
                                         val route = "podcast?feedId=${feedId ?: ""}&itunesId=${itunesId ?: ""}&feedUrl=${encode(feedUrl)}&title=${encode(title)}"

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -1324,9 +1324,8 @@ class MainActivity : ComponentActivity() {
                                         queueManager.addToQueue(episode, podcast)
                                     },
                                     onPodcastClick = { feedId, itunesId, feedUrl, title ->
-                                        fun encode(s: String?) = android.net.Uri.encode(s?.ifEmpty { "_" } ?: "_")
-                                        val route = "podcast?feedId=${feedId ?: ""}&itunesId=${itunesId ?: ""}&feedUrl=${encode(feedUrl)}&title=${encode(title)}"
-                                        navController.navigate(route)
+                                        val pId = feedId?.toString() ?: ""
+                                        navController.navigate("podcast/$pId?entryPoint=learn")
                                     }
                                 )
                             }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PodcastRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PodcastRepository.kt
@@ -786,9 +786,10 @@ class PodcastRepository(
         result
     }
 
-    suspend fun getCuratedCuriosity(): CuratedCuriosityResponseDto? = withContext(Dispatchers.IO) {
+    suspend fun getCuratedCuriosity(bypassCache: Boolean = false): CuratedCuriosityResponseDto? = withContext(Dispatchers.IO) {
         try {
-            val resp = api.getCuratedCuriosity(publicKey).execute()
+            val cbVal = if (bypassCache) System.currentTimeMillis().toString() else null
+            val resp = api.getCuratedCuriosity(publicKey, cbVal).execute()
             if (resp.isSuccessful) {
                 resp.body()
             } else {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueManager.kt
@@ -120,6 +120,11 @@ class QueueManager @Inject constructor(
         }
     }
     
+    fun addToQueue(episode: cx.aswin.boxcast.core.model.Episode, podcast: cx.aswin.boxcast.core.model.Podcast?) {
+        val item = episode.toEpisodeItem(podcast)
+        addToQueue(item, podcast)
+    }
+
     // Overload for Domain Objects (UI)
     fun playEpisode(
         episode: cx.aswin.boxcast.core.model.Episode,

--- a/core/network/src/main/java/cx/aswin/boxcast/core/network/BoxLoreApi.kt
+++ b/core/network/src/main/java/cx/aswin/boxcast/core/network/BoxLoreApi.kt
@@ -44,7 +44,8 @@ interface BoxLoreApi {
 
     @GET("curated/curiosity")
     fun getCuratedCuriosity(
-        @Header("X-App-Key") publicKey: String
+        @Header("X-App-Key") publicKey: String,
+        @Query("cb") cacheBuster: String? = null
     ): retrofit2.Call<CuratedCuriosityResponseDto>
     
     @GET("trending")

--- a/core/network/src/main/java/cx/aswin/boxcast/core/network/BoxLoreApi.kt
+++ b/core/network/src/main/java/cx/aswin/boxcast/core/network/BoxLoreApi.kt
@@ -42,7 +42,7 @@ interface BoxLoreApi {
         @Path("region") region: String
     ): retrofit2.Call<Briefing>
 
-    @GET("curated/curiosity")
+    @GET("curated/curiosity-v2")
     fun getCuratedCuriosity(
         @Header("X-App-Key") publicKey: String,
         @Query("cb") cacheBuster: String? = null

--- a/core/network/src/main/java/cx/aswin/boxcast/core/network/model/CuratedCuriosityModels.kt
+++ b/core/network/src/main/java/cx/aswin/boxcast/core/network/model/CuratedCuriosityModels.kt
@@ -8,6 +8,9 @@ data class CuratedCuriosityResponseDto(
     @SerialName("questionOfTheDay")
     val questionOfTheDay: DailyCuriosityDto? = null,
     
+    @SerialName("questionsStack")
+    val questionsStack: List<DailyCuriosityDto> = emptyList(),
+    
     @SerialName("categories")
     val categories: List<CuratedCuriosityCategoryDto> = emptyList()
 )
@@ -22,6 +25,9 @@ data class DailyCuriosityDto(
     
     @SerialName("explanation")
     val explanation: String? = null,
+    
+    @SerialName("curiosityScore")
+    val curiosityScore: Int? = 0,
     
     @SerialName("episode")
     val episode: EpisodeItem

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -317,7 +317,7 @@ private fun CuriosityCardContent(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(220.dp)
+                        .height(280.dp)
                         .align(Alignment.BottomCenter)
                         .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
                         .drawWithContent {
@@ -338,7 +338,7 @@ private fun CuriosityCardContent(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .blur(48.dp)
+                            .blur(80.dp)
                     ) {
                         OptimizedImage(
                             url = coverArt,
@@ -356,7 +356,10 @@ private fun CuriosityCardContent(
                             .background(
                                 brush = Brush.verticalGradient(
                                     colors = listOf(
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.55f),
+                                        Color.Transparent,
+                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f),
+                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.9f),
+                                        MaterialTheme.colorScheme.surfaceContainerHigh,
                                         MaterialTheme.colorScheme.surfaceContainerHigh
                                     )
                                 )

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -1,6 +1,9 @@
 package cx.aswin.boxcast.feature.explore
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
@@ -73,112 +76,135 @@ fun CuriosityCardStack(
         val cardsToShow = questions.take(4).reversed()
 
         cardsToShow.forEach { daily ->
-            val isTopCard = daily.episode.id.toString() == questions.first().episode.id.toString()
+            val stackIndex = questions.indexOf(daily)
+            val isTopCard = stackIndex == 0
 
-            if (isTopCard) {
-                val swipeState = rememberSwipeableCardState(key = daily.episode.id) { direction ->
-                    if (direction == SwipeDirection.Left) {
-                        onSwipeLeft(daily)
-                    } else {
-                        onSwipeRight(daily)
-                    }
+            val swipeState = rememberSwipeableCardState(key = daily.episode.id) { direction ->
+                if (direction == SwipeDirection.Left) {
+                    onSwipeLeft(daily)
+                } else {
+                    onSwipeRight(daily)
                 }
+            }
 
-                var isFlipped by remember(daily.episode.id) { mutableStateOf(false) }
+            var isFlipped by remember(daily.episode.id) { mutableStateOf(false) }
 
-                val cardRotationY by animateFloatAsState(
-                    targetValue = if (isFlipped) 180f else 0f,
-                    animationSpec = tween(durationMillis = 400),
-                    label = "CardFlip"
-                )
+            val cardRotationY by animateFloatAsState(
+                targetValue = if (isFlipped) 180f else 0f,
+                animationSpec = tween(durationMillis = 400),
+                label = "CardFlip"
+            )
 
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .offset {
+            // Dynamic spring animations for stack position changes
+            val scaleTarget = when (stackIndex) {
+                0 -> 1f
+                1 -> 0.95f
+                2 -> 0.90f
+                else -> 0.85f
+            }
+            val scale by animateFloatAsState(
+                targetValue = scaleTarget,
+                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow),
+                label = "CardScale"
+            )
+
+            val offsetTarget = when (stackIndex) {
+                0 -> 0.dp
+                1 -> 10.dp
+                2 -> 18.dp
+                else -> 26.dp
+            }
+            val verticalOffset by animateDpAsState(
+                targetValue = offsetTarget,
+                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow),
+                label = "CardOffset"
+            )
+
+            val rotationTarget = when (stackIndex) {
+                0 -> 0f
+                1 -> -7f
+                2 -> 7f
+                else -> -3.5f
+            }
+            val rotationAngle by animateFloatAsState(
+                targetValue = rotationTarget,
+                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow),
+                label = "CardRotation"
+            )
+
+            val alphaTarget = when (stackIndex) {
+                0 -> 1f
+                1 -> 0.85f
+                2 -> 0.65f
+                else -> 0.45f
+            }
+            val alphaVal by animateFloatAsState(
+                targetValue = alphaTarget,
+                animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMedium),
+                label = "CardAlpha"
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .offset {
+                        if (isTopCard) {
                             IntOffset(
                                 swipeState.offset.value.x.roundToInt(),
                                 swipeState.offset.value.y.roundToInt()
                             )
+                        } else {
+                            IntOffset(0, 0)
                         }
-                        .graphicsLayer {
-                            rotationZ = (swipeState.offset.value.x / 40f)
-                            this.rotationY = cardRotationY
-                            cameraDistance = 12f * density
+                    }
+                    .offset(y = verticalOffset)
+                    .scale(scale)
+                    .graphicsLayer {
+                        rotationZ = if (isTopCard) {
+                            rotationAngle + (swipeState.offset.value.x / 40f)
+                        } else {
+                            rotationAngle
                         }
-                        .pointerInput(daily.episode.id) {
-                            detectDragGestures(
-                                onDragEnd = {
-                                    val offsetX = swipeState.offset.value.x
-                                    if (offsetX > 400f) {
-                                        swipeState.swipe(SwipeDirection.Right)
-                                    } else if (offsetX < -400f) {
-                                        swipeState.swipe(SwipeDirection.Left)
-                                    } else {
+                        this.rotationY = if (isTopCard) cardRotationY else 0f
+                        alpha = alphaVal
+                        cameraDistance = 12f * density
+                    }
+                    .then(
+                        if (isTopCard) {
+                            Modifier.pointerInput(daily.episode.id) {
+                                detectDragGestures(
+                                    onDragEnd = {
+                                        val offsetX = swipeState.offset.value.x
+                                        if (offsetX > 400f) {
+                                            swipeState.swipe(SwipeDirection.Right)
+                                        } else if (offsetX < -400f) {
+                                            swipeState.swipe(SwipeDirection.Left)
+                                        } else {
+                                            swipeState.reset()
+                                        }
+                                    },
+                                    onDragCancel = {
                                         swipeState.reset()
+                                    },
+                                    onDrag = { change, dragAmount ->
+                                        change.consume()
+                                        swipeState.drag(dragAmount)
                                     }
-                                },
-                                onDragCancel = {
-                                    swipeState.reset()
-                                },
-                                onDrag = { change, dragAmount ->
-                                    change.consume()
-                                    swipeState.drag(dragAmount)
-                                }
-                            )
-                        }
-                ) {
-                    CuriosityCardContent(
-                        daily = daily,
-                        isCurrentlyPlaying = isCurrentlyPlaying(daily.episode.id.toString()),
-                        isFlipped = isFlipped,
-                        rotationY = cardRotationY,
-                        onFlipToggle = { isFlipped = !isFlipped },
-                        onPlayClick = { onPlayClick(daily) }
-                    )
-                }
-            } else {
-                // Lower cards in stack (up to 3 background levels)
-                val stackLevel = questions.indexOf(daily) // 1, 2, or 3
-                val scale = when (stackLevel) {
-                    1 -> 0.95f
-                    2 -> 0.90f
-                    else -> 0.85f
-                }
-                val verticalOffset = when (stackLevel) {
-                    1 -> 10.dp
-                    2 -> 18.dp
-                    else -> 26.dp
-                }
-                val rotationAngle = when (stackLevel) {
-                    1 -> -7f
-                    2 -> 7f
-                    else -> -3.5f
-                }
-
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .offset(y = verticalOffset)
-                        .scale(scale)
-                        .graphicsLayer {
-                            rotationZ = rotationAngle
-                            alpha = when (stackLevel) {
-                                1 -> 0.85f
-                                2 -> 0.65f
-                                else -> 0.45f
+                                )
                             }
+                        } else {
+                            Modifier
                         }
-                ) {
-                    CuriosityCardContent(
-                        daily = daily,
-                        isCurrentlyPlaying = false,
-                        isFlipped = false,
-                        rotationY = 0f,
-                        onFlipToggle = {},
-                        onPlayClick = {}
                     )
-                }
+            ) {
+                CuriosityCardContent(
+                    daily = daily,
+                    isCurrentlyPlaying = isCurrentlyPlaying(daily.episode.id.toString()),
+                    isFlipped = isFlipped && isTopCard,
+                    rotationY = if (isTopCard) cardRotationY else 0f,
+                    onFlipToggle = { if (isTopCard) isFlipped = !isFlipped },
+                    onPlayClick = { if (isTopCard) onPlayClick(daily) }
+                )
             }
         }
     }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -140,9 +140,8 @@ fun CuriosityCardStack(
             } else {
                 // Lower cards in stack
                 val stackLevel = questions.indexOf(daily) // 1 or 2
-                val scale = if (stackLevel == 1) 0.95f else 0.90f
-                val verticalOffset = if (stackLevel == 1) 16.dp else 32.dp
-                val rotationAngle = if (stackLevel == 1) -2f else 2f
+                val scale = if (stackLevel == 1) 0.93f else 0.86f
+                val verticalOffset = if (stackLevel == 1) 20.dp else 40.dp
 
                 Box(
                     modifier = Modifier
@@ -150,8 +149,7 @@ fun CuriosityCardStack(
                         .offset(y = verticalOffset)
                         .scale(scale)
                         .graphicsLayer {
-                            rotationZ = rotationAngle
-                            alpha = if (stackLevel == 1) 0.9f else 0.7f
+                            alpha = if (stackLevel == 1) 0.85f else 0.65f
                         }
                 ) {
                     CuriosityCardContent(

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -4,30 +4,29 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.ArrowForward
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.TouchApp
-import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.TouchApp
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -48,6 +47,9 @@ fun CuriosityCardStack(
     onSwipeLeft: (DailyCuriosityDto) -> Unit,
     onSwipeRight: (DailyCuriosityDto) -> Unit,
     onPlayClick: (DailyCuriosityDto) -> Unit,
+    onEpisodeClick: (DailyCuriosityDto) -> Unit,
+    onPodcastClick: (DailyCuriosityDto) -> Unit,
+    accentColor: Color,
     modifier: Modifier = Modifier
 ) {
     if (questions.isEmpty()) {
@@ -69,7 +71,7 @@ fun CuriosityCardStack(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(360.dp),
+            .height(530.dp),
         contentAlignment = Alignment.Center
     ) {
         // Render up to 4 cards in stack representation (reversed order so top is drawn last)
@@ -86,14 +88,6 @@ fun CuriosityCardStack(
                     onSwipeRight(daily)
                 }
             }
-
-            var isFlipped by remember(daily.episode.id) { mutableStateOf(false) }
-
-            val cardRotationY by animateFloatAsState(
-                targetValue = if (isFlipped) 180f else 0f,
-                animationSpec = tween(durationMillis = 400),
-                label = "CardFlip"
-            )
 
             // Dynamic spring animations for stack position changes
             val scaleTarget = when (stackIndex) {
@@ -165,7 +159,6 @@ fun CuriosityCardStack(
                         } else {
                             rotationAngle
                         }
-                        this.rotationY = if (isTopCard) cardRotationY else 0f
                         alpha = alphaVal
                         cameraDistance = 12f * density
                     }
@@ -200,10 +193,10 @@ fun CuriosityCardStack(
                 CuriosityCardContent(
                     daily = daily,
                     isCurrentlyPlaying = isCurrentlyPlaying(daily.episode.id.toString()),
-                    isFlipped = isFlipped && isTopCard,
-                    rotationY = if (isTopCard) cardRotationY else 0f,
-                    onFlipToggle = { if (isTopCard) isFlipped = !isFlipped },
-                    onPlayClick = { if (isTopCard) onPlayClick(daily) }
+                    accentColor = accentColor,
+                    onPlayClick = { if (isTopCard) onPlayClick(daily) },
+                    onEpisodeClick = { if (isTopCard) onEpisodeClick(daily) },
+                    onPodcastClick = { if (isTopCard) onPodcastClick(daily) }
                 )
             }
         }
@@ -214,10 +207,10 @@ fun CuriosityCardStack(
 private fun CuriosityCardContent(
     daily: DailyCuriosityDto,
     isCurrentlyPlaying: Boolean,
-    isFlipped: Boolean,
-    rotationY: Float,
-    onFlipToggle: () -> Unit,
+    accentColor: Color,
     onPlayClick: () -> Unit,
+    onEpisodeClick: () -> Unit,
+    onPodcastClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val coverArt = daily.episode.image ?: daily.episode.feedImage ?: ""
@@ -230,294 +223,234 @@ private fun CuriosityCardContent(
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
         modifier = modifier
             .fillMaxSize()
-            .expressiveClickable(onClick = onFlipToggle)
+            .expressiveClickable(onClick = onEpisodeClick)
     ) {
-        if (rotationY > 90f) {
-            // Back Side (Flipped View)
+        Box(modifier = Modifier.fillMaxSize()) {
+            // 1. Full-bleed blurred background
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .graphicsLayer {
-                        this.rotationY = 180f
-                    }
+                    .blur(60.dp)
             ) {
-                // Background cover art with solid container tint for legibility
                 OptimizedImage(
                     url = coverArt,
-                    proxyWidth = 300,
+                    proxyWidth = 200,
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
                     modifier = Modifier.fillMaxSize()
                 )
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.92f))
-                )
+            }
 
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(20.dp),
-                    verticalArrangement = Arrangement.SpaceBetween
+            // 2. Dark scrim over blurred BG (High opacity for text readability)
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.75f))
+            )
+
+            // 3. Content Column
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 20.dp, vertical = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                // 3a. Badges Row (Dismiss, Info, and Queue)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Column {
-                        // Header Row with Episode details
+                    // Dismiss (Left)
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = Color.Black.copy(alpha = 0.45f),
+                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
+                    ) {
                         Row(
-                            modifier = Modifier.fillMaxWidth(),
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            OptimizedImage(
-                                url = coverArt,
-                                proxyWidth = 120,
+                            Icon(
+                                imageVector = Icons.Filled.ArrowBack,
                                 contentDescription = null,
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier
-                                    .size(52.dp)
-                                    .clip(RoundedCornerShape(12.dp))
-                                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                                tint = Color(0xFFFF6B6B),
+                                modifier = Modifier.size(14.dp)
                             )
-
-                            Spacer(modifier = Modifier.width(12.dp))
-
-                            Column(modifier = Modifier.weight(1f)) {
-                                Text(
-                                    text = daily.episode.feedTitle ?: "Podcast",
-                                    style = MaterialTheme.typography.titleSmall,
-                                    fontWeight = FontWeight.Bold,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    color = MaterialTheme.colorScheme.onSurface
-                                )
-                                val durationSec = daily.episode.duration
-                                val durationMin = if (durationSec != null && durationSec > 0) {
-                                    "${durationSec / 60} min"
-                                } else {
-                                    "Daily micro-story"
-                                }
-                                Text(
-                                    text = durationMin,
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    fontWeight = FontWeight.SemiBold
-                                )
-                            }
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = "Dismiss",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White.copy(alpha = 0.9f)
+                            )
                         }
-
-                        Spacer(modifier = Modifier.height(20.dp))
-
-                        // Explanation text
-                        Text(
-                            text = daily.explanation ?: "No explanation available.",
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            lineHeight = 24.sp,
-                            maxLines = 6,
-                            overflow = TextOverflow.Ellipsis
-                        )
                     }
 
-                    // Premium listen button
-                    FilledTonalButton(
-                        onClick = onPlayClick,
-                        shape = RoundedCornerShape(16.dp),
-                        colors = if (isCurrentlyPlaying) {
-                            ButtonDefaults.filledTonalButtonColors(
-                                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                        } else {
-                            ButtonDefaults.filledTonalButtonColors()
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(52.dp),
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
+                    // Info (Center)
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = Color.Black.copy(alpha = 0.45f),
+                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
                     ) {
-                        Icon(
-                            imageVector = if (isCurrentlyPlaying) Icons.Filled.VolumeUp else Icons.Filled.PlayArrow,
-                            contentDescription = null,
-                            modifier = Modifier.size(20.dp)
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = if (isCurrentlyPlaying) "Playing micro-story" else "Listen to micro-story",
-                            style = MaterialTheme.typography.labelLarge,
-                            fontWeight = FontWeight.Bold
-                        )
+                        Row(
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.TouchApp,
+                                contentDescription = null,
+                                tint = Color(0xFF4DABF7),
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = "Info",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White.copy(alpha = 0.9f)
+                            )
+                        }
+                    }
+
+                    // Queue (Right)
+                    Surface(
+                        shape = RoundedCornerShape(12.dp),
+                        color = Color.Black.copy(alpha = 0.45f),
+                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.ArrowForward,
+                                contentDescription = null,
+                                tint = Color(0xFF69DB7C),
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = "Queue",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White.copy(alpha = 0.9f)
+                            )
+                        }
                     }
                 }
-            }
-        } else {
-            // Front side card structure: Unified Full Image Background with Blurred Bottom Panel
-            Box(modifier = Modifier.fillMaxSize()) {
-                // 1. Full Image Background
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 3b. Crisp square artwork (120dp)
                 OptimizedImage(
                     url = coverArt,
-                    proxyWidth = 600,
+                    proxyWidth = 240,
                     contentDescription = null,
                     contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .size(120.dp)
+                        .clip(RoundedCornerShape(16.dp))
                 )
 
-                // 3 Top Interactive Badges (Dismiss, Details, Queue) with frosted bg styling
-                // Dismiss (Top Start / Left - swipe left direction)
-                Surface(
+                Spacer(modifier = Modifier.height(10.dp))
+
+                // 3c. Podcast title row indicating it is clickable (using keyboard arrow right >)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
-                        .padding(16.dp)
-                        .align(Alignment.TopStart),
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
-                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
-                    shadowElevation = 3.dp
+                        .clip(RoundedCornerShape(8.dp))
+                        .expressiveClickable(onClick = onPodcastClick)
+                        .padding(horizontal = 10.dp, vertical = 4.dp)
                 ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = "Dismiss",
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
+                    Text(
+                        text = daily.episode.feedTitle ?: "Podcast",
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White.copy(alpha = 0.8f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                        contentDescription = "Go to podcast",
+                        tint = Color.White.copy(alpha = 0.6f),
+                        modifier = Modifier.size(16.dp)
+                    )
                 }
 
-                // Details (Top Center)
-                Surface(
-                    modifier = Modifier
-                        .padding(16.dp)
-                        .align(Alignment.TopCenter),
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
-                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
-                    shadowElevation = 3.dp
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.TouchApp,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.secondary,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = "Details",
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                }
+                Spacer(modifier = Modifier.height(16.dp))
 
-                // Queue (Top End / Right - swipe right direction)
-                Surface(
-                    modifier = Modifier
-                        .padding(16.dp)
-                        .align(Alignment.TopEnd),
-                    shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
-                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
-                    shadowElevation = 3.dp
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowForward,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(16.dp)
-                        )
-                        Spacer(modifier = Modifier.width(6.dp))
-                        Text(
-                            text = "Queue",
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                }
+                // 3d. Question Text (Hook)
+                Text(
+                    text = daily.question,
+                    fontSize = 28.sp,
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Black,
+                    color = Color.White,
+                    lineHeight = 36.sp,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
 
-                // 2. Dynamic Bottom Panel Wrapper (wraps blur and shading to size dynamically with the text)
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // 3e. Explanation Text
+                Text(
+                    text = daily.explanation ?: "",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.White.copy(alpha = 0.75f),
+                    lineHeight = 20.sp,
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                // Flexible Spacer 3: Distributes space between Content and Play controls
+                Spacer(modifier = Modifier.weight(1f))
+
+                // 3f. Custom pill-style play button - Premium Circular Glassmorphic Play/Pause
+                val isPlaying = isCurrentlyPlaying
                 Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter)
-                        .height(IntrinsicSize.Min) // Dynamic height tied to the text Column!
-                ) {
-                    // Blurred Artwork Backdrop (Fills the parent Box height dynamically)
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
-                            .drawWithContent {
-                                drawContent()
-                                // Alpha mask the content of this Box to fade smoothly at the top
-                                drawRect(
-                                    brush = Brush.verticalGradient(
+                        .size(72.dp)
+                        .border(1.5.dp, Color.White.copy(alpha = 0.25f), CircleShape)
+                        .padding(6.dp)
+                        .clip(CircleShape)
+                        .then(
+                            if (isPlaying) {
+                                Modifier.background(
+                                    Brush.radialGradient(
                                         colors = listOf(
-                                            Color.Transparent,
-                                            Color.Black
+                                            accentColor,
+                                            accentColor.copy(alpha = 0.8f)
                                         )
-                                    ),
-                                    blendMode = BlendMode.DstIn
-                                )
-                            }
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .blur(80.dp)
-                        ) {
-                            OptimizedImage(
-                                url = coverArt,
-                                proxyWidth = 300,
-                                contentDescription = null,
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier.fillMaxSize()
-                            )
-                        }
-                    }
-
-                    // Solid surface container tint overlay + Text Content Column (dynamic height wrapper)
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(
-                                brush = Brush.verticalGradient(
-                                    colors = listOf(
-                                        Color.Transparent,
-                                        Color(0xFF1A1A1E).copy(alpha = 0.5f),
-                                        Color(0xFF1A1A1E).copy(alpha = 0.95f),
-                                        Color(0xFF1A1A1E),
-                                        Color(0xFF1A1A1E)
                                     )
                                 )
-                            )
-                            // top = 48.dp is the gradient transition zone so the first text line sits on solid shading
-                            .padding(start = 20.dp, end = 20.dp, bottom = 18.dp, top = 48.dp)
-                    ) {
-                        Text(
-                            text = daily.question,
-                            style = MaterialTheme.typography.headlineMedium,
-                            fontWeight = FontWeight.ExtraBold,
-                            color = Color.White,
-                            lineHeight = 36.sp
+                            } else {
+                                Modifier.background(
+                                    Brush.radialGradient(
+                                        colors = listOf(
+                                            Color.White,
+                                            Color.White.copy(alpha = 0.9f)
+                                        )
+                                    )
+                                )
+                            }
                         )
-                    }
+                        .expressiveClickable(onClick = onPlayClick),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                        tint = if (isPlaying) Color.White else Color.Black,
+                        modifier = Modifier
+                            .size(32.dp)
+                            .then(
+                                if (!isPlaying) Modifier.offset(x = 2.dp) else Modifier
+                            )
+                    )
                 }
             }
         }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -364,48 +364,6 @@ private fun CuriosityCardContent(
                     )
                 }
 
-                // 3. Floating Overlays (Badges at the top)
-                // Score Badge (Top End)
-                Surface(
-                    modifier = Modifier
-                        .padding(16.dp)
-                        .align(Alignment.TopEnd),
-                    shape = RoundedCornerShape(8.dp),
-                    color = MaterialTheme.colorScheme.primaryContainer,
-                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.primary)
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "★ ${daily.curiosityScore ?: 5}",
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer
-                        )
-                    }
-                }
-
-                // Feed Title Badge (Top Start)
-                Surface(
-                    modifier = Modifier
-                        .padding(16.dp)
-                        .align(Alignment.TopStart),
-                    shape = RoundedCornerShape(8.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
-                ) {
-                    Text(
-                        text = daily.episode.feedTitle ?: "Micro-story",
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
 
                 // 4. Question & Interaction text overlayed on the scrim
                 Column(

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -8,7 +8,10 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -313,6 +316,94 @@ private fun CuriosityCardContent(
                     modifier = Modifier.fillMaxSize()
                 )
 
+                // 3 Top Interactive Badges (Queue, Details, Dismiss)
+                // Queue (Top Start / Left)
+                Surface(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .align(Alignment.TopStart),
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowForward,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = "Queue",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+
+                // Details (Top Center)
+                Surface(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .align(Alignment.TopCenter),
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.TouchApp,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.secondary,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = "Details",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+
+                // Dismiss (Top End / Right)
+                Surface(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .align(Alignment.TopEnd),
+                    shape = RoundedCornerShape(12.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(6.dp))
+                        Text(
+                            text = "Dismiss",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                    }
+                }
+
                 // 2. Dynamic Bottom Panel Wrapper (wraps blur and shading to size dynamically with the text)
                 Box(
                     modifier = Modifier
@@ -381,27 +472,6 @@ private fun CuriosityCardContent(
                             overflow = TextOverflow.Ellipsis,
                             lineHeight = 36.sp
                         )
-
-                        Spacer(modifier = Modifier.height(14.dp))
-
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = "Tap to Reveal Details",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.primary
-                            )
-                            Text(
-                                text = "Swipe to Skip / Queue",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Medium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
                     }
                 }
             }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -1,0 +1,332 @@
+package cx.aswin.boxcast.feature.explore
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
+import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
+import kotlin.math.roundToInt
+
+@Composable
+fun CuriosityCardStack(
+    questions: List<DailyCuriosityDto>,
+    isCurrentlyPlaying: (String) -> Boolean,
+    onSwipeLeft: (DailyCuriosityDto) -> Unit,
+    onSwipeRight: (DailyCuriosityDto) -> Unit,
+    onPlayClick: (DailyCuriosityDto) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (questions.isEmpty()) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(340.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "No more curiosities for today!",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        return
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(360.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        // Render up to 3 cards in stack representation (reversed order so top is drawn last)
+        val cardsToShow = questions.take(3).reversed()
+
+        cardsToShow.forEach { daily ->
+            val isTopCard = daily.episode.id.toString() == questions.first().episode.id.toString()
+
+            if (isTopCard) {
+                val swipeState = rememberSwipeableCardState(key = daily.episode.id) { direction ->
+                    if (direction == SwipeDirection.Left) {
+                        onSwipeLeft(daily)
+                    } else {
+                        onSwipeRight(daily)
+                    }
+                }
+
+                var isFlipped by remember(daily.episode.id) { mutableStateOf(false) }
+
+                val cardRotationY by animateFloatAsState(
+                    targetValue = if (isFlipped) 180f else 0f,
+                    animationSpec = tween(durationMillis = 400),
+                    label = "CardFlip"
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .offset {
+                            IntOffset(
+                                swipeState.offset.value.x.roundToInt(),
+                                swipeState.offset.value.y.roundToInt()
+                            )
+                        }
+                        .graphicsLayer {
+                            rotationZ = (swipeState.offset.value.x / 40f)
+                            this.rotationY = cardRotationY
+                            cameraDistance = 12f * density
+                        }
+                        .pointerInput(daily.episode.id) {
+                            detectDragGestures(
+                                onDragEnd = {
+                                    val offsetX = swipeState.offset.value.x
+                                    if (offsetX > 400f) {
+                                        swipeState.swipe(SwipeDirection.Right)
+                                    } else if (offsetX < -400f) {
+                                        swipeState.swipe(SwipeDirection.Left)
+                                    } else {
+                                        swipeState.reset()
+                                    }
+                                },
+                                onDragCancel = {
+                                    swipeState.reset()
+                                },
+                                onDrag = { change, dragAmount ->
+                                    change.consume()
+                                    swipeState.drag(dragAmount)
+                                }
+                            )
+                        }
+                ) {
+                    CuriosityCardContent(
+                        daily = daily,
+                        isCurrentlyPlaying = isCurrentlyPlaying(daily.episode.id.toString()),
+                        isFlipped = isFlipped,
+                        rotationY = cardRotationY,
+                        onFlipToggle = { isFlipped = !isFlipped },
+                        onPlayClick = { onPlayClick(daily) }
+                    )
+                }
+            } else {
+                // Lower cards in stack
+                val stackLevel = questions.indexOf(daily) // 1 or 2
+                val scale = if (stackLevel == 1) 0.95f else 0.90f
+                val verticalOffset = if (stackLevel == 1) 12.dp else 24.dp
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = verticalOffset)
+                        .scale(scale)
+                        .graphicsLayer {
+                            alpha = if (stackLevel == 1) 0.85f else 0.6f
+                        }
+                ) {
+                    CuriosityCardContent(
+                        daily = daily,
+                        isCurrentlyPlaying = false,
+                        isFlipped = false,
+                        rotationY = 0f,
+                        onFlipToggle = {},
+                        onPlayClick = {}
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CuriosityCardContent(
+    daily: DailyCuriosityDto,
+    isCurrentlyPlaying: Boolean,
+    isFlipped: Boolean,
+    rotationY: Float,
+    onFlipToggle: () -> Unit,
+    onPlayClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedCard(
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+        ),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        modifier = modifier
+            .fillMaxSize()
+            .expressiveClickable(onClick = onFlipToggle)
+    ) {
+        if (rotationY > 90f) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        this.rotationY = 180f
+                    }
+                    .padding(24.dp)
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Text(
+                        text = "EXPLANATION",
+                        style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 1.sp),
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = daily.explanation ?: "No explanation available.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        lineHeight = 22.sp,
+                        maxLines = 6,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        val showArt = daily.episode.image ?: daily.episode.feedImage ?: ""
+                        OptimizedImage(
+                            url = showArt,
+                            proxyWidth = 100,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .size(48.dp)
+                                .clip(RoundedCornerShape(8.dp))
+                        )
+
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        Column(
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(
+                                text = daily.episode.feedTitle ?: "Podcast Episode",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                            val durationSec = daily.episode.duration
+                            val durationMin = if (durationSec != null && durationSec > 0) {
+                                "${durationSec / 60} min"
+                            } else {
+                                "Unknown duration"
+                            }
+                            Text(
+                                text = durationMin,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+
+                        Spacer(modifier = Modifier.width(8.dp))
+
+                        FilledTonalButton(
+                            onClick = onPlayClick,
+                            shape = RoundedCornerShape(12.dp),
+                            colors = if (isCurrentlyPlaying) {
+                                ButtonDefaults.filledTonalButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                                )
+                            } else {
+                                ButtonDefaults.filledTonalButtonColors()
+                            },
+                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                        ) {
+                            Icon(
+                                imageVector = if (isCurrentlyPlaying) Icons.Filled.VolumeUp else Icons.Filled.PlayArrow,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = if (isCurrentlyPlaying) "Playing" else "Listen",
+                                style = MaterialTheme.typography.labelMedium
+                            )
+                        }
+                    }
+                }
+            }
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp)
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column {
+                        Text(
+                            text = "CURIOSITY OF THE DAY",
+                            style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 1.sp),
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.secondary
+                        )
+
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        Text(
+                            text = daily.question,
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            lineHeight = 34.sp
+                        )
+                    }
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "Tap to flip details",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        )
+                        Text(
+                            text = "Swipe to skip/queue",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -455,10 +455,10 @@ private fun CuriosityCardContent(
                                 brush = Brush.verticalGradient(
                                     colors = listOf(
                                         Color.Transparent,
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f),
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.95f),
-                                        MaterialTheme.colorScheme.surfaceContainerHigh,
-                                        MaterialTheme.colorScheme.surfaceContainerHigh
+                                        Color.Black.copy(alpha = 0.5f),
+                                        Color.Black.copy(alpha = 0.95f),
+                                        Color.Black,
+                                        Color.Black
                                     )
                                 )
                             )
@@ -469,7 +469,7 @@ private fun CuriosityCardContent(
                             text = daily.question,
                             style = MaterialTheme.typography.headlineMedium,
                             fontWeight = FontWeight.ExtraBold,
-                            color = MaterialTheme.colorScheme.onSurface,
+                            color = Color.White,
                             maxLines = 3,
                             overflow = TextOverflow.Ellipsis,
                             lineHeight = 36.sp

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -317,7 +317,7 @@ private fun CuriosityCardContent(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(280.dp)
+                        .height(300.dp)
                         .align(Alignment.BottomCenter)
                         .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
                         .drawWithContent {
@@ -348,24 +348,26 @@ private fun CuriosityCardContent(
                             modifier = Modifier.fillMaxSize()
                         )
                     }
-                    
-                    // Solid surface container tint overlay for M3 color tone consistency
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(
-                                brush = Brush.verticalGradient(
-                                    colors = listOf(
-                                        Color.Transparent,
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f),
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.9f),
-                                        MaterialTheme.colorScheme.surfaceContainerHigh,
-                                        MaterialTheme.colorScheme.surfaceContainerHigh
-                                    )
-                                )
-                            )
-                    )
                 }
+
+                // 3. Full-card Gradient Shading to make the text fully legible and clear
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            brush = Brush.verticalGradient(
+                                colors = listOf(
+                                    Color.Transparent,
+                                    MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.3f),
+                                    MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
+                                    MaterialTheme.colorScheme.surfaceContainerHigh,
+                                    MaterialTheme.colorScheme.surfaceContainerHigh
+                                ),
+                                startY = 0f,
+                                endY = 900f // Reaches full solid color higher up
+                            )
+                        )
+                )
 
                 // 4. Question & Interaction text overlayed on the scrim
                 Column(

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -318,29 +318,29 @@ private fun CuriosityCardContent(
                     modifier = Modifier.fillMaxSize()
                 )
 
-                // 3 Top Interactive Badges (Queue, Details, Dismiss)
-                // Queue (Top Start / Left)
+                // 3 Top Interactive Badges (Dismiss, Details, Queue) with frosted bg styling
+                // Dismiss (Top Start / Left - swipe left direction)
                 Surface(
                     modifier = Modifier
                         .padding(16.dp)
                         .align(Alignment.TopStart),
                     shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.6f),
+                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowForward,
+                            imageVector = Icons.Filled.ArrowBack,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
+                            tint = MaterialTheme.colorScheme.error,
                             modifier = Modifier.size(16.dp)
                         )
                         Spacer(modifier = Modifier.width(6.dp))
                         Text(
-                            text = "Queue",
+                            text = "Dismiss",
                             style = MaterialTheme.typography.labelMedium,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onSurface
@@ -354,8 +354,8 @@ private fun CuriosityCardContent(
                         .padding(16.dp)
                         .align(Alignment.TopCenter),
                     shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.6f),
+                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
@@ -377,28 +377,28 @@ private fun CuriosityCardContent(
                     }
                 }
 
-                // Dismiss (Top End / Right)
+                // Queue (Top End / Right - swipe right direction)
                 Surface(
                     modifier = Modifier
                         .padding(16.dp)
                         .align(Alignment.TopEnd),
                     shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.6f),
+                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
-                            imageVector = Icons.Filled.ArrowBack,
+                            imageVector = Icons.Filled.ArrowForward,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.error,
+                            tint = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.size(16.dp)
                         )
                         Spacer(modifier = Modifier.width(6.dp))
                         Text(
-                            text = "Dismiss",
+                            text = "Queue",
                             style = MaterialTheme.typography.labelMedium,
                             fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onSurface

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -256,89 +256,7 @@ private fun CuriosityCardContent(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 // 3a. Badges Row (Dismiss, Info, and Queue)
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    // Dismiss (Left)
-                    Surface(
-                        shape = RoundedCornerShape(12.dp),
-                        color = Color.Black.copy(alpha = 0.45f),
-                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.ArrowBack,
-                                contentDescription = null,
-                                tint = Color(0xFFFF6B6B),
-                                modifier = Modifier.size(14.dp)
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = "Dismiss",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White.copy(alpha = 0.9f)
-                            )
-                        }
-                    }
-
-                    // Info (Center)
-                    Surface(
-                        shape = RoundedCornerShape(12.dp),
-                        color = Color.Black.copy(alpha = 0.45f),
-                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.TouchApp,
-                                contentDescription = null,
-                                tint = Color(0xFF4DABF7),
-                                modifier = Modifier.size(14.dp)
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = "Info",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White.copy(alpha = 0.9f)
-                            )
-                        }
-                    }
-
-                    // Queue (Right)
-                    Surface(
-                        shape = RoundedCornerShape(12.dp),
-                        color = Color.Black.copy(alpha = 0.45f),
-                        border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.ArrowForward,
-                                contentDescription = null,
-                                tint = Color(0xFF69DB7C),
-                                modifier = Modifier.size(14.dp)
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = "Queue",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = Color.White.copy(alpha = 0.9f)
-                            )
-                        }
-                    }
-                }
+                CardBadgesRow()
 
                 Spacer(modifier = Modifier.height(16.dp))
 
@@ -410,49 +328,151 @@ private fun CuriosityCardContent(
                 Spacer(modifier = Modifier.weight(1f))
 
                 // 3f. Custom pill-style play button - Premium Circular Glassmorphic Play/Pause
-                val isPlaying = isCurrentlyPlaying
-                Box(
-                    modifier = Modifier
-                        .size(72.dp)
-                        .border(1.5.dp, Color.White.copy(alpha = 0.25f), CircleShape)
-                        .padding(6.dp)
-                        .clip(CircleShape)
-                        .then(
-                            if (isPlaying) {
-                                Modifier.background(
-                                    Brush.radialGradient(
-                                        colors = listOf(
-                                            accentColor,
-                                            accentColor.copy(alpha = 0.8f)
-                                        )
-                                    )
-                                )
-                            } else {
-                                Modifier.background(
-                                    Brush.radialGradient(
-                                        colors = listOf(
-                                            Color.White,
-                                            Color.White.copy(alpha = 0.9f)
-                                        )
-                                    )
-                                )
-                            }
-                        )
-                        .expressiveClickable(onClick = onPlayClick),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
-                        tint = if (isPlaying) Color.White else Color.Black,
-                        modifier = Modifier
-                            .size(32.dp)
-                            .then(
-                                if (!isPlaying) Modifier.offset(x = 2.dp) else Modifier
-                            )
-                    )
-                }
+                CircularPlayButton(
+                    isPlaying = isCurrentlyPlaying,
+                    accentColor = accentColor,
+                    onClick = onPlayClick
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun CardBadgesRow(
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Dismiss (Left)
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = Color.Black.copy(alpha = 0.45f),
+            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.ArrowBack,
+                    contentDescription = null,
+                    tint = Color(0xFFFF6B6B),
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "Dismiss",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White.copy(alpha = 0.9f)
+                )
+            }
+        }
+
+        // Info (Center)
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = Color.Black.copy(alpha = 0.45f),
+            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.TouchApp,
+                    contentDescription = null,
+                    tint = Color(0xFF4DABF7),
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "Info",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White.copy(alpha = 0.9f)
+                )
+            }
+        }
+
+        // Queue (Right)
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = Color.Black.copy(alpha = 0.45f),
+            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.15f))
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.ArrowForward,
+                    contentDescription = null,
+                    tint = Color(0xFF69DB7C),
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "Queue",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White.copy(alpha = 0.9f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CircularPlayButton(
+    isPlaying: Boolean,
+    accentColor: Color,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(72.dp)
+            .border(1.5.dp, Color.White.copy(alpha = 0.25f), CircleShape)
+            .padding(6.dp)
+            .clip(CircleShape)
+            .then(
+                if (isPlaying) {
+                    Modifier.background(
+                        Brush.radialGradient(
+                            colors = listOf(
+                                accentColor,
+                                accentColor.copy(alpha = 0.8f)
+                            )
+                        )
+                    )
+                } else {
+                    Modifier.background(
+                        Brush.radialGradient(
+                            colors = listOf(
+                                Color.White,
+                                Color.White.copy(alpha = 0.9f)
+                            )
+                        )
+                    )
+                }
+            )
+            .expressiveClickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+            contentDescription = if (isPlaying) "Pause" else "Play",
+            tint = if (isPlaying) Color.White else Color.Black,
+            modifier = Modifier
+                .size(32.dp)
+                .then(
+                    if (!isPlaying) Modifier.offset(x = 2.dp) else Modifier
+                )
+        )
     }
 }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -140,8 +140,9 @@ fun CuriosityCardStack(
             } else {
                 // Lower cards in stack
                 val stackLevel = questions.indexOf(daily) // 1 or 2
-                val scale = if (stackLevel == 1) 0.93f else 0.86f
-                val verticalOffset = if (stackLevel == 1) 20.dp else 40.dp
+                val scale = if (stackLevel == 1) 0.95f else 0.90f
+                val verticalOffset = if (stackLevel == 1) 10.dp else 18.dp
+                val rotationAngle = if (stackLevel == 1) -4.5f else 3.5f
 
                 Box(
                     modifier = Modifier
@@ -149,6 +150,7 @@ fun CuriosityCardStack(
                         .offset(y = verticalOffset)
                         .scale(scale)
                         .graphicsLayer {
+                            rotationZ = rotationAngle
                             alpha = if (stackLevel == 1) 0.85f else 0.65f
                         }
                 ) {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -16,9 +16,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -310,12 +313,26 @@ private fun CuriosityCardContent(
                     modifier = Modifier.fillMaxSize()
                 )
 
-                // 2. Blurred Bottom Panel (Glassy/premium effect using replica of artwork)
+                // 2. Blurred Bottom Panel (Fading out smoothly towards the top)
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(170.dp)
+                        .height(200.dp)
                         .align(Alignment.BottomCenter)
+                        .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                        .drawWithContent {
+                            drawContent()
+                            // Alpha mask the content of this Box to fade smoothly
+                            drawRect(
+                                brush = Brush.verticalGradient(
+                                    colors = listOf(
+                                        Color.Transparent,
+                                        Color.Black
+                                    )
+                                ),
+                                blendMode = BlendMode.DstIn
+                            )
+                        }
                 ) {
                     // Blurred Artwork Layer
                     Box(
@@ -332,15 +349,14 @@ private fun CuriosityCardContent(
                         )
                     }
                     
-                    // Dark/surface overlay on top of blurred artwork to ensure clean text contrast
+                    // Solid surface container tint overlay for M3 color tone consistency
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
                             .background(
                                 brush = Brush.verticalGradient(
                                     colors = listOf(
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f),
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
+                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.4f),
                                         MaterialTheme.colorScheme.surfaceContainerHigh
                                     )
                                 )
@@ -400,12 +416,12 @@ private fun CuriosityCardContent(
                 ) {
                     Text(
                         text = daily.question,
-                        style = MaterialTheme.typography.titleMedium,
+                        style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 3,
                         overflow = TextOverflow.Ellipsis,
-                        lineHeight = 22.sp
+                        lineHeight = 30.sp
                     )
 
                     Spacer(modifier = Modifier.height(14.dp))

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -313,98 +313,95 @@ private fun CuriosityCardContent(
                     modifier = Modifier.fillMaxSize()
                 )
 
-                // 2. Blurred Bottom Panel (Fading out smoothly towards the top)
+                // 2. Dynamic Bottom Panel Wrapper (wraps blur and shading to size dynamically with the text)
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(300.dp)
                         .align(Alignment.BottomCenter)
-                        .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
-                        .drawWithContent {
-                            drawContent()
-                            // Alpha mask the content of this Box to fade smoothly
-                            drawRect(
-                                brush = Brush.verticalGradient(
-                                    colors = listOf(
-                                        Color.Transparent,
-                                        Color.Black
-                                    )
-                                ),
-                                blendMode = BlendMode.DstIn
-                            )
-                        }
+                        .height(IntrinsicSize.Min) // Dynamic height tied to the text Column!
                 ) {
-                    // Blurred Artwork Layer
+                    // Blurred Artwork Backdrop (Fills the parent Box height dynamically)
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .blur(80.dp)
+                            .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                            .drawWithContent {
+                                drawContent()
+                                // Alpha mask the content of this Box to fade smoothly at the top
+                                drawRect(
+                                    brush = Brush.verticalGradient(
+                                        colors = listOf(
+                                            Color.Transparent,
+                                            Color.Black
+                                        )
+                                    ),
+                                    blendMode = BlendMode.DstIn
+                                )
+                            }
                     ) {
-                        OptimizedImage(
-                            url = coverArt,
-                            proxyWidth = 300,
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize()
-                        )
-                    }
-                }
-
-                // 3. Full-card Gradient Shading to make the text fully legible and clear
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            brush = Brush.verticalGradient(
-                                colors = listOf(
-                                    Color.Transparent,
-                                    MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.3f),
-                                    MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
-                                    MaterialTheme.colorScheme.surfaceContainerHigh,
-                                    MaterialTheme.colorScheme.surfaceContainerHigh
-                                ),
-                                startY = 0f,
-                                endY = 900f // Reaches full solid color higher up
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .blur(80.dp)
+                        ) {
+                            OptimizedImage(
+                                url = coverArt,
+                                proxyWidth = 300,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier.fillMaxSize()
                             )
-                        )
-                )
+                        }
+                    }
 
-                // 4. Question & Interaction text overlayed on the scrim
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .align(Alignment.BottomCenter)
-                        .padding(horizontal = 20.dp, vertical = 18.dp)
-                ) {
-                    Text(
-                        text = daily.question,
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.ExtraBold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 3,
-                        overflow = TextOverflow.Ellipsis,
-                        lineHeight = 36.sp
-                    )
-
-                    Spacer(modifier = Modifier.height(14.dp))
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
+                    // Solid surface container tint overlay + Text Content Column (dynamic height wrapper)
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                brush = Brush.verticalGradient(
+                                    colors = listOf(
+                                        Color.Transparent,
+                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f),
+                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.95f),
+                                        MaterialTheme.colorScheme.surfaceContainerHigh,
+                                        MaterialTheme.colorScheme.surfaceContainerHigh
+                                    )
+                                )
+                            )
+                            // top = 48.dp is the gradient transition zone so the first text line sits on solid shading
+                            .padding(start = 20.dp, end = 20.dp, bottom = 18.dp, top = 48.dp)
                     ) {
                         Text(
-                            text = "Tap to Reveal Details",
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.primary
+                            text = daily.question,
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontWeight = FontWeight.ExtraBold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
+                            lineHeight = 36.sp
                         )
-                        Text(
-                            text = "Swipe to Skip / Queue",
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.Medium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+
+                        Spacer(modifier = Modifier.height(14.dp))
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Tap to Reveal Details",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Text(
+                                text = "Swipe to Skip / Queue",
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                 }
             }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -489,8 +489,6 @@ private fun CuriosityCardContent(
                             style = MaterialTheme.typography.headlineMedium,
                             fontWeight = FontWeight.ExtraBold,
                             color = Color.White,
-                            maxLines = 3,
-                            overflow = TextOverflow.Ellipsis,
                             lineHeight = 36.sp
                         )
                     }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -323,8 +323,9 @@ private fun CuriosityCardContent(
                         .padding(16.dp)
                         .align(Alignment.TopStart),
                     shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.6f),
-                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
+                    shadowElevation = 3.dp
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
@@ -352,8 +353,9 @@ private fun CuriosityCardContent(
                         .padding(16.dp)
                         .align(Alignment.TopCenter),
                     shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.6f),
-                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
+                    shadowElevation = 3.dp
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
@@ -381,8 +383,9 @@ private fun CuriosityCardContent(
                         .padding(16.dp)
                         .align(Alignment.TopEnd),
                     shape = RoundedCornerShape(12.dp),
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.6f),
-                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.7f)),
+                    shadowElevation = 3.dp
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
@@ -453,10 +456,10 @@ private fun CuriosityCardContent(
                                 brush = Brush.verticalGradient(
                                     colors = listOf(
                                         Color.Transparent,
-                                        Color.Black.copy(alpha = 0.5f),
-                                        Color.Black.copy(alpha = 0.95f),
-                                        Color.Black,
-                                        Color.Black
+                                        Color(0xFF1A1A1E).copy(alpha = 0.5f),
+                                        Color(0xFF1A1A1E).copy(alpha = 0.95f),
+                                        Color(0xFF1A1A1E),
+                                        Color(0xFF1A1A1E)
                                     )
                                 )
                             )

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -317,7 +317,7 @@ private fun CuriosityCardContent(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(200.dp)
+                        .height(220.dp)
                         .align(Alignment.BottomCenter)
                         .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
                         .drawWithContent {
@@ -338,7 +338,7 @@ private fun CuriosityCardContent(
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
-                            .blur(24.dp)
+                            .blur(48.dp)
                     ) {
                         OptimizedImage(
                             url = coverArt,
@@ -356,14 +356,13 @@ private fun CuriosityCardContent(
                             .background(
                                 brush = Brush.verticalGradient(
                                     colors = listOf(
-                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.4f),
+                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.55f),
                                         MaterialTheme.colorScheme.surfaceContainerHigh
                                     )
                                 )
                             )
                     )
                 }
-
 
                 // 4. Question & Interaction text overlayed on the scrim
                 Column(
@@ -374,12 +373,12 @@ private fun CuriosityCardContent(
                 ) {
                     Text(
                         text = daily.question,
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.ExtraBold,
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 3,
                         overflow = TextOverflow.Ellipsis,
-                        lineHeight = 30.sp
+                        lineHeight = 36.sp
                     )
 
                     Spacer(modifier = Modifier.height(14.dp))

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -14,8 +14,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
@@ -168,6 +170,8 @@ private fun CuriosityCardContent(
     onPlayClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val coverArt = daily.episode.image ?: daily.episode.feedImage ?: ""
+
     OutlinedCard(
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.outlinedCardColors(
@@ -179,16 +183,32 @@ private fun CuriosityCardContent(
             .expressiveClickable(onClick = onFlipToggle)
     ) {
         if (rotationY > 90f) {
+            // Back Side (Flipped View)
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .graphicsLayer {
                         this.rotationY = 180f
                     }
-                    .padding(20.dp)
             ) {
+                // Background cover art with solid container tint for legibility
+                OptimizedImage(
+                    url = coverArt,
+                    proxyWidth = 300,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.92f))
+                )
+
                 Column(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(20.dp),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
                     Column {
@@ -197,9 +217,8 @@ private fun CuriosityCardContent(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            val showArt = daily.episode.image ?: daily.episode.feedImage ?: ""
                             OptimizedImage(
-                                url = showArt,
+                                url = coverArt,
                                 proxyWidth = 120,
                                 contentDescription = null,
                                 contentScale = ContentScale.Crop,
@@ -248,7 +267,7 @@ private fun CuriosityCardContent(
                         )
                     }
 
-                    // Premium full-width listen action button
+                    // Premium listen button
                     FilledTonalButton(
                         onClick = onPlayClick,
                         shape = RoundedCornerShape(16.dp),
@@ -280,75 +299,104 @@ private fun CuriosityCardContent(
                 }
             }
         } else {
-            // Front side card structure
-            Column(modifier = Modifier.fillMaxSize()) {
-                // Top Cover Artwork (occupies 60% height)
+            // Front side card structure: Unified Full Image Background with Blurred Bottom Panel
+            Box(modifier = Modifier.fillMaxSize()) {
+                // 1. Full Image Background
+                OptimizedImage(
+                    url = coverArt,
+                    proxyWidth = 600,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+
+                // 2. Blurred Bottom Panel (Glassy/premium effect using replica of artwork)
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(0.6f)
-                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .height(170.dp)
+                        .align(Alignment.BottomCenter)
                 ) {
-                    val coverArt = daily.episode.image ?: daily.episode.feedImage ?: ""
-                    OptimizedImage(
-                        url = coverArt,
-                        proxyWidth = 600,
-                        contentDescription = null,
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.fillMaxSize()
-                    )
-
-                    // Overlay pill containing curiosity score or tag
-                    Surface(
+                    // Blurred Artwork Layer
+                    Box(
                         modifier = Modifier
-                            .padding(16.dp)
-                            .align(Alignment.TopEnd),
-                        shape = RoundedCornerShape(8.dp),
-                        color = MaterialTheme.colorScheme.primaryContainer,
-                        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.primary)
+                            .fillMaxSize()
+                            .blur(24.dp)
                     ) {
-                        Row(
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = "★ ${daily.curiosityScore ?: 5}",
-                                style = MaterialTheme.typography.labelMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onPrimaryContainer
-                            )
-                        }
+                        OptimizedImage(
+                            url = coverArt,
+                            proxyWidth = 300,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
                     }
-
-                    // Feed Title Pill
-                    Surface(
+                    
+                    // Dark/surface overlay on top of blurred artwork to ensure clean text contrast
+                    Box(
                         modifier = Modifier
-                            .padding(16.dp)
-                            .align(Alignment.TopStart),
-                        shape = RoundedCornerShape(8.dp),
-                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                            .fillMaxSize()
+                            .background(
+                                brush = Brush.verticalGradient(
+                                    colors = listOf(
+                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.5f),
+                                        MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.85f),
+                                        MaterialTheme.colorScheme.surfaceContainerHigh
+                                    )
+                                )
+                            )
+                    )
+                }
+
+                // 3. Floating Overlays (Badges at the top)
+                // Score Badge (Top End)
+                Surface(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .align(Alignment.TopEnd),
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.primary)
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = daily.episode.feedTitle ?: "Micro-story",
+                            text = "★ ${daily.curiosityScore ?: 5}",
                             style = MaterialTheme.typography.labelMedium,
                             fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+                            color = MaterialTheme.colorScheme.onPrimaryContainer
                         )
                     }
                 }
 
-                // Bottom Content Container (occupies 40% height)
+                // Feed Title Badge (Top Start)
+                Surface(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .align(Alignment.TopStart),
+                    shape = RoundedCornerShape(8.dp),
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                ) {
+                    Text(
+                        text = daily.episode.feedTitle ?: "Micro-story",
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                // 4. Question & Interaction text overlayed on the scrim
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .weight(0.4f)
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                        .padding(horizontal = 20.dp, vertical = 16.dp),
-                    verticalArrangement = Arrangement.SpaceBetween
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 20.dp, vertical = 18.dp)
                 ) {
                     Text(
                         text = daily.question,
@@ -357,11 +405,10 @@ private fun CuriosityCardContent(
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 3,
                         overflow = TextOverflow.Ellipsis,
-                        lineHeight = 22.sp,
-                        modifier = Modifier.weight(1f)
+                        lineHeight = 22.sp
                     )
 
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(14.dp))
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -3,6 +3,7 @@ package cx.aswin.boxcast.feature.explore
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -184,130 +185,183 @@ private fun CuriosityCardContent(
                     .graphicsLayer {
                         this.rotationY = 180f
                     }
-                    .padding(24.dp)
-            ) {
-                Column(
-                    modifier = Modifier.fillMaxSize()
-                ) {
-                    Text(
-                        text = "EXPLANATION",
-                        style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 1.sp),
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary
-                    )
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Text(
-                        text = daily.explanation ?: "No explanation available.",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        lineHeight = 22.sp,
-                        maxLines = 6,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
-                    )
-
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        val showArt = daily.episode.image ?: daily.episode.feedImage ?: ""
-                        OptimizedImage(
-                            url = showArt,
-                            proxyWidth = 100,
-                            contentDescription = null,
-                            contentScale = ContentScale.Crop,
-                            modifier = Modifier
-                                .size(48.dp)
-                                .clip(RoundedCornerShape(8.dp))
-                        )
-
-                        Spacer(modifier = Modifier.width(12.dp))
-
-                        Column(
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text(
-                                text = daily.episode.feedTitle ?: "Podcast Episode",
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = FontWeight.SemiBold,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            val durationSec = daily.episode.duration
-                            val durationMin = if (durationSec != null && durationSec > 0) {
-                                "${durationSec / 60} min"
-                            } else {
-                                "Unknown duration"
-                            }
-                            Text(
-                                text = durationMin,
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
-
-                        Spacer(modifier = Modifier.width(8.dp))
-
-                        FilledTonalButton(
-                            onClick = onPlayClick,
-                            shape = RoundedCornerShape(12.dp),
-                            colors = if (isCurrentlyPlaying) {
-                                ButtonDefaults.filledTonalButtonColors(
-                                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                                )
-                            } else {
-                                ButtonDefaults.filledTonalButtonColors()
-                            },
-                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
-                        ) {
-                            Icon(
-                                imageVector = if (isCurrentlyPlaying) Icons.Filled.VolumeUp else Icons.Filled.PlayArrow,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp)
-                            )
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = if (isCurrentlyPlaying) "Playing" else "Listen",
-                                style = MaterialTheme.typography.labelMedium
-                            )
-                        }
-                    }
-                }
-            }
-        } else {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(24.dp)
+                    .padding(20.dp)
             ) {
                 Column(
                     modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
                     Column {
-                        Text(
-                            text = "CURIOSITY OF THE DAY",
-                            style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 1.sp),
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.secondary
-                        )
+                        // Header Row with Episode details
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            val showArt = daily.episode.image ?: daily.episode.feedImage ?: ""
+                            OptimizedImage(
+                                url = showArt,
+                                proxyWidth = 120,
+                                contentDescription = null,
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .size(52.dp)
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                            )
 
-                        Spacer(modifier = Modifier.height(24.dp))
+                            Spacer(modifier = Modifier.width(12.dp))
 
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = daily.episode.feedTitle ?: "Podcast",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                val durationSec = daily.episode.duration
+                                val durationMin = if (durationSec != null && durationSec > 0) {
+                                    "${durationSec / 60} min"
+                                } else {
+                                    "Daily micro-story"
+                                }
+                                Text(
+                                    text = durationMin,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.primary,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(20.dp))
+
+                        // Explanation text
                         Text(
-                            text = daily.question,
-                            style = MaterialTheme.typography.headlineSmall,
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                            lineHeight = 34.sp
+                            text = daily.explanation ?: "No explanation available.",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            lineHeight = 24.sp,
+                            maxLines = 6,
+                            overflow = TextOverflow.Ellipsis
                         )
                     }
+
+                    // Premium full-width listen action button
+                    FilledTonalButton(
+                        onClick = onPlayClick,
+                        shape = RoundedCornerShape(16.dp),
+                        colors = if (isCurrentlyPlaying) {
+                            ButtonDefaults.filledTonalButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        } else {
+                            ButtonDefaults.filledTonalButtonColors()
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
+                    ) {
+                        Icon(
+                            imageVector = if (isCurrentlyPlaying) Icons.Filled.VolumeUp else Icons.Filled.PlayArrow,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = if (isCurrentlyPlaying) "Playing micro-story" else "Listen to micro-story",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+        } else {
+            // Front side card structure
+            Column(modifier = Modifier.fillMaxSize()) {
+                // Top Cover Artwork (occupies 60% height)
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(0.6f)
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                ) {
+                    val coverArt = daily.episode.image ?: daily.episode.feedImage ?: ""
+                    OptimizedImage(
+                        url = coverArt,
+                        proxyWidth = 600,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+
+                    // Overlay pill containing curiosity score or tag
+                    Surface(
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .align(Alignment.TopEnd),
+                        shape = RoundedCornerShape(8.dp),
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.primary)
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "★ ${daily.curiosityScore ?: 5}",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        }
+                    }
+
+                    // Feed Title Pill
+                    Surface(
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .align(Alignment.TopStart),
+                        shape = RoundedCornerShape(8.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+                    ) {
+                        Text(
+                            text = daily.episode.feedTitle ?: "Micro-story",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
+
+                // Bottom Content Container (occupies 40% height)
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(0.4f)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                        .padding(horizontal = 20.dp, vertical = 16.dp),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = daily.question,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis,
+                        lineHeight = 22.sp,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -315,14 +369,16 @@ private fun CuriosityCardContent(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = "Tap to flip details",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            text = "Tap to Reveal Details",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary
                         )
                         Text(
-                            text = "Swipe to skip/queue",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            text = "Swipe to Skip / Queue",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -69,8 +69,8 @@ fun CuriosityCardStack(
             .height(360.dp),
         contentAlignment = Alignment.Center
     ) {
-        // Render up to 3 cards in stack representation (reversed order so top is drawn last)
-        val cardsToShow = questions.take(3).reversed()
+        // Render up to 4 cards in stack representation (reversed order so top is drawn last)
+        val cardsToShow = questions.take(4).reversed()
 
         cardsToShow.forEach { daily ->
             val isTopCard = daily.episode.id.toString() == questions.first().episode.id.toString()
@@ -138,11 +138,23 @@ fun CuriosityCardStack(
                     )
                 }
             } else {
-                // Lower cards in stack
-                val stackLevel = questions.indexOf(daily) // 1 or 2
-                val scale = if (stackLevel == 1) 0.95f else 0.90f
-                val verticalOffset = if (stackLevel == 1) 10.dp else 18.dp
-                val rotationAngle = if (stackLevel == 1) -4.5f else 3.5f
+                // Lower cards in stack (up to 3 background levels)
+                val stackLevel = questions.indexOf(daily) // 1, 2, or 3
+                val scale = when (stackLevel) {
+                    1 -> 0.95f
+                    2 -> 0.90f
+                    else -> 0.85f
+                }
+                val verticalOffset = when (stackLevel) {
+                    1 -> 10.dp
+                    2 -> 18.dp
+                    else -> 26.dp
+                }
+                val rotationAngle = when (stackLevel) {
+                    1 -> -7f
+                    2 -> 7f
+                    else -> -3.5f
+                }
 
                 Box(
                     modifier = Modifier
@@ -151,7 +163,11 @@ fun CuriosityCardStack(
                         .scale(scale)
                         .graphicsLayer {
                             rotationZ = rotationAngle
-                            alpha = if (stackLevel == 1) 0.85f else 0.65f
+                            alpha = when (stackLevel) {
+                                1 -> 0.85f
+                                2 -> 0.65f
+                                else -> 0.45f
+                            }
                         }
                 ) {
                     CuriosityCardContent(

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -141,15 +141,17 @@ fun CuriosityCardStack(
                 // Lower cards in stack
                 val stackLevel = questions.indexOf(daily) // 1 or 2
                 val scale = if (stackLevel == 1) 0.95f else 0.90f
-                val verticalOffset = if (stackLevel == 1) 12.dp else 24.dp
+                val verticalOffset = if (stackLevel == 1) 16.dp else 32.dp
+                val rotationAngle = if (stackLevel == 1) -2f else 2f
 
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(top = verticalOffset)
+                        .offset(y = verticalOffset)
                         .scale(scale)
                         .graphicsLayer {
-                            alpha = if (stackLevel == 1) 0.85f else 0.6f
+                            rotationZ = rotationAngle
+                            alpha = if (stackLevel == 1) 0.9f else 0.7f
                         }
                 ) {
                     CuriosityCardContent(

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -76,6 +76,7 @@ fun LearnScreen(
     playbackRepository: cx.aswin.boxcast.core.data.PlaybackRepository,
     bottomContentPadding: Dp,
     onEpisodeClick: (Episode) -> Unit,
+    onQueueEpisode: (Episode) -> Unit,
     onPodcastClick: (feedId: Long?, itunesId: Long?, feedUrl: String, title: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -197,20 +198,25 @@ fun LearnScreen(
                                 }
                             }
 
-                            // 2. Curiosity of the Day Section
-                            state.data.questionOfTheDay?.let { daily ->
-                                item {
-                                    val mappedEpisode = mapToEpisode(daily.episode)
-                                    val isCurrentlyPlaying = playerState.currentEpisode?.id == mappedEpisode.id && playerState.isPlaying
-                                    
-                                    CuriosityOfTheDayCard(
-                                        daily = daily,
-                                        isCurrentlyPlaying = isCurrentlyPlaying,
-                                        accentColor = accentColor,
-                                        onClick = { onEpisodeClick(mappedEpisode) },
-                                        modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
-                                    )
-                                }
+                            // 2. Curiosity Card Stack Section
+                            item {
+                                CuriosityCardStack(
+                                    questions = state.questionsStack,
+                                    isCurrentlyPlaying = { id -> playerState.currentEpisode?.id == id && playerState.isPlaying },
+                                    onSwipeLeft = { daily ->
+                                        viewModel.dismissCuriosity(daily.episode.id.toString())
+                                    },
+                                    onSwipeRight = { daily ->
+                                        val mappedEpisode = mapToEpisode(daily.episode)
+                                        onQueueEpisode(mappedEpisode)
+                                        viewModel.dismissCuriosity(daily.episode.id.toString())
+                                    },
+                                    onPlayClick = { daily ->
+                                        val mappedEpisode = mapToEpisode(daily.episode)
+                                        onEpisodeClick(mappedEpisode)
+                                    },
+                                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
+                                )
                             }
 
                             // 3. Curated Categories Sections
@@ -286,142 +292,7 @@ fun LearnScreen(
     }
 }
 
-@Composable
-private fun CuriosityOfTheDayCard(
-    daily: DailyCuriosityDto,
-    isCurrentlyPlaying: Boolean,
-    accentColor: Color,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val durationSec = daily.episode.duration
-    val durationMin = if (durationSec != null && durationSec > 0) {
-        "${durationSec / 60} min"
-    } else {
-        "Unknown duration"
-    }
 
-    val buttonColors = if (isCurrentlyPlaying) {
-        ButtonDefaults.filledTonalButtonColors(
-            containerColor = MaterialTheme.colorScheme.primaryContainer,
-            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-        )
-    } else {
-        ButtonDefaults.filledTonalButtonColors()
-    }
-
-    val buttonIcon = if (isCurrentlyPlaying) Icons.Filled.VolumeUp else Icons.Filled.PlayArrow
-    val buttonText = if (isCurrentlyPlaying) "Playing" else "Listen"
-
-    OutlinedCard(
-        shape = MaterialTheme.shapes.extraLarge,
-        colors = CardDefaults.outlinedCardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-        ),
-        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-        modifier = modifier
-            .fillMaxWidth()
-            .expressiveClickable(onClick = onClick)
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(20.dp)
-        ) {
-            // Header Badge
-            Text(
-                text = "CURIOSITY OF THE DAY",
-                style = MaterialTheme.typography.labelMedium.copy(letterSpacing = 1.sp),
-                fontWeight = FontWeight.Bold,
-                color = accentColor
-            )
-            
-            Spacer(modifier = Modifier.height(12.dp))
-            
-            // Question Text
-            Text(
-                text = daily.question,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-                lineHeight = 28.sp
-            )
-            
-            daily.explanation?.let { explanation ->
-                Spacer(modifier = Modifier.height(8.dp))
-                // Explanation Hook Text
-                Text(
-                    text = explanation,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    lineHeight = 20.sp
-                )
-            }
-            
-            Spacer(modifier = Modifier.height(20.dp))
-            
-            // Podcast Episode Context Row
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Show Artwork
-                val showArt = daily.episode.image ?: daily.episode.feedImage ?: ""
-                OptimizedImage(
-                    url = showArt,
-                    proxyWidth = 100,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .size(44.dp)
-                        .clip(RoundedCornerShape(8.dp))
-                )
-                
-                Spacer(modifier = Modifier.width(12.dp))
-                
-                Column(
-                    modifier = Modifier.weight(1f)
-                ) {
-                    Text(
-                        text = daily.episode.feedTitle ?: "Podcast Episode",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                    
-                    Text(
-                        text = durationMin,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                    )
-                }
-                
-                Spacer(modifier = Modifier.width(8.dp))
-                
-                // Quick Play Tonal Button
-                FilledTonalButton(
-                    onClick = onClick,
-                    shape = RoundedCornerShape(12.dp),
-                    colors = buttonColors,
-                    contentPadding = PaddingValues(horizontal = 14.dp, vertical = 0.dp)
-                ) {
-                    Icon(
-                        imageVector = buttonIcon,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp)
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Text(
-                        text = buttonText,
-                        style = MaterialTheme.typography.labelMedium
-                    )
-                }
-            }
-        }
-    }
-}
 
 @Composable
 private fun CuratedShowItem(

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -1,45 +1,35 @@
 package cx.aswin.boxcast.feature.explore
 
-import androidx.compose.foundation.BorderStroke
+import android.graphics.drawable.BitmapDrawable
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.VolumeUp
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.vectorResource
-import androidx.compose.foundation.Image
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.foundation.background
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.runtime.remember
-import android.graphics.drawable.BitmapDrawable
-import coil.compose.AsyncImagePainter
-import coil.compose.rememberAsyncImagePainter
-import coil.request.ImageRequest
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.graphics.Color
-import androidx.palette.graphics.Palette
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -49,36 +39,44 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import coil.compose.AsyncImagePainter
+import coil.compose.rememberAsyncImagePainter
+import coil.request.ImageRequest
 import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
+import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.network.model.CuratedCuriosityPodcastDto
 import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.ui.platform.LocalDensity
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -93,6 +91,7 @@ fun LearnScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val playerState by playbackRepository.playerState.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -106,40 +105,11 @@ fun LearnScreen(
             isRefreshing = isRefreshing,
             onRefresh = { viewModel.refresh() },
             state = pullToRefreshState,
-            modifier = Modifier.fillMaxSize(),
-            indicator = {
-                val density = LocalDensity.current
-                val pullProgress = pullToRefreshState.distanceFraction
-
-                if (pullProgress > 0f || isRefreshing) {
-                    Surface(
-                        modifier = Modifier
-                            .align(Alignment.TopCenter)
-                            .padding(top = 16.dp)
-                            .graphicsLayer {
-                                val scale = if (isRefreshing) 1f else pullProgress.coerceIn(0f, 1f)
-                                scaleX = scale
-                                scaleY = scale
-                                alpha = scale
-                                translationY = if (isRefreshing) {
-                                    with(density) { 24.dp.toPx() }
-                                } else {
-                                    pullProgress * with(density) { 32.dp.toPx() }
-                                }
-                            }
-                            .size(48.dp),
-                        shape = RoundedCornerShape(24.dp),
-                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                        tonalElevation = 6.dp,
-                        shadowElevation = 6.dp
-                    ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            BoxLoreLoader.Expressive(size = 30.dp)
-                        }
-                    }
-                }
-            }
+            modifier = Modifier.fillMaxSize()
         ) {
+            // Use the passed in bottomContentPadding from MainActivity instead of the local empty Scaffold padding
+            val bottomContentPaddingCalculated = bottomContentPadding
+
             when (val state = uiState) {
                 is LearnUiState.Loading -> {
                     Box(
@@ -149,7 +119,7 @@ fun LearnScreen(
                         BoxLoreLoader.Expressive(size = 64.dp)
                     }
                 }
-                
+
                 is LearnUiState.Success -> {
                     val context = LocalContext.current
                     var extractedColor by remember { mutableStateOf<Color?>(null) }
@@ -177,94 +147,82 @@ fun LearnScreen(
                         }
                     }
 
-                    val listState = rememberLazyListState()
-                    val firstVisibleItemIndex = listState.firstVisibleItemIndex
-                    val firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset
-                    
-                    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-                    val collapsedHeaderHeight = 56.dp + statusBarHeight
-                    val morphThreshold = with(LocalDensity.current) { 180.dp.toPx() }
-
-                    val scrollFraction = remember(listState, firstVisibleItemIndex, firstVisibleItemScrollOffset) {
-                        if (firstVisibleItemIndex > 0) 1f
-                        else (firstVisibleItemScrollOffset.toFloat() / morphThreshold).coerceIn(0f, 1f)
-                    }
-
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        LazyColumn(
-                            state = listState,
-                            modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(
-                                top = collapsedHeaderHeight,
-                                bottom = bottomContentPadding + 24.dp
-                            )
-                        ) {
-                            // 1. Header Section
-                            item {
-                                Image(
-                                    painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
-                                    contentDescription = "Lore",
-                                    colorFilter = ColorFilter.tint(accentColor),
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(36.dp)
-                                        .padding(start = 24.dp, end = 24.dp, top = 0.dp, bottom = 8.dp),
-                                    contentScale = ContentScale.Fit,
-                                    alignment = Alignment.CenterStart
-                                )
-                            }
-
-                            // 2. Curiosity Card Stack Section
-                            item {
-                                CuriosityCardStack(
-                                    questions = state.questionsStack,
-                                    isCurrentlyPlaying = { id -> playerState.currentEpisode?.id == id && playerState.isPlaying },
-                                    onSwipeLeft = { daily ->
-                                        viewModel.dismissCuriosity(daily.episode.id.toString())
-                                    },
-                                    onSwipeRight = { daily ->
-                                        val mappedEpisode = mapToEpisode(daily.episode)
-                                        onQueueEpisode(mappedEpisode)
-                                        viewModel.dismissCuriosity(daily.episode.id.toString())
-                                    },
-                                    onPlayClick = { daily ->
-                                        val mappedEpisode = mapToEpisode(daily.episode)
-                                        onEpisodeClick(mappedEpisode)
-                                    },
-                                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
-                                )
-                            }
-                        }
-
-                        // Floating Header Overlay
-                        val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
-                        val headerColor by animateColorAsState(
-                            targetValue = surfaceColor.copy(alpha = scrollFraction),
-                            animationSpec = spring(stiffness = Spring.StiffnessLow),
-                            label = "headerColor"
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .statusBarsPadding()
+                            .padding(bottom = bottomContentPaddingCalculated),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        // 1. Centered brand logo at the top of the page (Expanded to 40.dp)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Image(
+                            painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
+                            contentDescription = "Lore",
+                            colorFilter = ColorFilter.tint(accentColor),
+                            modifier = Modifier.height(40.dp)
                         )
-                        val titleAlpha = if (scrollFraction > 0.6f) (scrollFraction - 0.6f) / 0.4f else 0f
 
-                        Box(
+                        // 2. Top flexible spacer
+                        Spacer(modifier = Modifier.weight(1f))
+
+                        // 3. Curiosity Card Stack
+                        CuriosityCardStack(
+                            questions = state.questionsStack,
+                            isCurrentlyPlaying = { id -> playerState.currentEpisode?.id == id && playerState.isPlaying },
+                            onSwipeLeft = { daily ->
+                                viewModel.dismissCuriosity(daily.episode.id.toString())
+                            },
+                            onSwipeRight = { daily ->
+                                val mappedEpisode = mapToEpisode(daily.episode)
+                                onQueueEpisode(mappedEpisode)
+                                viewModel.dismissCuriosity(daily.episode.id.toString())
+                            },
+                            onPlayClick = { daily ->
+                                val isCurrent = playerState.currentEpisode?.id == daily.episode.id.toString()
+                                if (isCurrent) {
+                                    playbackRepository.togglePlayPause()
+                                } else {
+                                    val mappedEpisode = mapToEpisode(daily.episode)
+                                    val podcast = cx.aswin.boxcast.core.model.Podcast(
+                                        id = daily.episode.feedId?.toString() ?: "learn_fallback",
+                                        title = daily.episode.feedTitle ?: "Podcast",
+                                        artist = daily.episode.feedTitle ?: "Unknown",
+                                        imageUrl = daily.episode.feedImage ?: daily.episode.image ?: ""
+                                    )
+                                    coroutineScope.launch {
+                                        playbackRepository.playQueue(
+                                            episodes = listOf(mappedEpisode),
+                                            podcast = podcast,
+                                            startIndex = 0,
+                                            entryPoint = cx.aswin.boxcast.core.model.PlaybackEntryPoint.GENERIC
+                                        )
+                                    }
+                                }
+                            },
+                            onEpisodeClick = { daily ->
+                                val mappedEpisode = mapToEpisode(daily.episode)
+                                onEpisodeClick(mappedEpisode)
+                            },
+                            onPodcastClick = { daily ->
+                                onPodcastClick(
+                                    daily.episode.feedId,
+                                    null,
+                                    "",
+                                    daily.episode.feedTitle ?: "Podcast"
+                                )
+                            },
+                            accentColor = accentColor,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height(collapsedHeaderHeight)
-                                .background(headerColor)
-                                .statusBarsPadding(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Image(
-                                painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
-                                contentDescription = "Lore",
-                                colorFilter = ColorFilter.tint(accentColor),
-                                modifier = Modifier
-                                    .height(28.dp)
-                                    .graphicsLayer { alpha = titleAlpha }
-                            )
-                        }
+                                .padding(horizontal = 20.dp)
+                        )
+
+                        // 4. Bottom flexible spacer (exactly matches top spacer weight to center cards vertically)
+                        Spacer(modifier = Modifier.weight(1f))
                     }
                 }
-                
+
                 is LearnUiState.Error -> {
                     Column(
                         modifier = Modifier
@@ -296,9 +254,6 @@ fun LearnScreen(
     }
 }
 
-
-
-
 // Convert DTO EpisodeItem to Domain model Episode
 private fun mapToEpisode(item: cx.aswin.boxcast.core.network.model.EpisodeItem): Episode {
     return Episode(
@@ -325,4 +280,49 @@ private fun extractDominantColor(bitmap: android.graphics.Bitmap): Color {
     val dominant = palette.dominantSwatch?.rgb
     val colorInt = vibrant ?: muted ?: dominant ?: 0xFF6200EE.toInt()
     return Color(colorInt)
+}
+
+@Composable
+private fun CuratedShowItem(
+    show: CuratedCuriosityPodcastDto,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .width(110.dp)
+            .expressiveClickable(onClick = onClick)
+    ) {
+        OptimizedImage(
+            url = show.artwork ?: show.image ?: "",
+            proxyWidth = 220,
+            contentDescription = null,
+            modifier = Modifier
+                .size(110.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        )
+        
+        Spacer(modifier = Modifier.height(6.dp))
+        
+        Text(
+            text = show.title,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Bold,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        
+        val author = show.author
+        if (!author.isNullOrEmpty()) {
+            Text(
+                text = author,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
 }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -68,6 +68,14 @@ import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.network.model.CuratedCuriosityPodcastDto
 import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.ui.platform.LocalDensity
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -140,9 +148,14 @@ fun LearnScreen(
                     val listState = rememberLazyListState()
                     val firstVisibleItemIndex = listState.firstVisibleItemIndex
                     val firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset
+                    
+                    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+                    val collapsedHeaderHeight = 64.dp + statusBarHeight
+                    val morphThreshold = with(LocalDensity.current) { 180.dp.toPx() }
+
                     val scrollFraction = remember(listState, firstVisibleItemIndex, firstVisibleItemScrollOffset) {
                         if (firstVisibleItemIndex > 0) 1f
-                        else (firstVisibleItemScrollOffset.toFloat() / 300f).coerceIn(0f, 1f)
+                        else (firstVisibleItemScrollOffset.toFloat() / morphThreshold).coerceIn(0f, 1f)
                     }
 
                     Box(modifier = Modifier.fillMaxSize()) {
@@ -169,6 +182,7 @@ fun LearnScreen(
                             state = listState,
                             modifier = Modifier.fillMaxSize(),
                             contentPadding = PaddingValues(
+                                top = collapsedHeaderHeight,
                                 bottom = bottomContentPadding + 24.dp
                             )
                         ) {
@@ -177,14 +191,14 @@ fun LearnScreen(
                                 Column(
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .padding(horizontal = 20.dp, vertical = 20.dp)
+                                        .padding(horizontal = 24.dp, vertical = 20.dp)
                                 ) {
                                     Image(
                                         painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
                                         contentDescription = "Lore",
                                         colorFilter = ColorFilter.tint(accentColor),
                                         modifier = Modifier
-                                            .height(36.dp)
+                                            .height(54.dp)
                                             .fillMaxWidth(),
                                         contentScale = ContentScale.Fit,
                                         alignment = Alignment.CenterStart
@@ -257,6 +271,33 @@ fun LearnScreen(
                                     }
                                 }
                             }
+                        }
+
+                        // Floating Header Overlay
+                        val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
+                        val headerColor by animateColorAsState(
+                            targetValue = surfaceColor.copy(alpha = scrollFraction),
+                            animationSpec = spring(stiffness = Spring.StiffnessLow),
+                            label = "headerColor"
+                        )
+                        val titleAlpha = if (scrollFraction > 0.6f) (scrollFraction - 0.6f) / 0.4f else 0f
+
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(collapsedHeaderHeight)
+                                .background(headerColor)
+                                .statusBarsPadding(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Image(
+                                painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
+                                contentDescription = "Lore",
+                                colorFilter = ColorFilter.tint(accentColor),
+                                modifier = Modifier
+                                    .height(28.dp)
+                                    .graphicsLayer { alpha = titleAlpha }
+                            )
                         }
                     }
                 }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -96,7 +96,7 @@ fun LearnScreen(
     Scaffold(
         modifier = modifier.fillMaxSize(),
         containerColor = MaterialTheme.colorScheme.background
-    ) { innerPadding ->
+    ) { _ ->
         
         val isRefreshing = (uiState as? LearnUiState.Success)?.isRefreshing == true
         val pullToRefreshState = rememberPullToRefreshState()

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -167,28 +167,17 @@ fun LearnScreen(
                         ) {
                             // 1. Header Section
                             item {
-                                Column(
+                                Image(
+                                    painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
+                                    contentDescription = "Lore",
+                                    colorFilter = ColorFilter.tint(accentColor),
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .padding(start = 24.dp, end = 24.dp, top = 0.dp, bottom = 8.dp)
-                                ) {
-                                    Image(
-                                        painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
-                                        contentDescription = "Lore",
-                                        colorFilter = ColorFilter.tint(accentColor),
-                                        modifier = Modifier
-                                            .height(36.dp)
-                                            .fillMaxWidth(),
-                                        contentScale = ContentScale.Fit,
-                                        alignment = Alignment.CenterStart
-                                    )
-                                    Text(
-                                        text = "Feed your curiosity with daily micro-stories",
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
-                                        modifier = Modifier.padding(top = 8.dp)
-                                    )
-                                }
+                                        .height(36.dp)
+                                        .padding(start = 24.dp, end = 24.dp, top = 0.dp, bottom = 8.dp),
+                                    contentScale = ContentScale.Fit,
+                                    alignment = Alignment.CenterStart
+                                )
                             }
 
                             // 2. Curiosity Card Stack Section
@@ -210,45 +199,6 @@ fun LearnScreen(
                                     },
                                     modifier = Modifier.padding(horizontal = 20.dp, vertical = 8.dp)
                                 )
-                            }
-
-                            // 3. Curated Categories Sections
-                            items(state.data.categories) { category ->
-                                if (category.shows.isNotEmpty()) {
-                                    Column(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(vertical = 12.dp)
-                                    ) {
-                                        Text(
-                                            text = category.title,
-                                            style = MaterialTheme.typography.titleLarge,
-                                            fontWeight = FontWeight.SemiBold,
-                                            color = MaterialTheme.colorScheme.onBackground,
-                                            modifier = Modifier.padding(start = 20.dp, end = 20.dp, bottom = 8.dp)
-                                        )
-                                        
-                                        LazyRow(
-                                            contentPadding = PaddingValues(horizontal = 20.dp),
-                                            horizontalArrangement = Arrangement.spacedBy(16.dp),
-                                            modifier = Modifier.fillMaxWidth()
-                                        ) {
-                                            items(category.shows) { show ->
-                                                CuratedShowItem(
-                                                    show = show,
-                                                    onClick = {
-                                                        onPodcastClick(
-                                                            show.id,
-                                                            show.itunesId,
-                                                            show.feedUrl ?: "",
-                                                            show.title
-                                                        )
-                                                    }
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
                             }
                         }
 
@@ -314,59 +264,6 @@ fun LearnScreen(
 
 
 
-@Composable
-private fun CuratedShowItem(
-    show: CuratedCuriosityPodcastDto,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier
-            .width(110.dp)
-            .expressiveClickable(onClick = onClick)
-    ) {
-        // Thumbnail Artwork
-        OutlinedCard(
-            shape = RoundedCornerShape(16.dp),
-            border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-            colors = CardDefaults.outlinedCardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceVariant
-            ),
-            modifier = Modifier.size(110.dp)
-        ) {
-            OptimizedImage(
-                url = show.image ?: show.artwork ?: "",
-                proxyWidth = 220,
-                contentDescription = show.title,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize()
-            )
-        }
-        
-        Spacer(modifier = Modifier.height(6.dp))
-        
-        // Show Title
-        Text(
-            text = show.title,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.Medium,
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            lineHeight = 18.sp
-        )
-        
-        // Author
-        Text(
-            text = show.author ?: "Unknown",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.padding(top = 1.dp)
-        )
-    }
-}
 
 // Convert DTO EpisodeItem to Domain model Episode
 private fun mapToEpisode(item: cx.aswin.boxcast.core.network.model.EpisodeItem): Episode {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -148,7 +148,7 @@ fun LearnScreen(
                     val firstVisibleItemScrollOffset = listState.firstVisibleItemScrollOffset
                     
                     val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-                    val collapsedHeaderHeight = 64.dp + statusBarHeight
+                    val collapsedHeaderHeight = 56.dp + statusBarHeight
                     val morphThreshold = with(LocalDensity.current) { 180.dp.toPx() }
 
                     val scrollFraction = remember(listState, firstVisibleItemIndex, firstVisibleItemScrollOffset) {
@@ -189,14 +189,14 @@ fun LearnScreen(
                                 Column(
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .padding(horizontal = 24.dp, vertical = 20.dp)
+                                        .padding(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 12.dp)
                                 ) {
                                     Image(
                                         painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
                                         contentDescription = "Lore",
                                         colorFilter = ColorFilter.tint(accentColor),
                                         modifier = Modifier
-                                            .height(54.dp)
+                                            .height(36.dp)
                                             .fillMaxWidth(),
                                         contentScale = ContentScale.Fit,
                                         alignment = Alignment.CenterStart

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -155,8 +155,8 @@ fun LearnScreen(
                     var extractedColor by remember { mutableStateOf<Color?>(null) }
                     val accentColor = extractedColor ?: MaterialTheme.colorScheme.primary
 
-                    // Dynamic color extraction from daily curiosity cover art
-                    val dailyImage = state.data.questionOfTheDay?.episode?.let { it.image ?: it.feedImage }
+                    // Dynamic color extraction from active card cover art in the stack
+                    val dailyImage = state.data.questionsStack.firstOrNull()?.episode?.let { it.image ?: it.feedImage }
                     if (dailyImage != null) {
                         val painter = rememberAsyncImagePainter(
                             model = remember(dailyImage) {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -157,25 +157,6 @@ fun LearnScreen(
                     }
 
                     Box(modifier = Modifier.fillMaxSize()) {
-                        // Premium background glow inspired by the briefing screen
-                        val backgroundColor = MaterialTheme.colorScheme.background
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .height(280.dp)
-                                .graphicsLayer {
-                                    alpha = (1f - scrollFraction) * 0.15f
-                                }
-                                .background(
-                                    brush = Brush.verticalGradient(
-                                        colors = listOf(
-                                            accentColor,
-                                            backgroundColor
-                                        )
-                                    )
-                                )
-                        )
-
                         LazyColumn(
                             state = listState,
                             modifier = Modifier.fillMaxSize(),
@@ -189,7 +170,7 @@ fun LearnScreen(
                                 Column(
                                     modifier = Modifier
                                         .fillMaxWidth()
-                                        .padding(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 12.dp)
+                                        .padding(start = 24.dp, end = 24.dp, top = 0.dp, bottom = 8.dp)
                                 ) {
                                     Image(
                                         painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.network.model.CuratedCuriosityPodcastDto
@@ -110,9 +111,7 @@ fun LearnScreen(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center
                     ) {
-                        CircularProgressIndicator(
-                            color = MaterialTheme.colorScheme.primary
-                        )
+                        BoxLoreLoader.Expressive(size = 64.dp)
                     }
                 }
                 

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -102,9 +102,7 @@ fun LearnScreen(
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = { viewModel.refresh() },
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = innerPadding.calculateTopPadding())
+            modifier = Modifier.fillMaxSize()
         ) {
             when (val state = uiState) {
                 is LearnUiState.Loading -> {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -51,6 +51,8 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -97,13 +99,46 @@ fun LearnScreen(
         containerColor = MaterialTheme.colorScheme.background
     ) { innerPadding ->
         
-        // Setup Pull to Refresh wrapper
         val isRefreshing = (uiState as? LearnUiState.Success)?.isRefreshing == true
-        
+        val pullToRefreshState = rememberPullToRefreshState()
+
         PullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = { viewModel.refresh() },
-            modifier = Modifier.fillMaxSize()
+            state = pullToRefreshState,
+            modifier = Modifier.fillMaxSize(),
+            indicator = {
+                val density = LocalDensity.current
+                val pullProgress = pullToRefreshState.distanceFraction
+
+                if (pullProgress > 0f || isRefreshing) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .padding(top = 16.dp)
+                            .graphicsLayer {
+                                val scale = if (isRefreshing) 1f else pullProgress.coerceIn(0f, 1f)
+                                scaleX = scale
+                                scaleY = scale
+                                alpha = scale
+                                translationY = if (isRefreshing) {
+                                    with(density) { 24.dp.toPx() }
+                                } else {
+                                    pullProgress * with(density) { 32.dp.toPx() }
+                                }
+                            }
+                            .size(48.dp),
+                        shape = RoundedCornerShape(24.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        tonalElevation = 6.dp,
+                        shadowElevation = 6.dp
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            BoxLoreLoader.Expressive(size = 30.dp)
+                        }
+                    }
+                }
+            }
         ) {
             when (val state = uiState) {
                 is LearnUiState.Loading -> {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -10,11 +10,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
+
 sealed interface LearnUiState {
     data object Loading : LearnUiState
     
     data class Success(
         val data: CuratedCuriosityResponseDto,
+        val questionsStack: List<DailyCuriosityDto>,
         val isRefreshing: Boolean = false
     ) : LearnUiState
     
@@ -26,6 +29,7 @@ class LearnViewModel(
     application: Application
 ) : AndroidViewModel(application) {
 
+    private val prefs = getApplication<Application>().getSharedPreferences("boxcast_prefs", android.content.Context.MODE_PRIVATE)
     private val _uiState = MutableStateFlow<LearnUiState>(LearnUiState.Loading)
     val uiState: StateFlow<LearnUiState> = _uiState.asStateFlow()
 
@@ -33,13 +37,44 @@ class LearnViewModel(
         loadData()
     }
 
+    private fun getDismissedIds(): Set<String> {
+        return prefs.getStringSet("dismissed_curiosities", emptySet()) ?: emptySet()
+    }
+
+    fun dismissCuriosity(episodeId: String) {
+        val currentSet = getDismissedIds().toMutableSet()
+        currentSet.add(episodeId)
+        prefs.edit().putStringSet("dismissed_curiosities", currentSet).apply()
+
+        // Update the state with the pruned stack
+        val currentState = _uiState.value
+        if (currentState is LearnUiState.Success) {
+            val updatedStack = currentState.questionsStack.filterNot { it.episode.id.toString() == episodeId }
+            _uiState.value = currentState.copy(questionsStack = updatedStack)
+        }
+    }
+
+    private fun weightedShuffle(list: List<DailyCuriosityDto>): List<DailyCuriosityDto> {
+        if (list.size <= 1) return list
+        val random = java.util.Random()
+        return list.map { item ->
+            val u = random.nextDouble()
+            val w = (item.curiosityScore ?: 0).toDouble() + 1.0
+            val key = Math.pow(u, 1.0 / w)
+            Pair(item, key)
+        }.sortedByDescending { it.second }.map { it.first }
+    }
+
     fun loadData() {
         viewModelScope.launch {
             _uiState.value = LearnUiState.Loading
             try {
-                val res = podcastRepository.getCuratedCuriosity()
+                val res = podcastRepository.getCuratedCuriosity(bypassCache = false)
                 if (res != null) {
-                    _uiState.value = LearnUiState.Success(data = res)
+                    val dismissed = getDismissedIds()
+                    val remaining = res.questionsStack.filterNot { it.episode.id.toString() in dismissed }
+                    val shuffled = weightedShuffle(remaining)
+                    _uiState.value = LearnUiState.Success(data = res, questionsStack = shuffled)
                 } else {
                     _uiState.value = LearnUiState.Error("Failed to load curiosity curation")
                 }
@@ -56,9 +91,12 @@ class LearnViewModel(
                 _uiState.value = current.copy(isRefreshing = true)
             }
             try {
-                val res = podcastRepository.getCuratedCuriosity()
+                val res = podcastRepository.getCuratedCuriosity(bypassCache = true)
                 if (res != null) {
-                    _uiState.value = LearnUiState.Success(data = res, isRefreshing = false)
+                    val dismissed = getDismissedIds()
+                    val remaining = res.questionsStack.filterNot { it.episode.id.toString() in dismissed }
+                    val shuffled = weightedShuffle(remaining)
+                    _uiState.value = LearnUiState.Success(data = res, questionsStack = shuffled, isRefreshing = false)
                 } else {
                     if (current is LearnUiState.Success) {
                         _uiState.value = current.copy(isRefreshing = false)

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -56,7 +56,7 @@ class LearnViewModel(
 
     private fun weightedShuffle(list: List<DailyCuriosityDto>): List<DailyCuriosityDto> {
         if (list.size <= 1) return list
-        val random = java.util.Random()
+        val random = java.security.SecureRandom()
         return list.map { item ->
             val u = random.nextDouble()
             val w = (item.curiosityScore ?: 0).toDouble() + 1.0

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/SwipeableCardState.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/SwipeableCardState.kt
@@ -1,0 +1,60 @@
+package cx.aswin.boxcast.feature.explore
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.geometry.Offset
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+enum class SwipeDirection {
+    Left, Right
+}
+
+class SwipeableCardState(
+    val coroutineScope: CoroutineScope,
+    val onSwiped: (SwipeDirection) -> Unit
+) {
+    val offset = Animatable(Offset.Zero, Offset.VectorConverter)
+
+    fun swipe(direction: SwipeDirection) {
+        coroutineScope.launch {
+            val targetX = if (direction == SwipeDirection.Left) -1500f else 1500f
+            offset.animateTo(
+                targetValue = Offset(targetX, offset.value.y),
+                animationSpec = tween(durationMillis = 350)
+            )
+            onSwiped(direction)
+            offset.snapTo(Offset.Zero)
+        }
+    }
+
+    fun drag(dragAmount: Offset) {
+        coroutineScope.launch {
+            offset.snapTo(offset.value + dragAmount)
+        }
+    }
+
+    fun reset() {
+        coroutineScope.launch {
+            offset.animateTo(
+                targetValue = Offset.Zero,
+                animationSpec = tween(durationMillis = 250)
+            )
+        }
+    }
+}
+
+@Composable
+fun rememberSwipeableCardState(
+    key: Any?,
+    onSwiped: (SwipeDirection) -> Unit
+): SwipeableCardState {
+    val scope = rememberCoroutineScope()
+    return remember(key) {
+        SwipeableCardState(scope, onSwiped)
+    }
+}


### PR DESCRIPTION
This PR refactors the explore feed card stack UI to implement an organic curvy fanning layout, increases representation count to 4 cards, softens card shading to slate-charcoal, and updates the logo accent color extractor to pull dynamically from the top card of the fanned stack.