### PR TITLE
feat(download): download and cache podcast/episode artwork files locally for offline visibility

### DIFF
--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
@@ -72,6 +72,28 @@ class DownloadRepository(
         })
     }
 
+    private fun downloadArtworkLocally(context: Context, imageUrl: String?, subDir: String, fileName: String): String? {
+        if (imageUrl.isNullOrBlank()) return null
+        try {
+            val cleanUrlStr = if (imageUrl.startsWith("//")) "https:$imageUrl" else imageUrl
+            val url = java.net.URL(cleanUrlStr)
+            val dir = File(context.filesDir, subDir)
+            if (!dir.exists()) {
+                dir.mkdirs()
+            }
+            val file = File(dir, fileName)
+            url.openStream().use { input ->
+                file.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+            return file.absolutePath
+        } catch (e: Exception) {
+            android.util.Log.e("DownloadRepo", "Failed to download artwork: $imageUrl", e)
+            return null
+        }
+    }
+
     fun addDownload(episode: Episode, podcast: Podcast, isSmartDownloaded: Boolean = false) {
         val downloadRequest = DownloadRequest.Builder(episode.id, android.net.Uri.parse(episode.audioUrl))
             .setCustomCacheKey(episode.id)
@@ -103,14 +125,18 @@ class DownloadRepository(
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 android.util.Log.d("DownloadRepo", "Inserting optimistic download entity for ${episode.id}")
+                
+                val localEpisodeImg = downloadArtworkLocally(context, episode.imageUrl, "downloaded_artworks", "episode_${episode.id}.png") ?: episode.imageUrl
+                val localPodcastImg = downloadArtworkLocally(context, podcast.imageUrl, "downloaded_artworks", "podcast_${podcast.id}.png") ?: podcast.imageUrl
+                
                 val entity = DownloadedEpisodeEntity(
                     episodeId = episode.id,
                     podcastId = podcast.id,
                     episodeTitle = episode.title,
                     episodeDescription = episode.description,
-                    episodeImageUrl = episode.imageUrl,
+                    episodeImageUrl = localEpisodeImg,
                     podcastName = podcast.title,
-                    podcastImageUrl = podcast.imageUrl,
+                    podcastImageUrl = localPodcastImg,
                     durationMs = episode.duration * 1000L,
                     publishedDate = episode.publishedDate,
                     localFilePath = "", // Filled when done
@@ -136,6 +162,31 @@ class DownloadRepository(
             false
         )
         CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val existing = database.downloadedEpisodeDao().getDownload(episodeId)
+                if (existing != null) {
+                    existing.episodeImageUrl?.let { path ->
+                        if (path.startsWith("/") || path.startsWith("file://")) {
+                            val cleanPath = path.replace("file://", "")
+                            val file = File(cleanPath)
+                            if (file.exists()) {
+                                file.delete()
+                            }
+                        }
+                    }
+                    existing.podcastImageUrl?.let { path ->
+                        if (path.startsWith("/") || path.startsWith("file://")) {
+                            val cleanPath = path.replace("file://", "")
+                            val file = File(cleanPath)
+                            if (file.exists()) {
+                                file.delete()
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("DownloadRepo", "Failed to clean up artwork files for $episodeId", e)
+            }
             database.downloadedEpisodeDao().delete(episodeId)
         }
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
@@ -76,7 +76,7 @@ class DownloadRepository(
         if (imageUrl.isNullOrBlank()) return null
         try {
             val cleanUrlStr = if (imageUrl.startsWith("//")) "https:$imageUrl" else imageUrl
-            val url = java.net.URL(cleanUrlStr)
+            val url = java.net.URI.create(cleanUrlStr).toURL()
             val dir = File(context.filesDir, subDir)
             if (!dir.exists()) {
                 dir.mkdirs()
@@ -91,6 +91,22 @@ class DownloadRepository(
         } catch (e: Exception) {
             android.util.Log.e("DownloadRepo", "Failed to download artwork: $imageUrl", e)
             return null
+        }
+    }
+
+    private fun deleteLocalFileIfValid(path: String?) {
+        if (path.isNullOrBlank()) return
+        val prefix = "file://"
+        if (path.startsWith("/") || path.startsWith(prefix)) {
+            val cleanPath = path.removePrefix(prefix)
+            try {
+                val file = File(cleanPath)
+                if (file.exists()) {
+                    file.delete()
+                }
+            } catch (e: Exception) {
+                android.util.Log.w("DownloadRepo", "Failed to delete file: $cleanPath", e)
+            }
         }
     }
 
@@ -165,24 +181,8 @@ class DownloadRepository(
             try {
                 val existing = database.downloadedEpisodeDao().getDownload(episodeId)
                 if (existing != null) {
-                    existing.episodeImageUrl?.let { path ->
-                        if (path.startsWith("/") || path.startsWith("file://")) {
-                            val cleanPath = path.replace("file://", "")
-                            val file = File(cleanPath)
-                            if (file.exists()) {
-                                file.delete()
-                            }
-                        }
-                    }
-                    existing.podcastImageUrl?.let { path ->
-                        if (path.startsWith("/") || path.startsWith("file://")) {
-                            val cleanPath = path.replace("file://", "")
-                            val file = File(cleanPath)
-                            if (file.exists()) {
-                                file.delete()
-                            }
-                        }
-                    }
+                    deleteLocalFileIfValid(existing.episodeImageUrl)
+                    deleteLocalFileIfValid(existing.podcastImageUrl)
                 }
             } catch (e: Exception) {
                 android.util.Log.e("DownloadRepo", "Failed to clean up artwork files for $episodeId", e)


### PR DESCRIPTION
Downloads and caches podcast and episode artwork image files locally during downloads, saving absolute local file paths in DownloadedEpisodeEntity. Resolves the issue where downloaded episode cover art is not visible offline.