### PR TITLE
feat: implement PostHog telemetry for Learn screen and Lore tab navigation

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -2227,6 +2227,7 @@ class MainActivity : ComponentActivity() {
                         BoxLoreNavigationBar(
                             currentRoute = activeTab,
                             onNavigate = { route ->
+                                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackNavTabClicked(route)
                                 // Navigation logic for bottom tabs
                                 // podcast/ and episode/ routes are "detail" screens that can be reached from multiple tabs
                                 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/EpisodeMapper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/EpisodeMapper.kt
@@ -1,0 +1,22 @@
+package cx.aswin.boxcast.core.data
+
+import cx.aswin.boxcast.core.model.Episode
+import cx.aswin.boxcast.core.network.model.EpisodeItem
+
+fun EpisodeItem.toEpisode(): Episode {
+    return Episode(
+        id = id.toString(),
+        title = title,
+        description = description ?: "",
+        audioUrl = enclosureUrl ?: "",
+        imageUrl = image ?: feedImage,
+        podcastImageUrl = feedImage,
+        podcastTitle = feedTitle,
+        podcastId = feedId?.toString(),
+        duration = duration ?: 0,
+        publishedDate = datePublished ?: 0L,
+        chaptersUrl = chaptersUrl,
+        transcriptUrl = transcriptUrl,
+        enclosureType = enclosureType
+    )
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -1483,28 +1483,30 @@ object AnalyticsHelper {
         PostHog.capture(event = "learn_screen_viewed")
     }
 
-    fun trackLearnCardDismissed(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
+    private fun trackLearnCardEvent(
+        eventName: String,
+        episodeId: String,
+        episodeTitle: String?,
+        podcastId: String?,
+        podcastTitle: String?
+    ) {
         val props = mutableMapOf<String, Any>("episode_id" to episodeId)
         episodeTitle?.let { props["episode_title"] = it }
         podcastId?.let { props["podcast_id"] = it }
         podcastTitle?.let { props["podcast_title"] = it }
-        PostHog.capture(event = "learn_card_dismissed", properties = props)
+        PostHog.capture(event = eventName, properties = props)
+    }
+
+    fun trackLearnCardDismissed(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
+        trackLearnCardEvent("learn_card_dismissed", episodeId, episodeTitle, podcastId, podcastTitle)
     }
 
     fun trackLearnCardQueued(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
-        val props = mutableMapOf<String, Any>("episode_id" to episodeId)
-        episodeTitle?.let { props["episode_title"] = it }
-        podcastId?.let { props["podcast_id"] = it }
-        podcastTitle?.let { props["podcast_title"] = it }
-        PostHog.capture(event = "learn_card_queued", properties = props)
+        trackLearnCardEvent("learn_card_queued", episodeId, episodeTitle, podcastId, podcastTitle)
     }
 
     fun trackLearnCardInfoClicked(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
-        val props = mutableMapOf<String, Any>("episode_id" to episodeId)
-        episodeTitle?.let { props["episode_title"] = it }
-        podcastId?.let { props["podcast_id"] = it }
-        podcastTitle?.let { props["podcast_title"] = it }
-        PostHog.capture(event = "learn_card_info_clicked", properties = props)
+        trackLearnCardEvent("learn_card_info_clicked", episodeId, episodeTitle, podcastId, podcastTitle)
     }
 
     fun trackLearnCardPodcastClicked(podcastId: String?, podcastTitle: String?) {
@@ -1515,11 +1517,7 @@ object AnalyticsHelper {
     }
 
     fun trackLearnCardPlayClicked(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
-        val props = mutableMapOf<String, Any>("episode_id" to episodeId)
-        episodeTitle?.let { props["episode_title"] = it }
-        podcastId?.let { props["podcast_id"] = it }
-        podcastTitle?.let { props["podcast_title"] = it }
-        PostHog.capture(event = "learn_card_play_clicked", properties = props)
+        trackLearnCardEvent("learn_card_play_clicked", episodeId, episodeTitle, podcastId, podcastTitle)
     }
 
     fun trackLearnScreenSession(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -1470,6 +1470,78 @@ object AnalyticsHelper {
         PostHog.capture(event = "daily_briefing_screen_viewed", properties = props)
     }
 
+    // ── 15. Learn Screen Telemetry ──────────────────────────────────
+
+    fun trackNavTabClicked(tabName: String) {
+        PostHog.capture(
+            event = "nav_tab_clicked",
+            properties = mapOf("tab" to tabName)
+        )
+    }
+
+    fun trackLearnScreenViewed() {
+        PostHog.capture(event = "learn_screen_viewed")
+    }
+
+    fun trackLearnCardDismissed(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
+        val props = mutableMapOf<String, Any>("episode_id" to episodeId)
+        episodeTitle?.let { props["episode_title"] = it }
+        podcastId?.let { props["podcast_id"] = it }
+        podcastTitle?.let { props["podcast_title"] = it }
+        PostHog.capture(event = "learn_card_dismissed", properties = props)
+    }
+
+    fun trackLearnCardQueued(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
+        val props = mutableMapOf<String, Any>("episode_id" to episodeId)
+        episodeTitle?.let { props["episode_title"] = it }
+        podcastId?.let { props["podcast_id"] = it }
+        podcastTitle?.let { props["podcast_title"] = it }
+        PostHog.capture(event = "learn_card_queued", properties = props)
+    }
+
+    fun trackLearnCardInfoClicked(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
+        val props = mutableMapOf<String, Any>("episode_id" to episodeId)
+        episodeTitle?.let { props["episode_title"] = it }
+        podcastId?.let { props["podcast_id"] = it }
+        podcastTitle?.let { props["podcast_title"] = it }
+        PostHog.capture(event = "learn_card_info_clicked", properties = props)
+    }
+
+    fun trackLearnCardPodcastClicked(podcastId: String?, podcastTitle: String?) {
+        val props = mutableMapOf<String, Any>()
+        podcastId?.let { props["podcast_id"] = it }
+        podcastTitle?.let { props["podcast_title"] = it }
+        PostHog.capture(event = "learn_card_podcast_clicked", properties = props)
+    }
+
+    fun trackLearnCardPlayClicked(episodeId: String, episodeTitle: String?, podcastId: String?, podcastTitle: String?) {
+        val props = mutableMapOf<String, Any>("episode_id" to episodeId)
+        episodeTitle?.let { props["episode_title"] = it }
+        podcastId?.let { props["podcast_id"] = it }
+        podcastTitle?.let { props["podcast_title"] = it }
+        PostHog.capture(event = "learn_card_play_clicked", properties = props)
+    }
+
+    fun trackLearnScreenSession(
+        timeSpentSeconds: Float,
+        cardsDismissedCount: Int,
+        cardsQueuedCount: Int,
+        playsCount: Int,
+        podcastsClickedCount: Int,
+        infosClickedCount: Int
+    ) {
+        PostHog.capture(
+            event = "learn_screen_session",
+            properties = mapOf(
+                "time_spent_seconds" to timeSpentSeconds,
+                "cards_dismissed_count" to cardsDismissedCount,
+                "cards_queued_count" to cardsQueuedCount,
+                "plays_count" to playsCount,
+                "podcasts_clicked_count" to podcastsClickedCount,
+                "infos_clicked_count" to infosClickedCount
+            )
+        )
+    }
 
     fun flush() {
         try {

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/theme/LifecycleUtils.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/theme/LifecycleUtils.kt
@@ -1,0 +1,29 @@
+package cx.aswin.boxcast.core.designsystem.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+@Composable
+fun TrackScreenSession(
+    onSessionResume: () -> Unit,
+    onSessionExit: () -> Unit
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_STOP -> onSessionExit()
+                Lifecycle.Event.ON_START -> onSessionResume()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            onSessionExit()
+        }
+    }
+}

--- a/core/model/src/main/java/cx/aswin/boxcast/core/model/PlaybackEntryPoint.kt
+++ b/core/model/src/main/java/cx/aswin/boxcast/core/model/PlaybackEntryPoint.kt
@@ -2,5 +2,6 @@ package cx.aswin.boxcast.core.model
 
 enum class PlaybackEntryPoint {
     GENERIC,
-    HOME_MIXTAPE
+    HOME_MIXTAPE,
+    LEARN
 }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreScreen.kt
@@ -113,6 +113,7 @@ import cx.aswin.boxcast.core.designsystem.theme.SectionHeaderFontFamily
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.designsystem.components.RegionNudgeBanner
+import cx.aswin.boxcast.core.designsystem.theme.TrackScreenSession
 
 import cx.aswin.boxcast.core.model.Episode
 import androidx.compose.ui.graphics.Brush
@@ -138,21 +139,10 @@ fun ExploreScreen(
         cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackExploreScreenViewed(entryPoint)
     }
 
-    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
-    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
-        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
-            when (event) {
-                androidx.lifecycle.Lifecycle.Event.ON_STOP -> viewModel.trackScreenExit()
-                androidx.lifecycle.Lifecycle.Event.ON_START -> viewModel.onScreenResume()
-                else -> {}
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-            viewModel.trackScreenExit()
-        }
-    }
+    TrackScreenSession(
+        onSessionResume = viewModel::onScreenResume,
+        onSessionExit = viewModel::trackScreenExit
+    )
 
     ExploreContent(
         uiState = uiState,

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -110,6 +110,26 @@ fun LearnScreen(
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
 
+    LaunchedEffect(Unit) {
+        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnScreenViewed()
+    }
+
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            when (event) {
+                androidx.lifecycle.Lifecycle.Event.ON_STOP -> viewModel.trackScreenExit()
+                androidx.lifecycle.Lifecycle.Event.ON_START -> viewModel.onScreenResume()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            viewModel.trackScreenExit()
+        }
+    }
+
     // Extract dominant color state at screen level
     var extractedColor by remember { mutableStateOf<Color?>(null) }
     val baseAccentColor = extractedColor ?: MaterialTheme.colorScheme.primary
@@ -268,14 +288,35 @@ fun LearnScreen(
                                 isCurrentlyPlaying = { id -> playerState.currentEpisode?.id == id && playerState.isPlaying },
                                 isCurrentlyLoading = { id -> playerState.currentEpisode?.id == id && playerState.isLoading },
                                 onSwipeLeft = { daily ->
+                                    viewModel.trackCardDismissed()
+                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardDismissed(
+                                        episodeId = daily.episode.id.toString(),
+                                        episodeTitle = daily.episode.title,
+                                        podcastId = daily.episode.feedId?.toString(),
+                                        podcastTitle = daily.episode.feedTitle
+                                    )
                                     viewModel.dismissCuriosity(daily.episode.id.toString())
                                 },
                                 onSwipeRight = { daily ->
+                                    viewModel.trackCardQueued()
+                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardQueued(
+                                        episodeId = daily.episode.id.toString(),
+                                        episodeTitle = daily.episode.title,
+                                        podcastId = daily.episode.feedId?.toString(),
+                                        podcastTitle = daily.episode.feedTitle
+                                    )
                                     val mappedEpisode = mapToEpisode(daily.episode)
                                     onQueueEpisode(mappedEpisode)
                                     viewModel.dismissCuriosity(daily.episode.id.toString())
                                 },
                                 onPlayClick = { daily ->
+                                    viewModel.trackPlayClicked()
+                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardPlayClicked(
+                                        episodeId = daily.episode.id.toString(),
+                                        episodeTitle = daily.episode.title,
+                                        podcastId = daily.episode.feedId?.toString(),
+                                        podcastTitle = daily.episode.feedTitle
+                                    )
                                     val isCurrent = playerState.currentEpisode?.id == daily.episode.id.toString()
                                     if (isCurrent) {
                                         playbackRepository.togglePlayPause()
@@ -292,16 +333,28 @@ fun LearnScreen(
                                                 episodes = listOf(mappedEpisode),
                                                 podcast = podcast,
                                                 startIndex = 0,
-                                                entryPoint = cx.aswin.boxcast.core.model.PlaybackEntryPoint.GENERIC
+                                                entryPoint = cx.aswin.boxcast.core.model.PlaybackEntryPoint.LEARN
                                             )
                                         }
                                     }
                                 },
                                 onEpisodeClick = { daily ->
+                                    viewModel.trackInfoClicked()
+                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardInfoClicked(
+                                        episodeId = daily.episode.id.toString(),
+                                        episodeTitle = daily.episode.title,
+                                        podcastId = daily.episode.feedId?.toString(),
+                                        podcastTitle = daily.episode.feedTitle
+                                    )
                                     val mappedEpisode = mapToEpisode(daily.episode)
                                     onEpisodeClick(mappedEpisode)
                                 },
                                 onPodcastClick = { daily ->
+                                    viewModel.trackPodcastClicked()
+                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardPodcastClicked(
+                                        podcastId = daily.episode.feedId?.toString(),
+                                        podcastTitle = daily.episode.feedTitle
+                                    )
                                     onPodcastClick(
                                         daily.episode.feedId,
                                         null,
@@ -324,17 +377,38 @@ fun LearnScreen(
                                 activeCard = activeCard,
                                 onDismissClick = {
                                     activeCard?.let { daily ->
+                                        viewModel.trackCardDismissed()
+                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardDismissed(
+                                            episodeId = daily.episode.id.toString(),
+                                            episodeTitle = daily.episode.title,
+                                            podcastId = daily.episode.feedId?.toString(),
+                                            podcastTitle = daily.episode.feedTitle
+                                        )
                                         viewModel.dismissCuriosity(daily.episode.id.toString())
                                     }
                                 },
                                 onInfoClick = {
                                     activeCard?.let { daily ->
+                                        viewModel.trackInfoClicked()
+                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardInfoClicked(
+                                            episodeId = daily.episode.id.toString(),
+                                            episodeTitle = daily.episode.title,
+                                            podcastId = daily.episode.feedId?.toString(),
+                                            podcastTitle = daily.episode.feedTitle
+                                        )
                                         val mappedEpisode = mapToEpisode(daily.episode)
                                         onEpisodeClick(mappedEpisode)
                                     }
                                 },
                                 onQueueClick = {
                                     activeCard?.let { daily ->
+                                        viewModel.trackCardQueued()
+                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardQueued(
+                                            episodeId = daily.episode.id.toString(),
+                                            episodeTitle = daily.episode.title,
+                                            podcastId = daily.episode.feedId?.toString(),
+                                            podcastTitle = daily.episode.feedTitle
+                                        )
                                         val mappedEpisode = mapToEpisode(daily.episode)
                                         onQueueEpisode(mappedEpisode)
                                         viewModel.dismissCuriosity(daily.episode.id.toString())

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -509,21 +509,21 @@ private fun DeckControlsRow(
     }
 }
 
-private fun mapToEpisode(item: cx.aswin.boxcast.core.network.model.EpisodeItem): Episode {
-    return Episode(
-        id = item.id.toString(),
-        title = item.title,
-        description = item.description ?: "",
-        audioUrl = item.enclosureUrl ?: "",
-        imageUrl = item.image ?: item.feedImage,
-        podcastImageUrl = item.feedImage,
-        podcastTitle = item.feedTitle,
-        podcastId = item.feedId?.toString(),
-        duration = item.duration ?: 0,
-        publishedDate = item.datePublished ?: 0L,
-        chaptersUrl = item.chaptersUrl,
-        transcriptUrl = item.transcriptUrl,
-        enclosureType = item.enclosureType
+private fun mapToEpisode(item: cx.aswin.boxcast.core.network.model.EpisodeItem): Episode = item.run {
+    Episode(
+        id = id.toString(),
+        title = title,
+        description = description.orEmpty(),
+        audioUrl = enclosureUrl.orEmpty(),
+        imageUrl = image ?: feedImage ?: "",
+        podcastImageUrl = feedImage,
+        podcastTitle = feedTitle,
+        podcastId = feedId?.toString(),
+        duration = duration ?: 0,
+        publishedDate = datePublished ?: 0L,
+        chaptersUrl = chaptersUrl,
+        transcriptUrl = transcriptUrl,
+        enclosureType = enclosureType
     )
 }
 

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -264,23 +264,24 @@ fun LearnScreen(
                     }
                     is LearnUiState.Success -> {
                         val handleDismiss: (DailyCuriosityDto) -> Unit = { daily ->
+                            val mappedEpisode = mapToEpisode(daily.episode)
                             viewModel.trackCardDismissed()
-                            trackLearnCardAction("dismiss", daily)
-                            viewModel.dismissCuriosity(daily.episode.id.toString())
+                            trackLearnCardAction("dismiss", mappedEpisode)
+                            viewModel.dismissCuriosity(mappedEpisode.id)
                         }
 
                         val handleQueue: (DailyCuriosityDto) -> Unit = { daily ->
-                            viewModel.trackCardQueued()
-                            trackLearnCardAction("queue", daily)
                             val mappedEpisode = mapToEpisode(daily.episode)
+                            viewModel.trackCardQueued()
+                            trackLearnCardAction("queue", mappedEpisode)
                             onQueueEpisode(mappedEpisode)
-                            viewModel.dismissCuriosity(daily.episode.id.toString())
+                            viewModel.dismissCuriosity(mappedEpisode.id)
                         }
 
                         val handleInfo: (DailyCuriosityDto) -> Unit = { daily ->
-                            viewModel.trackInfoClicked()
-                            trackLearnCardAction("info", daily)
                             val mappedEpisode = mapToEpisode(daily.episode)
+                            viewModel.trackInfoClicked()
+                            trackLearnCardAction("info", mappedEpisode)
                             onEpisodeClick(mappedEpisode)
                         }
 
@@ -311,18 +312,18 @@ fun LearnScreen(
                                 onSwipeLeft = handleDismiss,
                                 onSwipeRight = handleQueue,
                                 onPlayClick = { daily ->
+                                    val mappedEpisode = mapToEpisode(daily.episode)
                                     viewModel.trackPlayClicked()
-                                    trackLearnCardAction("play", daily)
-                                    val isCurrent = playerState.currentEpisode?.id == daily.episode.id.toString()
+                                    trackLearnCardAction("play", mappedEpisode)
+                                    val isCurrent = playerState.currentEpisode?.id == mappedEpisode.id
                                     if (isCurrent) {
                                         playbackRepository.togglePlayPause()
                                     } else {
-                                        val mappedEpisode = mapToEpisode(daily.episode)
                                         val podcast = cx.aswin.boxcast.core.model.Podcast(
-                                            id = daily.episode.feedId?.toString() ?: "learn_fallback",
-                                            title = daily.episode.feedTitle ?: "Podcast",
-                                            artist = daily.episode.feedTitle ?: "Unknown",
-                                            imageUrl = daily.episode.feedImage ?: daily.episode.image ?: ""
+                                            id = mappedEpisode.podcastId ?: "learn_fallback",
+                                            title = mappedEpisode.podcastTitle ?: "Podcast",
+                                            artist = mappedEpisode.podcastTitle ?: "Unknown",
+                                            imageUrl = mappedEpisode.imageUrl ?: ""
                                         )
                                         coroutineScope.launch {
                                             playbackRepository.playQueue(
@@ -336,13 +337,14 @@ fun LearnScreen(
                                 },
                                 onEpisodeClick = handleInfo,
                                 onPodcastClick = { daily ->
+                                    val mappedEpisode = mapToEpisode(daily.episode)
                                     viewModel.trackPodcastClicked()
-                                    trackLearnCardAction("podcast", daily)
+                                    trackLearnCardAction("podcast", mappedEpisode)
                                     onPodcastClick(
-                                        daily.episode.feedId,
+                                        mappedEpisode.podcastId?.toLongOrNull(),
                                         null,
                                         "",
-                                        daily.episode.feedTitle ?: "Podcast"
+                                        mappedEpisode.podcastTitle ?: "Podcast"
                                     )
                                 },
                                 accentColor = animatedAccentColor,
@@ -599,13 +601,13 @@ private fun CuratedShowItem(
 
 private fun trackLearnCardAction(
     action: String,
-    daily: DailyCuriosityDto
+    episode: Episode
 ) {
     val analytics = cx.aswin.boxcast.core.data.analytics.AnalyticsHelper
-    val episodeId = daily.episode.id.toString()
-    val episodeTitle = daily.episode.title
-    val podcastId = daily.episode.feedId?.toString()
-    val podcastTitle = daily.episode.feedTitle
+    val episodeId = episode.id
+    val episodeTitle = episode.title
+    val podcastId = episode.podcastId
+    val podcastTitle = episode.podcastTitle
 
     when (action) {
         "dismiss" -> analytics.trackLearnCardDismissed(episodeId, episodeTitle, podcastId, podcastTitle)

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -265,23 +265,13 @@ fun LearnScreen(
                     is LearnUiState.Success -> {
                         val handleDismiss: (DailyCuriosityDto) -> Unit = { daily ->
                             viewModel.trackCardDismissed()
-                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardDismissed(
-                                episodeId = daily.episode.id.toString(),
-                                episodeTitle = daily.episode.title,
-                                podcastId = daily.episode.feedId?.toString(),
-                                podcastTitle = daily.episode.feedTitle
-                            )
+                            trackLearnCardAction("dismiss", daily)
                             viewModel.dismissCuriosity(daily.episode.id.toString())
                         }
 
                         val handleQueue: (DailyCuriosityDto) -> Unit = { daily ->
                             viewModel.trackCardQueued()
-                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardQueued(
-                                episodeId = daily.episode.id.toString(),
-                                episodeTitle = daily.episode.title,
-                                podcastId = daily.episode.feedId?.toString(),
-                                podcastTitle = daily.episode.feedTitle
-                            )
+                            trackLearnCardAction("queue", daily)
                             val mappedEpisode = mapToEpisode(daily.episode)
                             onQueueEpisode(mappedEpisode)
                             viewModel.dismissCuriosity(daily.episode.id.toString())
@@ -289,12 +279,7 @@ fun LearnScreen(
 
                         val handleInfo: (DailyCuriosityDto) -> Unit = { daily ->
                             viewModel.trackInfoClicked()
-                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardInfoClicked(
-                                episodeId = daily.episode.id.toString(),
-                                episodeTitle = daily.episode.title,
-                                podcastId = daily.episode.feedId?.toString(),
-                                podcastTitle = daily.episode.feedTitle
-                            )
+                            trackLearnCardAction("info", daily)
                             val mappedEpisode = mapToEpisode(daily.episode)
                             onEpisodeClick(mappedEpisode)
                         }
@@ -327,12 +312,7 @@ fun LearnScreen(
                                 onSwipeRight = handleQueue,
                                 onPlayClick = { daily ->
                                     viewModel.trackPlayClicked()
-                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardPlayClicked(
-                                        episodeId = daily.episode.id.toString(),
-                                        episodeTitle = daily.episode.title,
-                                        podcastId = daily.episode.feedId?.toString(),
-                                        podcastTitle = daily.episode.feedTitle
-                                    )
+                                    trackLearnCardAction("play", daily)
                                     val isCurrent = playerState.currentEpisode?.id == daily.episode.id.toString()
                                     if (isCurrent) {
                                         playbackRepository.togglePlayPause()
@@ -357,10 +337,7 @@ fun LearnScreen(
                                 onEpisodeClick = handleInfo,
                                 onPodcastClick = { daily ->
                                     viewModel.trackPodcastClicked()
-                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardPodcastClicked(
-                                        podcastId = daily.episode.feedId?.toString(),
-                                        podcastTitle = daily.episode.feedTitle
-                                    )
+                                    trackLearnCardAction("podcast", daily)
                                     onPodcastClick(
                                         daily.episode.feedId,
                                         null,
@@ -617,5 +594,24 @@ private fun CuratedShowItem(
                 overflow = TextOverflow.Ellipsis
             )
         }
+    }
+}
+
+private fun trackLearnCardAction(
+    action: String,
+    daily: DailyCuriosityDto
+) {
+    val analytics = cx.aswin.boxcast.core.data.analytics.AnalyticsHelper
+    val episodeId = daily.episode.id.toString()
+    val episodeTitle = daily.episode.title
+    val podcastId = daily.episode.feedId?.toString()
+    val podcastTitle = daily.episode.feedTitle
+
+    when (action) {
+        "dismiss" -> analytics.trackLearnCardDismissed(episodeId, episodeTitle, podcastId, podcastTitle)
+        "queue" -> analytics.trackLearnCardQueued(episodeId, episodeTitle, podcastId, podcastTitle)
+        "info" -> analytics.trackLearnCardInfoClicked(episodeId, episodeTitle, podcastId, podcastTitle)
+        "play" -> analytics.trackLearnCardPlayClicked(episodeId, episodeTitle, podcastId, podcastTitle)
+        "podcast" -> analytics.trackLearnCardPodcastClicked(podcastId, podcastTitle)
     }
 }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -92,6 +92,7 @@ import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.network.model.CuratedCuriosityPodcastDto
 import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
+import cx.aswin.boxcast.core.data.toEpisode
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -264,7 +265,7 @@ fun LearnScreen(
                     }
                     is LearnUiState.Success -> {
                         val handleLearnCardAction: (String, DailyCuriosityDto) -> Unit = { action, daily ->
-                            val mappedEpisode = mapToEpisode(daily.episode)
+                            val mappedEpisode = daily.episode.toEpisode()
                             when (action) {
                                 "dismiss" -> {
                                     viewModel.trackCardDismissed()
@@ -507,24 +508,6 @@ private fun DeckControlsRow(
             }
         }
     }
-}
-
-private fun mapToEpisode(item: cx.aswin.boxcast.core.network.model.EpisodeItem): Episode = item.run {
-    Episode(
-        id = id.toString(),
-        title = title,
-        description = description.orEmpty(),
-        audioUrl = enclosureUrl.orEmpty(),
-        imageUrl = image ?: feedImage ?: "",
-        podcastImageUrl = feedImage,
-        podcastTitle = feedTitle,
-        podcastId = feedId?.toString(),
-        duration = duration ?: 0,
-        publishedDate = datePublished ?: 0L,
-        chaptersUrl = chaptersUrl,
-        transcriptUrl = transcriptUrl,
-        enclosureType = enclosureType
-    )
 }
 
 private fun extractDominantColor(bitmap: android.graphics.Bitmap): Color {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -263,6 +263,42 @@ fun LearnScreen(
                         }
                     }
                     is LearnUiState.Success -> {
+                        val handleDismiss: (DailyCuriosityDto) -> Unit = { daily ->
+                            viewModel.trackCardDismissed()
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardDismissed(
+                                episodeId = daily.episode.id.toString(),
+                                episodeTitle = daily.episode.title,
+                                podcastId = daily.episode.feedId?.toString(),
+                                podcastTitle = daily.episode.feedTitle
+                            )
+                            viewModel.dismissCuriosity(daily.episode.id.toString())
+                        }
+
+                        val handleQueue: (DailyCuriosityDto) -> Unit = { daily ->
+                            viewModel.trackCardQueued()
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardQueued(
+                                episodeId = daily.episode.id.toString(),
+                                episodeTitle = daily.episode.title,
+                                podcastId = daily.episode.feedId?.toString(),
+                                podcastTitle = daily.episode.feedTitle
+                            )
+                            val mappedEpisode = mapToEpisode(daily.episode)
+                            onQueueEpisode(mappedEpisode)
+                            viewModel.dismissCuriosity(daily.episode.id.toString())
+                        }
+
+                        val handleInfo: (DailyCuriosityDto) -> Unit = { daily ->
+                            viewModel.trackInfoClicked()
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardInfoClicked(
+                                episodeId = daily.episode.id.toString(),
+                                episodeTitle = daily.episode.title,
+                                podcastId = daily.episode.feedId?.toString(),
+                                podcastTitle = daily.episode.feedTitle
+                            )
+                            val mappedEpisode = mapToEpisode(daily.episode)
+                            onEpisodeClick(mappedEpisode)
+                        }
+
                         Column(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -287,28 +323,8 @@ fun LearnScreen(
                                 questions = state.questionsStack,
                                 isCurrentlyPlaying = { id -> playerState.currentEpisode?.id == id && playerState.isPlaying },
                                 isCurrentlyLoading = { id -> playerState.currentEpisode?.id == id && playerState.isLoading },
-                                onSwipeLeft = { daily ->
-                                    viewModel.trackCardDismissed()
-                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardDismissed(
-                                        episodeId = daily.episode.id.toString(),
-                                        episodeTitle = daily.episode.title,
-                                        podcastId = daily.episode.feedId?.toString(),
-                                        podcastTitle = daily.episode.feedTitle
-                                    )
-                                    viewModel.dismissCuriosity(daily.episode.id.toString())
-                                },
-                                onSwipeRight = { daily ->
-                                    viewModel.trackCardQueued()
-                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardQueued(
-                                        episodeId = daily.episode.id.toString(),
-                                        episodeTitle = daily.episode.title,
-                                        podcastId = daily.episode.feedId?.toString(),
-                                        podcastTitle = daily.episode.feedTitle
-                                    )
-                                    val mappedEpisode = mapToEpisode(daily.episode)
-                                    onQueueEpisode(mappedEpisode)
-                                    viewModel.dismissCuriosity(daily.episode.id.toString())
-                                },
+                                onSwipeLeft = handleDismiss,
+                                onSwipeRight = handleQueue,
                                 onPlayClick = { daily ->
                                     viewModel.trackPlayClicked()
                                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardPlayClicked(
@@ -338,17 +354,7 @@ fun LearnScreen(
                                         }
                                     }
                                 },
-                                onEpisodeClick = { daily ->
-                                    viewModel.trackInfoClicked()
-                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardInfoClicked(
-                                        episodeId = daily.episode.id.toString(),
-                                        episodeTitle = daily.episode.title,
-                                        podcastId = daily.episode.feedId?.toString(),
-                                        podcastTitle = daily.episode.feedTitle
-                                    )
-                                    val mappedEpisode = mapToEpisode(daily.episode)
-                                    onEpisodeClick(mappedEpisode)
-                                },
+                                onEpisodeClick = handleInfo,
                                 onPodcastClick = { daily ->
                                     viewModel.trackPodcastClicked()
                                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardPodcastClicked(
@@ -376,43 +382,13 @@ fun LearnScreen(
                             DeckControlsRow(
                                 activeCard = activeCard,
                                 onDismissClick = {
-                                    activeCard?.let { daily ->
-                                        viewModel.trackCardDismissed()
-                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardDismissed(
-                                            episodeId = daily.episode.id.toString(),
-                                            episodeTitle = daily.episode.title,
-                                            podcastId = daily.episode.feedId?.toString(),
-                                            podcastTitle = daily.episode.feedTitle
-                                        )
-                                        viewModel.dismissCuriosity(daily.episode.id.toString())
-                                    }
+                                    activeCard?.let(handleDismiss)
                                 },
                                 onInfoClick = {
-                                    activeCard?.let { daily ->
-                                        viewModel.trackInfoClicked()
-                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardInfoClicked(
-                                            episodeId = daily.episode.id.toString(),
-                                            episodeTitle = daily.episode.title,
-                                            podcastId = daily.episode.feedId?.toString(),
-                                            podcastTitle = daily.episode.feedTitle
-                                        )
-                                        val mappedEpisode = mapToEpisode(daily.episode)
-                                        onEpisodeClick(mappedEpisode)
-                                    }
+                                    activeCard?.let(handleInfo)
                                 },
                                 onQueueClick = {
-                                    activeCard?.let { daily ->
-                                        viewModel.trackCardQueued()
-                                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnCardQueued(
-                                            episodeId = daily.episode.id.toString(),
-                                            episodeTitle = daily.episode.title,
-                                            podcastId = daily.episode.feedId?.toString(),
-                                            podcastTitle = daily.episode.feedTitle
-                                        )
-                                        val mappedEpisode = mapToEpisode(daily.episode)
-                                        onQueueEpisode(mappedEpisode)
-                                        viewModel.dismissCuriosity(daily.episode.id.toString())
-                                    }
+                                    activeCard?.let(handleQueue)
                                 }
                             )
 

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -263,26 +263,59 @@ fun LearnScreen(
                         }
                     }
                     is LearnUiState.Success -> {
-                        val handleDismiss: (DailyCuriosityDto) -> Unit = { daily ->
+                        val handleLearnCardAction: (String, DailyCuriosityDto) -> Unit = { action, daily ->
                             val mappedEpisode = mapToEpisode(daily.episode)
-                            viewModel.trackCardDismissed()
-                            trackLearnCardAction("dismiss", mappedEpisode)
-                            viewModel.dismissCuriosity(mappedEpisode.id)
-                        }
-
-                        val handleQueue: (DailyCuriosityDto) -> Unit = { daily ->
-                            val mappedEpisode = mapToEpisode(daily.episode)
-                            viewModel.trackCardQueued()
-                            trackLearnCardAction("queue", mappedEpisode)
-                            onQueueEpisode(mappedEpisode)
-                            viewModel.dismissCuriosity(mappedEpisode.id)
-                        }
-
-                        val handleInfo: (DailyCuriosityDto) -> Unit = { daily ->
-                            val mappedEpisode = mapToEpisode(daily.episode)
-                            viewModel.trackInfoClicked()
-                            trackLearnCardAction("info", mappedEpisode)
-                            onEpisodeClick(mappedEpisode)
+                            when (action) {
+                                "dismiss" -> {
+                                    viewModel.trackCardDismissed()
+                                    trackLearnCardAction("dismiss", mappedEpisode)
+                                    viewModel.dismissCuriosity(mappedEpisode.id)
+                                }
+                                "queue" -> {
+                                    viewModel.trackCardQueued()
+                                    trackLearnCardAction("queue", mappedEpisode)
+                                    onQueueEpisode(mappedEpisode)
+                                    viewModel.dismissCuriosity(mappedEpisode.id)
+                                }
+                                "info" -> {
+                                    viewModel.trackInfoClicked()
+                                    trackLearnCardAction("info", mappedEpisode)
+                                    onEpisodeClick(mappedEpisode)
+                                }
+                                "play" -> {
+                                    viewModel.trackPlayClicked()
+                                    trackLearnCardAction("play", mappedEpisode)
+                                    val isCurrent = playerState.currentEpisode?.id == mappedEpisode.id
+                                    if (isCurrent) {
+                                        playbackRepository.togglePlayPause()
+                                    } else {
+                                        val podcast = cx.aswin.boxcast.core.model.Podcast(
+                                            id = mappedEpisode.podcastId ?: "learn_fallback",
+                                            title = mappedEpisode.podcastTitle ?: "Podcast",
+                                            artist = mappedEpisode.podcastTitle ?: "Unknown",
+                                            imageUrl = mappedEpisode.imageUrl ?: ""
+                                        )
+                                        coroutineScope.launch {
+                                            playbackRepository.playQueue(
+                                                episodes = listOf(mappedEpisode),
+                                                podcast = podcast,
+                                                startIndex = 0,
+                                                entryPoint = cx.aswin.boxcast.core.model.PlaybackEntryPoint.LEARN
+                                            )
+                                        }
+                                    }
+                                }
+                                "podcast" -> {
+                                    viewModel.trackPodcastClicked()
+                                    trackLearnCardAction("podcast", mappedEpisode)
+                                    onPodcastClick(
+                                        mappedEpisode.podcastId?.toLongOrNull(),
+                                        null,
+                                        "",
+                                        mappedEpisode.podcastTitle ?: "Podcast"
+                                    )
+                                }
+                            }
                         }
 
                         Column(
@@ -309,44 +342,11 @@ fun LearnScreen(
                                 questions = state.questionsStack,
                                 isCurrentlyPlaying = { id -> playerState.currentEpisode?.id == id && playerState.isPlaying },
                                 isCurrentlyLoading = { id -> playerState.currentEpisode?.id == id && playerState.isLoading },
-                                onSwipeLeft = handleDismiss,
-                                onSwipeRight = handleQueue,
-                                onPlayClick = { daily ->
-                                    val mappedEpisode = mapToEpisode(daily.episode)
-                                    viewModel.trackPlayClicked()
-                                    trackLearnCardAction("play", mappedEpisode)
-                                    val isCurrent = playerState.currentEpisode?.id == mappedEpisode.id
-                                    if (isCurrent) {
-                                        playbackRepository.togglePlayPause()
-                                    } else {
-                                        val podcast = cx.aswin.boxcast.core.model.Podcast(
-                                            id = mappedEpisode.podcastId ?: "learn_fallback",
-                                            title = mappedEpisode.podcastTitle ?: "Podcast",
-                                            artist = mappedEpisode.podcastTitle ?: "Unknown",
-                                            imageUrl = mappedEpisode.imageUrl ?: ""
-                                        )
-                                        coroutineScope.launch {
-                                            playbackRepository.playQueue(
-                                                episodes = listOf(mappedEpisode),
-                                                podcast = podcast,
-                                                startIndex = 0,
-                                                entryPoint = cx.aswin.boxcast.core.model.PlaybackEntryPoint.LEARN
-                                            )
-                                        }
-                                    }
-                                },
-                                onEpisodeClick = handleInfo,
-                                onPodcastClick = { daily ->
-                                    val mappedEpisode = mapToEpisode(daily.episode)
-                                    viewModel.trackPodcastClicked()
-                                    trackLearnCardAction("podcast", mappedEpisode)
-                                    onPodcastClick(
-                                        mappedEpisode.podcastId?.toLongOrNull(),
-                                        null,
-                                        "",
-                                        mappedEpisode.podcastTitle ?: "Podcast"
-                                    )
-                                },
+                                onSwipeLeft = { handleLearnCardAction("dismiss", it) },
+                                onSwipeRight = { handleLearnCardAction("queue", it) },
+                                onPlayClick = { handleLearnCardAction("play", it) },
+                                onEpisodeClick = { handleLearnCardAction("info", it) },
+                                onPodcastClick = { handleLearnCardAction("podcast", it) },
                                 accentColor = animatedAccentColor,
                                 modifier = Modifier
                                     .fillMaxWidth()
@@ -361,13 +361,13 @@ fun LearnScreen(
                             DeckControlsRow(
                                 activeCard = activeCard,
                                 onDismissClick = {
-                                    activeCard?.let(handleDismiss)
+                                    activeCard?.let { handleLearnCardAction("dismiss", it) }
                                 },
                                 onInfoClick = {
-                                    activeCard?.let(handleInfo)
+                                    activeCard?.let { handleLearnCardAction("info", it) }
                                 },
                                 onQueueClick = {
-                                    activeCard?.let(handleQueue)
+                                    activeCard?.let { handleLearnCardAction("queue", it) }
                                 }
                             )
 

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -93,6 +93,7 @@ import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.network.model.CuratedCuriosityPodcastDto
 import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
 import cx.aswin.boxcast.core.data.toEpisode
+import cx.aswin.boxcast.core.designsystem.theme.TrackScreenSession
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -115,21 +116,10 @@ fun LearnScreen(
         cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnScreenViewed()
     }
 
-    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
-    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
-        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
-            when (event) {
-                androidx.lifecycle.Lifecycle.Event.ON_STOP -> viewModel.trackScreenExit()
-                androidx.lifecycle.Lifecycle.Event.ON_START -> viewModel.onScreenResume()
-                else -> {}
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-            viewModel.trackScreenExit()
-        }
-    }
+    TrackScreenSession(
+        onSessionResume = viewModel::onScreenResume,
+        onSessionExit = viewModel::trackScreenExit
+    )
 
     // Extract dominant color state at screen level
     var extractedColor by remember { mutableStateOf<Color?>(null) }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -35,6 +35,56 @@ class LearnViewModel(
     private val _uiState = MutableStateFlow<LearnUiState>(LearnUiState.Loading)
     val uiState: StateFlow<LearnUiState> = _uiState.asStateFlow()
 
+    // Telemetry tracking fields
+    private var sessionStartTime = System.currentTimeMillis()
+    private var hasTrackedExit = false
+    private var cardsDismissedCount = 0
+    private var cardsQueuedCount = 0
+    private var playsCount = 0
+    private var podcastsClickedCount = 0
+    private var infosClickedCount = 0
+
+    fun onScreenResume() {
+        if (hasTrackedExit) {
+            sessionStartTime = System.currentTimeMillis()
+            hasTrackedExit = false
+        }
+    }
+
+    fun trackScreenExit() {
+        if (hasTrackedExit) return
+        hasTrackedExit = true
+        val timeSpent = (System.currentTimeMillis() - sessionStartTime) / 1000f
+        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLearnScreenSession(
+            timeSpentSeconds = timeSpent,
+            cardsDismissedCount = cardsDismissedCount,
+            cardsQueuedCount = cardsQueuedCount,
+            playsCount = playsCount,
+            podcastsClickedCount = podcastsClickedCount,
+            infosClickedCount = infosClickedCount
+        )
+    }
+
+    fun trackCardDismissed() {
+        cardsDismissedCount++
+    }
+
+    fun trackCardQueued() {
+        cardsQueuedCount++
+    }
+
+    fun trackPlayClicked() {
+        playsCount++
+    }
+
+    fun trackPodcastClicked() {
+        podcastsClickedCount++
+    }
+
+    fun trackInfoClicked() {
+        infosClickedCount++
+    }
+
     private var currentPage = 1
     private var isLoadingMore = false
     private var isEndOfContent = false

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -48,6 +48,11 @@ class LearnViewModel(
         if (hasTrackedExit) {
             sessionStartTime = System.currentTimeMillis()
             hasTrackedExit = false
+            cardsDismissedCount = 0
+            cardsQueuedCount = 0
+            playsCount = 0
+            podcastsClickedCount = 0
+            infosClickedCount = 0
         }
     }
 

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoScreen.kt
@@ -165,6 +165,7 @@ import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
 import cx.aswin.boxcast.core.designsystem.components.LogRecomposition
 import cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
+import cx.aswin.boxcast.core.designsystem.theme.TrackScreenSession
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Person
 import kotlinx.coroutines.delay
@@ -303,21 +304,10 @@ fun PodcastInfoScreen(
         viewModel.searchEpisodes("") // Optional: Clear search on close? Or keep it? Let's clear for now.
     }
 
-    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
-    androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
-        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
-            when (event) {
-                androidx.lifecycle.Lifecycle.Event.ON_STOP -> viewModel.trackScreenExit()
-                androidx.lifecycle.Lifecycle.Event.ON_START -> viewModel.onScreenResume()
-                else -> {}
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
-            viewModel.trackScreenExit()
-        }
-    }
+    TrackScreenSession(
+        onSessionResume = viewModel::onScreenResume,
+        onSessionExit = viewModel::trackScreenExit
+    )
 
     LaunchedEffect(podcastId) {
         viewModel.loadPodcast(podcastId)


### PR DESCRIPTION
This PR implements PostHog telemetry for the Learn Screen and Lore Tab navigation clicks, capturing detailed interaction events and session summaries.