### PR TITLE
style: truncate podcast names in curiosity card

### DIFF
--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -290,7 +290,10 @@ private fun CuriosityCardContent(
                         style = MaterialTheme.typography.labelSmall,
                         fontWeight = FontWeight.Black,
                         letterSpacing = 1.5.sp,
-                        color = Color.White.copy(alpha = 0.8f)
+                        color = Color.White.copy(alpha = 0.8f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Icon(

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -92,6 +92,16 @@ class LearnViewModel(
         return filterAndShuffleNewItems(res.questionsStack, currentStack)
     }
 
+    private fun appendCuriositiesToSuccessState(newItems: List<DailyCuriosityDto>) {
+        _uiState.update { state ->
+            if (state is LearnUiState.Success) {
+                state.copy(questionsStack = state.questionsStack + newItems)
+            } else {
+                state
+            }
+        }
+    }
+
     private fun fetchNextPage() {
         if (isLoadingMore || isEndOfContent) return
         if (_uiState.value !is LearnUiState.Success) return
@@ -114,13 +124,7 @@ class LearnViewModel(
                 }
 
                 if (accumulatedNew.isNotEmpty()) {
-                    _uiState.update { state ->
-                        if (state is LearnUiState.Success) {
-                            state.copy(questionsStack = state.questionsStack + accumulatedNew)
-                        } else {
-                            state
-                        }
-                    }
+                    appendCuriositiesToSuccessState(accumulatedNew)
                 }
             } catch (e: Exception) {
                 android.util.Log.e("LearnViewModel", "Failed to load page ${currentPage + 1}", e)

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -66,6 +66,32 @@ class LearnViewModel(
         }
     }
 
+    private fun filterAndShuffleNewItems(
+        rawItems: List<DailyCuriosityDto>,
+        currentStack: List<DailyCuriosityDto>
+    ): List<DailyCuriosityDto> {
+        val dismissed = getDismissedIds()
+        val newItems = rawItems.filterNot { it.episode.id.toString() in dismissed }
+        if (newItems.isEmpty()) return emptyList()
+
+        val shuffledNew = weightedShuffle(newItems)
+        val existingIds = currentStack.map { it.episode.id }.toSet()
+        return shuffledNew.filterNot { it.episode.id in existingIds }
+    }
+
+    private suspend fun fetchPageAndFilter(
+        page: Int,
+        currentStack: List<DailyCuriosityDto>
+    ): List<DailyCuriosityDto> {
+        val res = podcastRepository.getCuratedCuriosity(page = page, bypassCache = false) ?: return emptyList()
+        if (res.questionsStack.isEmpty()) {
+            isEndOfContent = true
+            return emptyList()
+        }
+        currentPage = page
+        return filterAndShuffleNewItems(res.questionsStack, currentStack)
+    }
+
     private fun fetchNextPage() {
         if (isLoadingMore || isEndOfContent) return
         if (_uiState.value !is LearnUiState.Success) return
@@ -76,35 +102,14 @@ class LearnViewModel(
                 var pageToFetch = currentPage + 1
                 var accumulatedNew = emptyList<DailyCuriosityDto>()
                 var pageAttempts = 0
-                val maxAttempts = 5 // prevent infinite loop
+                val maxAttempts = 5
 
                 while (accumulatedNew.isEmpty() && !isEndOfContent && pageAttempts < maxAttempts) {
                     pageAttempts++
-                    val res = podcastRepository.getCuratedCuriosity(page = pageToFetch, bypassCache = false)
-                    if (res != null) {
-                        if (res.questionsStack.isEmpty()) {
-                            isEndOfContent = true
-                        } else {
-                            currentPage = pageToFetch
-                            val dismissed = getDismissedIds()
-                            val newItems = res.questionsStack.filterNot { it.episode.id.toString() in dismissed }
-                            
-                            if (newItems.isNotEmpty()) {
-                                val shuffledNew = weightedShuffle(newItems)
-                                val currentStack = (_uiState.value as? LearnUiState.Success)?.questionsStack ?: emptyList()
-                                val existingIds = currentStack.map { it.episode.id }.toSet()
-                                val uniqueNew = shuffledNew.filterNot { it.episode.id in existingIds }
-                                
-                                if (uniqueNew.isNotEmpty()) {
-                                    accumulatedNew = uniqueNew
-                                }
-                            }
-                            // Advance for the next iteration of the loop if still empty
-                            pageToFetch++
-                        }
-                    } else {
-                        // API failure, break to avoid infinite loop
-                        break
+                    val currentStack = (_uiState.value as? LearnUiState.Success)?.questionsStack ?: emptyList()
+                    accumulatedNew = fetchPageAndFilter(pageToFetch, currentStack)
+                    if (!isEndOfContent) {
+                        pageToFetch++
                     }
                 }
 

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import cx.aswin.boxcast.core.data.PodcastRepository
 import cx.aswin.boxcast.core.network.model.CuratedCuriosityResponseDto
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
@@ -36,6 +38,7 @@ class LearnViewModel(
     private var currentPage = 1
     private var isLoadingMore = false
     private var isEndOfContent = false
+    private var fetchJob: Job? = null
 
     init {
         loadData()
@@ -65,30 +68,52 @@ class LearnViewModel(
 
     private fun fetchNextPage() {
         if (isLoadingMore || isEndOfContent) return
-        val currentState = _uiState.value as? LearnUiState.Success ?: return
+        if (_uiState.value !is LearnUiState.Success) return
 
         isLoadingMore = true
-        viewModelScope.launch {
+        fetchJob = viewModelScope.launch {
             try {
-                val nextPage = currentPage + 1
-                val res = podcastRepository.getCuratedCuriosity(page = nextPage, bypassCache = false)
-                if (res != null) {
-                    if (res.questionsStack.isEmpty()) {
-                        isEndOfContent = true
-                    } else {
-                        currentPage = nextPage
-                        val dismissed = getDismissedIds()
-                        val newItems = res.questionsStack.filterNot { it.episode.id.toString() in dismissed }
-                        
-                        if (newItems.isNotEmpty()) {
-                            val shuffledNew = weightedShuffle(newItems)
-                            val currentStack = (_uiState.value as? LearnUiState.Success)?.questionsStack ?: emptyList()
-                            val existingIds = currentStack.map { it.episode.id }.toSet()
-                            val uniqueNew = shuffledNew.filterNot { it.episode.id in existingIds }
+                var pageToFetch = currentPage + 1
+                var accumulatedNew = emptyList<DailyCuriosityDto>()
+                var pageAttempts = 0
+                val maxAttempts = 5 // prevent infinite loop
+
+                while (accumulatedNew.isEmpty() && !isEndOfContent && pageAttempts < maxAttempts) {
+                    pageAttempts++
+                    val res = podcastRepository.getCuratedCuriosity(page = pageToFetch, bypassCache = false)
+                    if (res != null) {
+                        if (res.questionsStack.isEmpty()) {
+                            isEndOfContent = true
+                        } else {
+                            currentPage = pageToFetch
+                            val dismissed = getDismissedIds()
+                            val newItems = res.questionsStack.filterNot { it.episode.id.toString() in dismissed }
                             
-                            _uiState.value = currentState.copy(
-                                questionsStack = currentStack + uniqueNew
-                            )
+                            if (newItems.isNotEmpty()) {
+                                val shuffledNew = weightedShuffle(newItems)
+                                val currentStack = (_uiState.value as? LearnUiState.Success)?.questionsStack ?: emptyList()
+                                val existingIds = currentStack.map { it.episode.id }.toSet()
+                                val uniqueNew = shuffledNew.filterNot { it.episode.id in existingIds }
+                                
+                                if (uniqueNew.isNotEmpty()) {
+                                    accumulatedNew = uniqueNew
+                                }
+                            }
+                            // Advance for the next iteration of the loop if still empty
+                            pageToFetch++
+                        }
+                    } else {
+                        // API failure, break to avoid infinite loop
+                        break
+                    }
+                }
+
+                if (accumulatedNew.isNotEmpty()) {
+                    _uiState.update { state ->
+                        if (state is LearnUiState.Success) {
+                            state.copy(questionsStack = state.questionsStack + accumulatedNew)
+                        } else {
+                            state
                         }
                     }
                 }
@@ -112,7 +137,8 @@ class LearnViewModel(
     }
 
     fun loadData() {
-        viewModelScope.launch {
+        fetchJob?.cancel()
+        fetchJob = viewModelScope.launch {
             _uiState.value = LearnUiState.Loading
             currentPage = 1
             isEndOfContent = false
@@ -134,7 +160,8 @@ class LearnViewModel(
     }
 
     fun refresh() {
-        viewModelScope.launch {
+        fetchJob?.cancel()
+        fetchJob = viewModelScope.launch {
             val current = _uiState.value
             if (current is LearnUiState.Success) {
                 _uiState.value = current.copy(isRefreshing = true)

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -258,6 +258,7 @@ fun HomeRoute(
             },
             onSubmitFeedback = onSubmitFeedback,
             onResetFeatureFlag = viewModel::resetFeatureFlag,
+            onClearDismissedCuriosities = viewModel::clearDismissedCuriosities,
             onResetSleepNudge = onResetSleepNudge,
             onClearSleepTimer = onClearSleepTimer,
             onSwitchRegion = viewModel::setRegion,
@@ -312,6 +313,7 @@ fun HomeScreen(
     onResetFeatureFlag: () -> Unit = {},
     onResetSleepNudge: () -> Unit = {},
     onClearSleepTimer: () -> Unit = {},
+    onClearDismissedCuriosities: () -> Unit = {},
     onSwitchRegion: (String) -> Unit = {},
     onDismissNudge: () -> Unit = {},
     onPodcastSelected: (String?) -> Unit = {},
@@ -355,6 +357,7 @@ fun HomeScreen(
             onResetFeatureFlag = onResetFeatureFlag,
             onResetSleepNudge = onResetSleepNudge,
             onClearSleepTimer = onClearSleepTimer,
+            onClearDismissedCuriosities = onClearDismissedCuriosities,
             onDismissRequest = { showDebugDialog = false }
         )
     }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -1873,6 +1873,11 @@ mixtapePodcasts = cachedMix
             userPrefs.dismissFeatureAnnouncement("")
         }
     }
+
+    fun clearDismissedCuriosities() {
+        val prefs = getApplication<Application>().getSharedPreferences("boxcast_prefs", android.content.Context.MODE_PRIVATE)
+        prefs.edit().remove("dismissed_curiosities").apply()
+    }
     
     private suspend fun resolveFavoritePodcast(
         overriddenId: String?,

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DebugDbInspectorDialog.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DebugDbInspectorDialog.kt
@@ -41,6 +41,7 @@ fun DebugDbInspectorDialog(
     onResetFeatureFlag: () -> Unit,
     onResetSleepNudge: () -> Unit,
     onClearSleepTimer: () -> Unit,
+    onClearDismissedCuriosities: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
     Dialog(onDismissRequest = onDismissRequest) {
@@ -87,6 +88,9 @@ fun DebugDbInspectorDialog(
                         }
                         androidx.compose.material3.OutlinedButton(onClick = onResetFeatureFlag) {
                             Text("Reset Dialog Flag")
+                        }
+                        androidx.compose.material3.OutlinedButton(onClick = onClearDismissedCuriosities) {
+                            Text("Clear Dismissed Cards")
                         }
                     }
                 }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DebugDbInspectorDialog.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/DebugDbInspectorDialog.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 
 @OptIn(ExperimentalMaterial3Api::class)
+@Suppress("kotlin:S107")
 @Composable
 fun DebugDbInspectorDialog(
     history: List<ListeningHistoryEntity>,


### PR DESCRIPTION
Limits the podcast name inside the curiosity cards to a single line with ellipsis.