### PR TITLE
fix(briefing): reduce background artwork blur on Briefing screen

### DIFF
--- a/feature/briefing/src/main/java/cx/aswin/boxcast/feature/briefing/BriefingScreen.kt
+++ b/feature/briefing/src/main/java/cx/aswin/boxcast/feature/briefing/BriefingScreen.kt
@@ -616,7 +616,7 @@ fun BriefingContent(
                 contentDescription = null,
                 modifier = Modifier
                     .fillMaxSize()
-                    .blur(20.dp, edgeTreatment = androidx.compose.ui.draw.BlurredEdgeTreatment.Unbounded)
+                    .blur(8.dp, edgeTreatment = androidx.compose.ui.draw.BlurredEdgeTreatment.Unbounded)
                     .alpha(0.55f),
                 contentScale = ContentScale.Crop
             )


### PR DESCRIPTION
Reduces the cover artwork background blur on the Daily Briefing screen from 20.dp to 8.dp, ensuring the branding logo embedded in the background graphic remains visible.