### PR TITLE
feat(sync): rewrite PI data pipeline as single-pass staged architecture

### DIFF
--- a/.github/workflows/sync-pi-data.yml
+++ b/.github/workflows/sync-pi-data.yml
@@ -2,47 +2,58 @@ name: Sync Podcast Index Data
 
 on:
   schedule:
-    # Optimized triggers for fresh morning news across key timezones (5x/day)
-    - cron: '0 0 * * *'   # 00:00 UTC → India morning (5:30 AM IST)
-    - cron: '0 5 * * *'   # 05:00 UTC → UK/Europe morning (6:00 AM BST)
-    - cron: '0 11 * * *'  # 11:00 UTC → US East morning (7:00 AM EDT)
-    - cron: '0 14 * * *'  # 14:00 UTC → US West morning (7:00 AM PDT)
-    - cron: '0 20 * * *'  # 20:00 UTC → Overnight refresh for next-day Asia/India
-  workflow_dispatch: # Allow manual trigger
+    # Fresh morning content across key timezones (5x/day)
+    - cron: '0 0 * * *'   # 00:00 UTC - India morning + daily charts refresh
+    - cron: '0 5 * * *'   # 05:00 UTC - UK/Europe morning
+    - cron: '0 11 * * *'  # 11:00 UTC - US East morning
+    - cron: '0 14 * * *'  # 14:00 UTC - US West morning
+    - cron: '0 20 * * *'  # 20:00 UTC - overnight refresh + cleanup job
+  workflow_dispatch:
+    inputs:
+      job:
+        description: 'What to run'
+        type: choice
+        default: sync
+        options: [sync, remediate-qdrant, remediate-qdrant-dry-run]
+      embedding_budget:
+        description: 'Override MAX_EMBEDDINGS_PER_RUN (sync only)'
+        required: false
+        default: ''
 
 permissions:
   contents: write
 
+# Queue runs instead of cancelling half-done vector batches.
+concurrency:
+  group: sync-pi-data
+  cancel-in-progress: false
+
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  TURSO_URL: ${{ secrets.TURSO_URL }}
+  TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+  QDRANT_URL: ${{ secrets.QDRANT_URL }}
+  QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
+  PODCAST_INDEX_API_KEY: ${{ secrets.PODCAST_INDEX_API_KEY }}
+  PODCAST_INDEX_API_SECRET: ${{ secrets.PODCAST_INDEX_API_SECRET }}
 
 jobs:
-  sync-pi-data:
+  sync:
+    if: github.event_name == 'schedule' || inputs.job == 'sync'
     runs-on: ubuntu-latest
-    timeout-minutes: 120
-    concurrency:
-      group: sync-pi-data-${{ matrix.country }}-${{ github.ref }}
-      cancel-in-progress: true
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        country: [us, in, gb, fr]
-    
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           ref: master
-          token: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'npm'
 
-      - name: Cache Transformers Models
+      - name: Cache embedding model
         uses: actions/cache@v4
         with:
           path: ./.cache
@@ -51,170 +62,106 @@ jobs:
             transformers-cache-
 
       - name: Install dependencies
-        run: |
-          echo "[WORKFLOW] Pre-installing standard dependencies..."
-          npm install
+        run: npm install
 
-      - name: Populate Charts Table
+      - name: 'Stage 1: Refresh charts (daily at 00:00 + manual)'
         if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 0 * * *'
-        env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-        run: |
-          echo "[WORKFLOW] Populating Apple charts for country ${{ matrix.country }}..."
-          node scripts/populate-charts.js --country ${{ matrix.country }}
+        run: node scripts/sync/01-refresh-charts.js
 
-      - name: Run Pre-check Sync
+      - name: 'Stage 2a: Pre-check missing shows'
         id: precheck
-        env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-        run: node scripts/pre-check-sync.js --country ${{ matrix.country }}
+        run: node scripts/sync/02-import-podcasts.js --precheck
 
-      - name: Download Podcast Index Database
-        if: steps.precheck.outputs.skip_download != 'true'
+      - name: 'Stage 2b: Download PI dump (only when many shows are missing)'
+        if: steps.precheck.outputs.need_dump == 'true'
         run: |
-          echo "Downloading PI database dump..."
-          curl -L -f -A "BoxLore/1.0 (github.com/ashwkun/box.lore.android)" -o podcastindex_feeds.db.tgz https://public.podcastindex.org/podcastindex_feeds.db.tgz
-          echo "Extracting..."
+          echo "Missing ${{ steps.precheck.outputs.missing_count }} shows - downloading PI dump"
+          curl -L -f -A "BoxLore/1.0 (github.com/ashwkun/box.lore.android)" \
+            -o podcastindex_feeds.db.tgz https://public.podcastindex.org/podcastindex_feeds.db.tgz
           tar -xzf podcastindex_feeds.db.tgz
-          ls -la *.db
-          
-      - name: Inspect PI dump schema
-        if: steps.precheck.outputs.skip_download != 'true'
+
+      - name: 'Stage 2c: Export missing shows from dump'
+        if: steps.precheck.outputs.need_dump == 'true'
         run: |
-          echo "=== Tables in PI dump ==="
-          sqlite3 podcastindex_feeds.db ".tables"
-          echo ""
-          echo "=== Podcasts/Feeds table schema ==="
-          sqlite3 podcastindex_feeds.db ".schema podcasts" || sqlite3 podcastindex_feeds.db ".schema newsfeeds" || true
-          echo ""
-          echo "=== Sample row ==="
-          sqlite3 podcastindex_feeds.db "SELECT * FROM podcasts LIMIT 1;" 2>/dev/null || sqlite3 podcastindex_feeds.db "SELECT * FROM newsfeeds LIMIT 1;" || true
-          echo ""
-          echo "=== Sample row ==="
-          sqlite3 podcastindex_feeds.db "SELECT * FROM podcasts LIMIT 1;" 2>/dev/null || sqlite3 podcastindex_feeds.db "SELECT * FROM newsfeeds LIMIT 1;" || true
-          echo ""
-          echo "=== Episodes table schema ==="
-          sqlite3 podcastindex_feeds.db ".schema episodes" || true
-          
-      - name: Get chart iTunes IDs
-        env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-        run: |
-          echo "[WORKFLOW] Fetching active iTunes IDs from Turso DB charts table for country: ${{ matrix.country }}..."
-          node scripts/get-chart-itunes-ids.js --country ${{ matrix.country }} > chart_itunes_ids.txt
-          echo "[WORKFLOW] Successfully retrieved $(wc -l < chart_itunes_ids.txt) iTunes IDs from Turso charts."
-          echo "[WORKFLOW] First few iTunes IDs retrieved:"
-          head -5 chart_itunes_ids.txt
-          
-      - name: Export podcasts from PI dump
-        if: steps.precheck.outputs.skip_download != 'true'
-        run: |
-          echo "[WORKFLOW] Creating temporary SQLite table 'chart_ids' inside podcastindex_feeds.db..."
           sqlite3 podcastindex_feeds.db "CREATE TABLE chart_ids (itunes_id INTEGER);"
-          
-          echo "[WORKFLOW] Importing retrieved chart iTunes IDs from 'chart_itunes_ids.txt' into SQLite..."
-          sqlite3 -csv podcastindex_feeds.db ".import chart_itunes_ids.txt chart_ids"
-          echo "[WORKFLOW] SQLite Database status: $(sqlite3 podcastindex_feeds.db 'SELECT COUNT(*) FROM chart_ids;') iTunes IDs successfully imported into temporary table."
-          
-          # Export podcasts - using correct column names from PI dump
-          echo "[WORKFLOW] Querying and exporting podcast feeds matching chart IDs from sqlite dump to CSV format..."
+          sqlite3 -csv podcastindex_feeds.db ".import missing_itunes_ids.txt chart_ids"
+          echo "Imported $(sqlite3 podcastindex_feeds.db 'SELECT COUNT(*) FROM chart_ids;') missing iTunes IDs"
+          # Column list must match PODCAST_IMPORT_COLUMNS in scripts/sync/lib/config.js
           sqlite3 -header -csv podcastindex_feeds.db "
-            SELECT 
+            SELECT
               p.id,
-              p.itunesId as itunes_id,
+              p.itunesId AS itunes_id,
               p.title,
-              p.itunesAuthor as author,
+              p.itunesAuthor AS author,
               p.description,
-              p.imageUrl as image_url,
-              p.url as feed_url,
-              p.link as website_url,
-              p.category1 || ',' || p.category2 as categories,
+              p.imageUrl AS image_url,
+              p.url AS feed_url,
+              p.link AS website_url,
+              p.category1 || ',' || p.category2 AS categories,
               p.language,
               p.explicit,
-              p.itunesType as type,
-              p.episodeCount,
-              p.newestItemPubdate,
-              p.lastUpdate
+              p.itunesType AS type
             FROM podcasts p
             WHERE p.itunesId IN (SELECT itunes_id FROM chart_ids);
           " > podcasts_export.csv
-          echo "[WORKFLOW] Successfully generated 'podcasts_export.csv' with $(wc -l < podcasts_export.csv) lines including headers."
+          echo "Exported $(wc -l < podcasts_export.csv) lines (incl. header)"
 
-      - name: Import to Turso
+      - name: 'Stage 2d: Import podcasts'
+        run: node scripts/sync/02-import-podcasts.js --import
+
+      - name: 'Stage 3: Sync episodes'
+        run: node scripts/sync/03-sync-episodes.js
+
+      - name: 'Stage 4: Vectorize episodes'
         env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-          PODCAST_INDEX_API_KEY: ${{ secrets.PODCAST_INDEX_API_KEY }}
-          PODCAST_INDEX_API_SECRET: ${{ secrets.PODCAST_INDEX_API_SECRET }}
-        run: |
-          echo "[WORKFLOW] Starting import-pi-data.js to load podcasts into Turso DB..."
-          node scripts/import-pi-data.js --country ${{ matrix.country }}
+          MAX_EMBEDDINGS_PER_RUN: ${{ inputs.embedding_budget || '3000' }}
+        run: node scripts/sync/04-vectorize-episodes.js
 
-      - name: Sync Episodes via API
-        env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-          PODCAST_INDEX_API_KEY: ${{ secrets.PODCAST_INDEX_API_KEY }}
-          PODCAST_INDEX_API_SECRET: ${{ secrets.PODCAST_INDEX_API_SECRET }}
-        run: |
-          echo "[WORKFLOW] Starting sync-episodes.js to fetch latest episode details and medium flags from API..."
-          node scripts/sync-episodes.js --country ${{ matrix.country }}
+      - name: 'Stage 5: Vectorize shows'
+        run: node scripts/sync/05-vectorize-shows.js
 
-      - name: Generate Vector Embeddings
-        env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-          QDRANT_URL: ${{ secrets.QDRANT_URL }}
-          QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
-          PODCAST_INDEX_API_KEY: ${{ secrets.PODCAST_INDEX_API_KEY }}
-          PODCAST_INDEX_API_SECRET: ${{ secrets.PODCAST_INDEX_API_SECRET }}
-        run: |
-          echo "[WORKFLOW] Running vectorize.js to calculate and sync embedding vectors to Qdrant Cloud for country ${{ matrix.country }}..."
-          node scripts/vectorize.js --country ${{ matrix.country }}
+      - name: 'Stage 7: Record DB cost stats'
+        if: always()
+        run: node scripts/sync/07-record-stats.js
 
-      - name: Generate Podcast Vector Embeddings
-        env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-          QDRANT_URL: ${{ secrets.QDRANT_URL }}
-          QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
+      - name: Commit pipeline state
+        if: always()
         run: |
-          echo "[WORKFLOW] Running vectorize-podcasts.js to calculate and sync show embedding vectors to Qdrant Cloud for country ${{ matrix.country }}..."
-          node scripts/vectorize-podcasts.js --country ${{ matrix.country }}
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add data/sync_cache.json data/db_cost_history.json data/db_cost_report.md
+          if git diff --cached --quiet; then
+            echo "No state changes to commit"
+            exit 0
+          fi
+          git commit -m "chore(sync): update pipeline state and db stats [skip ci]"
+          for attempt in 1 2 3 4 5; do
+            if git push origin master; then
+              echo "Pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Push failed (attempt ${attempt}) - rebasing and retrying"
+            git pull --rebase origin master
+            sleep 5
+          done
+          echo "::error::Failed to push pipeline state after 5 attempts"
+          exit 1
 
-      - name: Record and Log Database Costs
-        env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-          COUNTRY: ${{ matrix.country }}
-        run: |
-          echo "[WORKFLOW] Recording database read/write counts..."
-          node scripts/record-db-stats.js --country ${{ matrix.country }}
-
-      - name: Commit and push sync cache & stats
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/sync_cache.json data/db_cost_history.json data/db_cost_report.md || true
-          git commit -m "chore: update sync cache and db stats [skip ci]" || true
-          git reset --hard || true
-          git pull --rebase origin master || true
-          git push || true
-
-      - name: Cleanup
-        run: rm -f *.db *.tgz *.csv *.txt
+      - name: Cleanup workspace temp files
+        if: always()
+        run: rm -f *.db *.tgz *.csv missing_itunes_ids.txt
 
   cleanup-non-chart:
-    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 20 * * *'
+    if: github.event.schedule == '0 20 * * *'
+    needs: sync
     runs-on: ubuntu-latest
-    needs: sync-pi-data
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+        with:
+          ref: master
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -224,12 +171,55 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Cleanup Non-Chart Podcasts and Episodes
-        env:
-          TURSO_URL: ${{ secrets.TURSO_URL }}
-          TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
-          QDRANT_URL: ${{ secrets.QDRANT_URL }}
-          QDRANT_API_KEY: ${{ secrets.QDRANT_API_KEY }}
+      - name: 'Stage 6: Cleanup non-chart shows (7-day grace)'
+        run: node scripts/sync/06-cleanup-non-chart.js
+
+      - name: Commit pipeline state
         run: |
-          echo "[WORKFLOW] Cleaning up podcasts and episodes not present in charts..."
-          node scripts/cleanup-non-chart-shows.js
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git pull --rebase origin master
+          git add data/sync_cache.json
+          if git diff --cached --quiet; then
+            echo "No state changes to commit"
+            exit 0
+          fi
+          git commit -m "chore(sync): update cleanup grace state [skip ci]"
+          for attempt in 1 2 3 4 5; do
+            if git push origin master; then
+              echo "Pushed on attempt ${attempt}"
+              exit 0
+            fi
+            echo "Push failed (attempt ${attempt}) - rebasing and retrying"
+            git pull --rebase origin master
+            sleep 5
+          done
+          echo "::error::Failed to push cleanup state after 5 attempts"
+          exit 1
+
+  remediate-qdrant:
+    if: github.event_name == 'workflow_dispatch' && startsWith(inputs.job, 'remediate-qdrant')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run Qdrant remediation
+        run: |
+          if [ "${{ inputs.job }}" = "remediate-qdrant-dry-run" ]; then
+            node scripts/sync/remediate-qdrant.js --dry-run
+          else
+            node scripts/sync/remediate-qdrant.js
+          fi

--- a/scripts/sync/01-refresh-charts.js
+++ b/scripts/sync/01-refresh-charts.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Stage 1: Refresh the Turso charts table from iTunes RSS for all configured
+ * countries. Runs on the 00:00 UTC schedule (or manual dispatch) only.
+ *
+ * - One full charts-table read, diffed in memory (no per-category SELECTs).
+ * - iTunes requests are spaced and retried; a failed fetch for a
+ *   country/category skips BOTH upserts and deletes for that pair (a 403
+ *   throttle must never masquerade as an empty chart and wipe rows).
+ * - Only changed rows are written, in batched transactions.
+ */
+
+const log = require('./lib/log');
+const turso = require('./lib/turso');
+const state = require('./lib/state');
+const cfg = require('./lib/config');
+
+const ITUNES_SPACING_MS = 350;
+const ITUNES_RETRIES = 3;
+
+async function fetchItunesChart(country, category) {
+    const genreParam = category === 'all' ? '' : `/genre=${cfg.GENRE_MAP[category]}`;
+    const url = `https://itunes.apple.com/${country}/rss/toppodcasts${genreParam}/limit=200/json`;
+
+    for (let attempt = 1; attempt <= ITUNES_RETRIES; attempt++) {
+        try {
+            const res = await fetch(url);
+            if (res.status === 403 || res.status === 429) {
+                const backoff = 2000 * Math.pow(2, attempt - 1);
+                log.warn(`iTunes ${res.status} for ${country}/${category}; retrying in ${backoff}ms (attempt ${attempt}/${ITUNES_RETRIES})`);
+                await new Promise(r => setTimeout(r, backoff));
+                continue;
+            }
+            if (!res.ok) throw new Error(`iTunes HTTP ${res.status}`);
+            const data = await res.json();
+            const entries = data.feed?.entry || [];
+            return entries.map(e => ({
+                itunesId: e.id?.attributes?.['im:id'] || '',
+                name: e['im:name']?.label || '',
+                artist: e['im:artist']?.label || '',
+                imageUrl: e['im:image']?.[2]?.label || e['im:image']?.[1]?.label || '',
+            })).filter(p => p.itunesId);
+        } catch (e) {
+            if (attempt === ITUNES_RETRIES) throw e;
+            const backoff = 2000 * Math.pow(2, attempt - 1);
+            log.warn(`iTunes fetch failed for ${country}/${category}: ${e.message}; retrying in ${backoff}ms`);
+            await new Promise(r => setTimeout(r, backoff));
+        }
+    }
+    throw new Error(`iTunes fetch exhausted retries for ${country}/${category}`);
+}
+
+function rowKey(country, category, itunesId) {
+    return `${country}|${category}|${itunesId}`;
+}
+
+async function main() {
+    turso.assertEnv();
+    turso.beginStep('refresh-charts');
+    await turso.healthCheck();
+
+    log.banner('Stage 1 · Refresh Charts', {
+        'Countries': cfg.ALL_COUNTRIES.map(c => c.toUpperCase()).join(', '),
+        'Categories': String(cfg.CATEGORIES.length),
+        'Chart fetches': String(cfg.ALL_COUNTRIES.length * cfg.CATEGORIES.length),
+    });
+
+    // --- Read the entire charts table once and index it ---
+    log.group('Read existing charts');
+    const existingRes = await turso.execute(
+        'SELECT country, category, itunes_id, name, artist, image_url, rank FROM charts'
+    );
+    const existing = new Map();
+    for (const [country, category, itunesId, name, artist, imageUrl, rank] of turso.rows(existingRes)) {
+        existing.set(rowKey(country, category, String(itunesId)), {
+            name: name || '', artist: artist || '', imageUrl: imageUrl || '',
+            rank: parseInt(rank, 10),
+        });
+    }
+    log.info(`Existing chart rows: ${log.fmt(existing.size)}`);
+    log.endGroup();
+
+    // --- Fetch all charts, spaced ---
+    let upserts = 0;
+    let deletes = 0;
+    let unchanged = 0;
+    let failedPairs = 0;
+    const totalPairs = cfg.ALL_COUNTRIES.length * cfg.CATEGORIES.length;
+    const prog = log.progress(totalPairs, 'charts');
+
+    for (const country of cfg.ALL_COUNTRIES) {
+        log.group(`Country: ${country.toUpperCase()}`);
+        for (const category of cfg.CATEGORIES) {
+            await new Promise(r => setTimeout(r, ITUNES_SPACING_MS));
+            let podcasts;
+            try {
+                podcasts = await fetchItunesChart(country, category);
+            } catch (e) {
+                log.warn(`SKIPPING ${country}/${category} entirely (fetch failed: ${e.message}) - no upserts, no deletes`);
+                failedPairs++;
+                prog.tick();
+                continue;
+            }
+            if (podcasts.length === 0) {
+                // Empty response is suspicious (charts are never empty); treat like a failure.
+                log.warn(`SKIPPING ${country}/${category}: iTunes returned 0 entries`);
+                failedPairs++;
+                prog.tick();
+                continue;
+            }
+
+            const statements = [];
+            const activeIds = [];
+            for (let i = 0; i < podcasts.length; i++) {
+                const p = podcasts[i];
+                const rank = i + 1;
+                activeIds.push(String(p.itunesId));
+                const prev = existing.get(rowKey(country, category, String(p.itunesId)));
+                if (prev && prev.rank === rank && prev.name === p.name && prev.artist === p.artist && prev.imageUrl === p.imageUrl) {
+                    unchanged++;
+                    continue;
+                }
+                statements.push({
+                    sql: `INSERT INTO charts (itunes_id, name, artist, image_url, country, category, rank)
+                          VALUES (?, ?, ?, ?, ?, ?, ?)
+                          ON CONFLICT(itunes_id, country, category) DO UPDATE SET
+                              rank = excluded.rank, name = excluded.name,
+                              artist = excluded.artist, image_url = excluded.image_url`,
+                    args: [p.itunesId, p.name, p.artist, p.imageUrl, country, category, rank],
+                });
+            }
+
+            // Delete rows that fell off this chart (safe: fetch succeeded above)
+            const currentSet = new Set(activeIds);
+            let droppedCount = 0;
+            for (const key of existing.keys()) {
+                const [c, cat, id] = key.split('|');
+                if (c === country && cat === category && !currentSet.has(id)) droppedCount++;
+            }
+            if (droppedCount > 0) {
+                const placeholders = activeIds.map(() => '?').join(',');
+                statements.push({
+                    sql: `DELETE FROM charts WHERE country = ? AND category = ? AND itunes_id NOT IN (${placeholders})`,
+                    args: [country, category, ...activeIds],
+                });
+            }
+
+            if (statements.length > 0) {
+                await turso.transaction(statements);
+                upserts += statements.length - (droppedCount > 0 ? 1 : 0);
+                deletes += droppedCount;
+            }
+            prog.tick();
+        }
+        log.endGroup();
+    }
+
+    // Record charts refresh time in state so stage 3 refreshes its candidate cache
+    const st = state.load();
+    st.chartsRefreshedAt = Date.now();
+    state.save(st);
+
+    const stats = turso.getStats();
+    log.costFooter('Stage 1 · Refresh Charts', {
+        reads: stats.reads,
+        writes: stats.writes,
+        apiCalls: totalPairs - failedPairs,
+        detail: `${log.fmt(upserts)} upserted · ${log.fmt(deletes)} dropped · ${log.fmt(unchanged)} unchanged · ${failedPairs} pairs skipped`,
+    });
+    log.summaryTable('Stage 1: Refresh Charts', [{
+        stage: 'refresh-charts',
+        reads: stats.reads,
+        writes: stats.writes,
+        apiCalls: totalPairs - failedPairs,
+        detail: `${upserts} upserts, ${deletes} deletes, ${failedPairs} failed pairs`,
+    }]);
+
+    if (failedPairs > totalPairs / 2) {
+        log.error(`More than half of chart fetches failed (${failedPairs}/${totalPairs}) - failing run`);
+        process.exit(1);
+    }
+}
+
+main()
+    .then(() => turso.flushStats())
+    .catch(err => {
+        log.error(`refresh-charts failed: ${err.message}`);
+        turso.flushStats();
+        process.exit(1);
+    });

--- a/scripts/sync/02-import-podcasts.js
+++ b/scripts/sync/02-import-podcasts.js
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Stage 2: Ensure every chart show exists in the Turso podcasts table.
+ *
+ * Modes:
+ *   --precheck  Compute missing chart shows (union across all countries),
+ *               write missing_itunes_ids.txt for the dump-export step, and
+ *               set GHA outputs need_dump / missing_count.
+ *   --import    If podcasts_export.csv exists (dump path), bulk-import it;
+ *               otherwise fetch missing shows individually from the PI API
+ *               (capped). Fixed column whitelist - NO auto-ALTER.
+ */
+
+const fs = require('fs');
+const log = require('./lib/log');
+const turso = require('./lib/turso');
+const pi = require('./lib/podcast-index');
+const cfg = require('./lib/config');
+
+const MISSING_IDS_FILE = 'missing_itunes_ids.txt';
+const CSV_FILE = 'podcasts_export.csv';
+
+const GENRE_PRIORITY = [
+    'Technology', 'News', 'Business', 'Science', 'Sports', 'True Crime',
+    'History', 'Comedy', 'Arts', 'Fiction', 'Music', 'Religion & Spirituality',
+    'Kids & Family', 'Government', 'Health', 'TV & Film', 'Education',
+];
+
+function sortCategories(rawCats) {
+    if (!rawCats) return rawCats;
+    return rawCats.split(',')
+        .map(c => c.trim())
+        .filter(Boolean)
+        .sort((a, b) => {
+            const ia = GENRE_PRIORITY.indexOf(a);
+            const ib = GENRE_PRIORITY.indexOf(b);
+            if (ia !== -1 && ib !== -1) return ia - ib;
+            if (ia !== -1) return -1;
+            if (ib !== -1) return 1;
+            return a.localeCompare(b);
+        })
+        .join(', ');
+}
+
+function parseCSVLine(line) {
+    const result = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (ch === '"') {
+            if (inQuotes && line[i + 1] === '"') { current += '"'; i++; }
+            else inQuotes = !inQuotes;
+        } else if (ch === ',' && !inQuotes) {
+            result.push(current);
+            current = '';
+        } else {
+            current += ch;
+        }
+    }
+    result.push(current);
+    return result;
+}
+
+/** Missing chart itunes ids (string-normalized set difference). */
+async function computeMissing() {
+    const chartsRes = await turso.execute(
+        'SELECT DISTINCT CAST(itunes_id AS INTEGER) FROM charts WHERE itunes_id IS NOT NULL'
+    );
+    const chartIds = turso.rows(chartsRes).map(r => String(r[0])).filter(Boolean);
+
+    const podsRes = await turso.execute(
+        'SELECT DISTINCT itunes_id FROM podcasts WHERE itunes_id IS NOT NULL'
+    );
+    const existing = new Set(turso.rows(podsRes).map(r => String(r[0])));
+
+    const missing = chartIds.filter(id => !existing.has(id));
+    return { chartIds, missing };
+}
+
+async function precheck() {
+    const { chartIds, missing } = await computeMissing();
+    log.info(`Chart shows (union all countries): ${log.fmt(chartIds.length)}`);
+    log.info(`Missing from podcasts table:       ${log.fmt(missing.length)}`);
+
+    const needDump = missing.length > cfg.DUMP_THRESHOLD;
+    fs.writeFileSync(MISSING_IDS_FILE, missing.join('\n') + (missing.length ? '\n' : ''));
+    log.info(`Decision: need_dump=${needDump} (threshold ${cfg.DUMP_THRESHOLD})`);
+
+    if (process.env.GITHUB_OUTPUT) {
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `need_dump=${needDump}\n`);
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, `missing_count=${missing.length}\n`);
+    }
+}
+
+async function importFromCSV() {
+    const content = fs.readFileSync(CSV_FILE, 'utf-8');
+    const lines = content.split('\n').filter(l => l.trim());
+    if (lines.length < 2) {
+        log.info('CSV contains no data rows - nothing to import');
+        return 0;
+    }
+
+    const headers = parseCSVLine(lines[0]);
+    // Enforce the fixed whitelist: every CSV header must be a known column.
+    const unknown = headers.filter(h => !cfg.PODCAST_IMPORT_COLUMNS.includes(h));
+    if (unknown.length > 0) {
+        throw new Error(`CSV contains non-whitelisted columns: ${unknown.join(', ')} - refusing to import (no auto-ALTER)`);
+    }
+
+    const catIdx = headers.indexOf('categories');
+    const dataLines = lines.slice(1);
+    log.info(`Importing ${log.fmt(dataLines.length)} rows from ${CSV_FILE}`);
+
+    const BATCH = 50;
+    let imported = 0;
+    const prog = log.progress(dataLines.length, 'csv-import');
+
+    for (let i = 0; i < dataLines.length; i += BATCH) {
+        const statements = dataLines.slice(i, i + BATCH).map(line => {
+            const values = parseCSVLine(line);
+            if (catIdx !== -1 && values[catIdx]) {
+                values[catIdx] = sortCategories(values[catIdx]);
+            }
+            const placeholders = headers.map(() => '?').join(',');
+            return {
+                sql: `INSERT OR IGNORE INTO podcasts (${headers.join(',')}) VALUES (${placeholders})`,
+                args: values,
+            };
+        });
+        await turso.batch(statements);
+        imported += statements.length;
+        for (let k = 0; k < statements.length; k++) prog.tick();
+    }
+    return imported;
+}
+
+async function importFromAPI() {
+    pi.assertEnv();
+    const { missing } = await computeMissing();
+    if (missing.length === 0) {
+        log.info('All chart shows already present - nothing to import');
+        return 0;
+    }
+
+    const toImport = missing.slice(0, cfg.API_IMPORT_CAP);
+    if (missing.length > cfg.API_IMPORT_CAP) {
+        log.warn(`${missing.length} shows missing; importing first ${cfg.API_IMPORT_CAP} via API (rest handled by next dump run)`);
+    }
+    log.info(`Fetching ${toImport.length} shows from the PI API`);
+
+    const cols = cfg.PODCAST_IMPORT_COLUMNS;
+    const placeholders = cols.map(() => '?').join(',');
+    let imported = 0;
+    let notFound = 0;
+    const statements = [];
+    const prog = log.progress(toImport.length, 'api-import');
+
+    for (const itunesId of toImport) {
+        let feed = null;
+        try {
+            feed = await pi.podcastByItunesId(itunesId);
+        } catch (e) {
+            log.warn(`PI lookup failed for itunes_id=${itunesId}: ${e.message}`);
+        }
+        prog.tick();
+        if (!feed) { notFound++; continue; }
+
+        const categoriesStr = feed.categories
+            ? sortCategories(Object.values(feed.categories).join(', '))
+            : '';
+        statements.push({
+            sql: `INSERT INTO podcasts (${cols.join(',')}) VALUES (${placeholders})
+                  ON CONFLICT(id) DO UPDATE SET itunes_id = excluded.itunes_id
+                  WHERE itunes_id IS NULL OR itunes_id != excluded.itunes_id`,
+            args: [
+                feed.id,
+                feed.itunesId || itunesId,
+                feed.title || 'Unknown Title',
+                feed.author || 'Unknown Author',
+                (feed.description || '').substring(0, 1000),
+                feed.image || feed.artwork || '',
+                feed.url || '',
+                feed.link || '',
+                categoriesStr,
+                feed.language || 'en',
+                feed.explicit ? '1' : '0',
+                feed.itunesType || 'episodic',
+            ],
+        });
+        imported++;
+
+        if (statements.length >= 50) {
+            await turso.batch(statements.splice(0));
+        }
+    }
+    if (statements.length > 0) await turso.batch(statements);
+
+    log.info(`API import done: ${imported} imported, ${notFound} not found on PI`);
+    return imported;
+}
+
+async function main() {
+    turso.assertEnv();
+    turso.beginStep('import-podcasts');
+    await turso.healthCheck();
+
+    if (process.argv.includes('--precheck')) {
+        log.banner('Stage 2a · Pre-check Missing Shows', {
+            'Dump threshold': String(cfg.DUMP_THRESHOLD),
+        });
+        await precheck();
+        return;
+    }
+
+    let imported = 0;
+    let mode;
+    if (fs.existsSync(CSV_FILE)) {
+        mode = 'dump';
+        log.banner('Stage 2 · Import Podcasts', { 'Mode': 'bulk (PI dump CSV)' });
+        log.group('Bulk import from PI dump CSV');
+        imported = await importFromCSV();
+        log.endGroup();
+    } else {
+        mode = 'api';
+        log.banner('Stage 2 · Import Podcasts', {
+            'Mode': 'incremental (PI API)',
+            'Per-run cap': String(cfg.API_IMPORT_CAP),
+        });
+        log.group('Incremental import via PI API');
+        imported = await importFromAPI();
+        log.endGroup();
+    }
+
+    const stats = turso.getStats();
+    log.costFooter('Stage 2 · Import Podcasts', {
+        reads: stats.reads,
+        writes: stats.writes,
+        apiCalls: pi.getApiCallCount(),
+        detail: `${log.fmt(imported)} shows imported (${mode})`,
+    });
+    log.summaryTable('Stage 2: Import Podcasts', [{
+        stage: `import-podcasts (${mode})`,
+        reads: stats.reads,
+        writes: stats.writes,
+        apiCalls: pi.getApiCallCount(),
+        detail: `${imported} shows imported`,
+    }]);
+}
+
+main()
+    .then(() => turso.flushStats())
+    .catch(err => {
+        log.error(`import-podcasts failed: ${err.message}`);
+        turso.flushStats();
+        process.exit(1);
+    });

--- a/scripts/sync/03-sync-episodes.js
+++ b/scripts/sync/03-sync-episodes.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Stage 3: Sync latest-episode metadata for chart shows from the PI API.
+ *
+ * - Candidate list (id, latest_ep_id, categories, medium) is cached in the
+ *   git state file and re-queried from Turso only after a charts refresh or
+ *   when older than 20h - the other runs cost near-zero Turso reads.
+ * - Staleness gating: News shows re-checked after 8h, others after 24h.
+ * - Latest-episode-unchanged shows cost 0 Turso writes (state-only update).
+ * - New episodes write latest_ep_* + qdrant_vectorized=0 (feeds stage 4).
+ */
+
+const log = require('./lib/log');
+const turso = require('./lib/turso');
+const pi = require('./lib/podcast-index');
+const state = require('./lib/state');
+const text = require('./lib/text');
+const cfg = require('./lib/config');
+
+const CANDIDATE_CACHE_MAX_AGE_MS = 20 * 60 * 60 * 1000;
+const CONCURRENCY = 5;
+
+/** Refresh candidate cache from Turso and seed state records. */
+async function refreshCandidates(st) {
+    log.info('[CANDIDATES] Refreshing candidate list from Turso');
+    const res = await turso.execute(`
+        SELECT p.id, p.latest_ep_id, p.categories, p.medium
+        FROM podcasts p
+        WHERE p.itunes_id IN (SELECT DISTINCT CAST(itunes_id AS INTEGER) FROM charts WHERE itunes_id IS NOT NULL)
+    `);
+    const ids = [];
+    for (const [id, latestEpId, categories, medium] of turso.rows(res)) {
+        const podId = String(id);
+        ids.push(podId);
+        const rec = st.shows[podId] || {};
+        // Seed from DB only when state doesn't know these yet (state is the
+        // authority afterwards, since this pipeline is the only writer).
+        if (rec.e === undefined && latestEpId) rec.e = String(latestEpId);
+        // Compact flag: store n:1 for News shows instead of the category string
+        if ((categories || '').includes('News')) rec.n = 1; else delete rec.n;
+        if (rec.m === undefined && medium) rec.m = medium;
+        st.shows[podId] = rec;
+    }
+    st.candidateIds = ids;
+    st.candidatesRefreshedAt = Date.now();
+    log.info(`[CANDIDATES] ${log.fmt(ids.length)} chart shows cached`);
+}
+
+async function main() {
+    turso.assertEnv();
+    pi.assertEnv();
+    turso.beginStep('sync-episodes');
+    await turso.healthCheck();
+
+    const st = state.load();
+
+    log.banner('Stage 3 · Sync Episodes', {
+        'Staleness tiers': 'News 8h · Regular 24h (±10% jitter)',
+        'Per-run check cap': log.fmt(cfg.MAX_CHECKS_PER_RUN),
+        'Concurrency': String(CONCURRENCY),
+    });
+
+    // --- Candidate cache: refresh only when stale or after charts refresh ---
+    const cacheAge = Date.now() - (st.candidatesRefreshedAt || 0);
+    const chartsNewerThanCache = (st.chartsRefreshedAt || 0) > (st.candidatesRefreshedAt || 0);
+    if (!st.candidateIds || chartsNewerThanCache || cacheAge > CANDIDATE_CACHE_MAX_AGE_MS) {
+        await refreshCandidates(st);
+    } else {
+        log.info(`[CANDIDATES] Using cached list (${log.fmt(st.candidateIds.length)} shows, age ${Math.round(cacheAge / 3600000)}h) - 0 Turso reads`);
+    }
+
+    // --- Staleness gating ---
+    // Deterministic per-show jitter (+/-STALENESS_JITTER) spreads check times
+    // so the fleet doesn't re-synchronize into one giant wave per day.
+    const jitterFactor = (id) => {
+        let h = 0;
+        for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+        return 1 + ((h % 1000) / 1000 - 0.5) * 2 * cfg.STALENESS_JITTER;
+    };
+
+    const now = Date.now();
+    let neverChecked = 0, staleNews = 0, staleRegular = 0;
+    const allDue = st.candidateIds.filter(id => {
+        const rec = st.shows[id] || {};
+        if (!rec.c) { neverChecked++; return true; }
+        const isNews = rec.n === 1;
+        const threshold = (isNews ? cfg.NEWS_STALE_MS : cfg.REGULAR_STALE_MS) * jitterFactor(id);
+        if (now - rec.c >= threshold) {
+            if (isNews) staleNews++; else staleRegular++;
+            return true;
+        }
+        return false;
+    });
+    // Oldest checks first, then cap per run: deferred shows lead the queue
+    // next run, so backlogs self-distribute across the 5 daily runs.
+    allDue.sort((a, b) => (st.shows[a]?.c || 0) - (st.shows[b]?.c || 0));
+    const due = allDue.slice(0, cfg.MAX_CHECKS_PER_RUN);
+    const deferred = allDue.length - due.length;
+
+    log.group('Sync plan');
+    log.info(`Chart shows:        ${log.fmt(st.candidateIds.length)}`);
+    log.info(`Due for check:      ${log.fmt(allDue.length)}`);
+    log.info(`Checking this run:  ${log.fmt(due.length)} (cap ${log.fmt(cfg.MAX_CHECKS_PER_RUN)}, ${log.fmt(deferred)} deferred to next run)`);
+    log.info(`- never checked:    ${log.fmt(neverChecked)}`);
+    log.info(`- stale news (8h):  ${log.fmt(staleNews)}`);
+    log.info(`- stale other (24h):${log.fmt(staleRegular)}`);
+    log.endGroup();
+
+    // --- Process ---
+    let updated = 0, unchanged = 0, empty = 0, errors = 0;
+    const prog = log.progress(due.length, 'episode-sync', 5);
+
+    for (let i = 0; i < due.length; i += CONCURRENCY) {
+        const batch = due.slice(i, i + CONCURRENCY);
+        await Promise.all(batch.map(async (podId) => {
+            const rec = st.shows[podId] || {};
+            try {
+                const episodes = await pi.episodesByFeedId(podId, 1);
+                if (episodes.length === 0) {
+                    empty++;
+                    state.recordCheck(st, podId);
+                    return;
+                }
+                const latest = episodes[0];
+
+                if (rec.e && String(latest.id) === String(rec.e)) {
+                    unchanged++;
+                    state.recordCheck(st, podId);
+                    return;
+                }
+
+                // New/changed episode: resolve medium if unknown, then write.
+                let medium = rec.m;
+                if (!medium) {
+                    try {
+                        const feed = await pi.podcastByFeedId(podId);
+                        medium = feed?.medium || 'podcast';
+                    } catch {
+                        medium = 'podcast';
+                    }
+                }
+
+                await turso.execute(`
+                    UPDATE podcasts SET
+                        latest_ep_id = ?, latest_ep_title = ?, latest_ep_date = ?,
+                        latest_ep_duration = ?, latest_ep_url = ?, latest_ep_image = ?,
+                        latest_ep_type = ?, latest_ep_description = ?,
+                        latest_ep_chapters_url = ?, latest_ep_transcript_url = ?,
+                        latest_ep_persons = ?, latest_ep_transcripts = ?,
+                        medium = ?, last_ep_sync = ?, qdrant_vectorized = 0
+                    WHERE id = ?
+                `, [
+                    String(latest.id),
+                    latest.title || '',
+                    latest.datePublished || 0,
+                    latest.duration || 0,
+                    latest.enclosureUrl || '',
+                    latest.image || latest.feedImage || '',
+                    latest.enclosureType || 'audio/mpeg',
+                    text.cleanDescription(latest.description),
+                    latest.chaptersUrl || null,
+                    latest.transcriptUrl || null,
+                    latest.persons ? JSON.stringify(latest.persons) : null,
+                    latest.transcripts ? JSON.stringify(latest.transcripts) : null,
+                    medium,
+                    Date.now(),
+                    podId,
+                ]);
+                updated++;
+                state.recordCheck(st, podId, { latestEpId: latest.id }).m = medium;
+            } catch (e) {
+                errors++;
+                log.warn(`Show ${podId}: ${e.message}`);
+                // No recordCheck on error -> retried next run
+            }
+        }));
+        for (let k = 0; k < batch.length; k++) prog.tick(`new ${updated} / same ${unchanged}`);
+        turso.flushStats();
+        state.save(st);
+    }
+
+    state.save(st);
+    const stats = turso.getStats();
+    log.costFooter('Stage 3 · Sync Episodes', {
+        reads: stats.reads,
+        writes: stats.writes,
+        apiCalls: pi.getApiCallCount(),
+        detail: `${log.fmt(due.length)} checked (${log.fmt(deferred)} deferred) · ${updated} new · ${unchanged} unchanged · ${empty} empty · ${errors} errors`,
+    });
+    log.summaryTable('Stage 3: Sync Episodes', [{
+        stage: 'sync-episodes',
+        reads: stats.reads,
+        writes: stats.writes,
+        apiCalls: pi.getApiCallCount(),
+        detail: `${due.length} checked (${deferred} deferred): ${updated} new, ${unchanged} unchanged, ${empty} empty, ${errors} errors`,
+    }]);
+
+    // Fail loudly when the API is systematically failing (not on scattered errors)
+    if (due.length > 20 && errors > due.length / 2) {
+        log.error(`More than half of episode checks failed (${errors}/${due.length})`);
+        process.exit(1);
+    }
+}
+
+main()
+    .then(() => turso.flushStats())
+    .catch(err => {
+        log.error(`sync-episodes failed: ${err.message}`);
+        turso.flushStats();
+        process.exit(1);
+    });

--- a/scripts/sync/04-vectorize-episodes.js
+++ b/scripts/sync/04-vectorize-episodes.js
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Stage 4: Generate episode embeddings for pending full-tier chart shows and
+ * upsert to the Qdrant 'episodes' collection.
+ *
+ * Bounded by MAX_EMBEDDINGS_PER_RUN (a budget of new vectors, NOT a show
+ * count): incremental shows (1-2 new eps) always flow through; leftover
+ * budget drains cold-start/backlog shows (up to EPISODES_PER_SHOW each),
+ * oldest-first. Prune-before-insert keeps every show at strictly the latest
+ * EPISODES_PER_SHOW points. Upserts use wait=true so qdrant_vectorized=1 is
+ * only set after vectors are durable.
+ */
+
+const log = require('./lib/log');
+const turso = require('./lib/turso');
+const qdrant = require('./lib/qdrant');
+const pi = require('./lib/podcast-index');
+const embedder = require('./lib/embedder');
+const text = require('./lib/text');
+const cfg = require('./lib/config');
+
+const UPSERT_BATCH = 100;
+
+async function ensureIndexes() {
+    await turso.execute(`CREATE INDEX IF NOT EXISTS idx_podcasts_pending_ep_vec
+                         ON podcasts(qdrant_vectorized) WHERE qdrant_vectorized = 0`);
+}
+
+async function main() {
+    turso.assertEnv();
+    qdrant.assertEnv();
+    pi.assertEnv();
+    turso.beginStep('vectorize-episodes');
+    await turso.healthCheck();
+    await ensureIndexes();
+    await qdrant.ensureCollection(cfg.EPISODES_COLLECTION, cfg.VECTOR_DIM);
+
+    if (cfg.FULL_TIER_COUNTRIES.length === 0) {
+        log.info('No full-tier countries configured - nothing to vectorize');
+        return;
+    }
+
+    // --- Pending shows (oldest flagged first) ---
+    const countryPlaceholders = cfg.FULL_TIER_COUNTRIES.map(() => '?').join(',');
+    const res = await turso.execute(`
+        SELECT p.id, p.title, p.categories, p.author, p.image_url, p.language
+        FROM podcasts p
+        WHERE (p.qdrant_vectorized = 0 OR p.qdrant_vectorized IS NULL)
+          AND p.itunes_id IN (
+              SELECT DISTINCT CAST(itunes_id AS INTEGER) FROM charts WHERE country IN (${countryPlaceholders})
+          )
+        ORDER BY (p.last_ep_sync IS NULL) DESC, p.last_ep_sync ASC
+    `, cfg.FULL_TIER_COUNTRIES);
+
+    const pending = turso.rows(res).map(r => ({
+        id: String(r[0]),
+        title: r[1] || 'Unknown Show',
+        categories: r[2] || 'Podcast',
+        author: r[3] || '',
+        image_url: r[4] || '',
+        language: r[5] || 'en',
+    }));
+    log.banner('Stage 4 · Vectorize Episodes', {
+        'Pending shows': log.fmt(pending.length),
+        'Embedding budget': log.fmt(cfg.MAX_EMBEDDINGS_PER_RUN),
+        'Episodes per show': String(cfg.EPISODES_PER_SHOW),
+        'Collection': cfg.EPISODES_COLLECTION,
+    });
+    if (pending.length === 0) {
+        log.summaryTable('Stage 4: Vectorize Episodes', [{
+            stage: 'vectorize-episodes', reads: turso.getStats().reads,
+            writes: turso.getStats().writes, detail: 'queue empty',
+        }]);
+        return;
+    }
+
+    let budget = cfg.MAX_EMBEDDINGS_PER_RUN;
+    let embedded = 0;
+    let showsCompleted = 0;
+    let showsSkippedExisting = 0;
+    let errors = 0;
+    let processedCount = 0;
+
+    // Points buffered for batch upsert; flag updates follow durable writes.
+    let pointsQueue = [];
+    let flagQueue = [];
+
+    async function flush() {
+        if (pointsQueue.length > 0) {
+            await qdrant.upsert(cfg.EPISODES_COLLECTION, pointsQueue);
+            pointsQueue = [];
+        }
+        if (flagQueue.length > 0) {
+            const placeholders = flagQueue.map(() => '?').join(',');
+            await turso.execute(
+                `UPDATE podcasts SET qdrant_vectorized = 1 WHERE id IN (${placeholders})`,
+                flagQueue
+            );
+            flagQueue = [];
+        }
+        turso.flushStats();
+    }
+
+    const prog = log.progress(pending.length, 'vectorize', 5);
+
+    for (const pod of pending) {
+        if (budget <= 0) {
+            log.info(`[BUDGET] Embedding budget exhausted (${embedded}/${cfg.MAX_EMBEDDINGS_PER_RUN}). Remaining backlog: ${pending.length - processedCount} shows`);
+            break;
+        }
+        processedCount++;
+
+        let episodes;
+        try {
+            episodes = await pi.episodesByFeedId(pod.id, cfg.EPISODES_PER_SHOW);
+        } catch (e) {
+            errors++;
+            log.warn(`Show ${pod.id} (${pod.title.substring(0, 40)}): episode fetch failed: ${e.message}`);
+            prog.tick();
+            continue;
+        }
+
+        if (episodes.length === 0) {
+            flagQueue.push(pod.id);
+            showsCompleted++;
+            prog.tick();
+            continue;
+        }
+
+        const eps = episodes.slice(0, cfg.EPISODES_PER_SHOW).map(ep => ({
+            raw: ep,
+            uuid: qdrant.stableUUID(ep.id),
+        }));
+        const uuids = eps.map(e => e.uuid);
+
+        // Prune BEFORE insert: drop any points for this show outside its latest set.
+        try {
+            await qdrant.deleteByFilter(cfg.EPISODES_COLLECTION, {
+                must: [{ key: 'podcast_id', match: { value: parseInt(pod.id, 10) || 0 } }],
+                must_not: [{ has_id: uuids }],
+            });
+        } catch (e) {
+            log.warn(`Prune failed for show ${pod.id}: ${e.message}`);
+        }
+
+        const existing = await qdrant.existingIds(cfg.EPISODES_COLLECTION, uuids);
+        const toEmbed = eps.filter(e => !existing.has(e.uuid));
+        showsSkippedExisting += existing.size;
+
+        if (toEmbed.length === 0) {
+            flagQueue.push(pod.id);
+            showsCompleted++;
+            prog.tick();
+            continue;
+        }
+
+        let showFailed = false;
+        const showPoints = [];
+        for (const item of toEmbed) {
+            const ep = item.raw;
+            const cleaned = text.cleanDescription(ep.description || '');
+            const embedText = text.episodeEmbedText({ title: ep.title, cleanedDescription: cleaned }, pod);
+            try {
+                const vector = await embedder.embed(embedText);
+                showPoints.push({
+                    id: item.uuid,
+                    vector,
+                    payload: {
+                        id: parseInt(ep.id, 10) || 0,
+                        title: ep.title || '',
+                        description: (ep.description || '').substring(0, cfg.PAYLOAD_DESCRIPTION_MAX),
+                        podcast_id: parseInt(pod.id, 10) || 0,
+                        podcast_title: pod.title,
+                        podcast_author: pod.author,
+                        podcast_image_url: pod.image_url,
+                        podcast_categories: pod.categories,
+                        language: pod.language,
+                        audio_url: ep.enclosureUrl || '',
+                        image_url: ep.image || ep.feedImage || pod.image_url || '',
+                        published_date: ep.datePublished || 0,
+                        duration: ep.duration || 0,
+                    },
+                });
+            } catch (e) {
+                errors++;
+                showFailed = true;
+                log.warn(`Embedding failed for "${(ep.title || '').substring(0, 40)}" (show ${pod.id}): ${e.message}`);
+            }
+        }
+
+        embedded += showPoints.length;
+        budget -= showPoints.length;
+        pointsQueue.push(...showPoints);
+        if (!showFailed) {
+            flagQueue.push(pod.id);
+            showsCompleted++;
+        }
+
+        if (pointsQueue.length >= UPSERT_BATCH) {
+            try {
+                await flush();
+            } catch (e) {
+                errors += pointsQueue.length;
+                log.error(`Qdrant upsert batch failed: ${e.message}`);
+                pointsQueue = [];
+                flagQueue = [];
+            }
+        }
+        prog.tick(`embedded ${embedded}/${cfg.MAX_EMBEDDINGS_PER_RUN}`);
+    }
+
+    try {
+        await flush();
+    } catch (e) {
+        errors += pointsQueue.length;
+        log.error(`Final Qdrant flush failed: ${e.message}`);
+    }
+
+    const backlog = pending.length - processedCount;
+    const stats = turso.getStats();
+    log.costFooter('Stage 4 · Vectorize Episodes', {
+        reads: stats.reads,
+        writes: stats.writes,
+        apiCalls: pi.getApiCallCount(),
+        detail: `${log.fmt(embedded)}/${log.fmt(cfg.MAX_EMBEDDINGS_PER_RUN)} budget used · ${showsCompleted} shows done · ${log.fmt(showsSkippedExisting)} already existed · backlog ${log.fmt(backlog)} · ${errors} errors`,
+    });
+    log.summaryTable('Stage 4: Vectorize Episodes', [{
+        stage: 'vectorize-episodes',
+        reads: stats.reads,
+        writes: stats.writes,
+        apiCalls: pi.getApiCallCount(),
+        detail: `${embedded}/${cfg.MAX_EMBEDDINGS_PER_RUN} budget used, ${showsCompleted} shows done, backlog ${backlog}, ${errors} errors`,
+    }]);
+
+    if (processedCount > 20 && errors > processedCount) {
+        log.error('Error count exceeds processed shows - failing run for visibility');
+        process.exit(1);
+    }
+}
+
+main()
+    .then(() => turso.flushStats())
+    .catch(err => {
+        log.error(`vectorize-episodes failed: ${err.message}`);
+        turso.flushStats();
+        process.exit(1);
+    });

--- a/scripts/sync/05-vectorize-shows.js
+++ b/scripts/sync/05-vectorize-shows.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Stage 5: Generate show-level embeddings for pending full-tier chart shows
+ * and upsert to the Qdrant 'podcasts' collection (1 vector per show).
+ * Shares the embedding budget philosophy of stage 4 (1 embedding per show,
+ * so this stage drains fast and cheap). wait=true before flag flips.
+ */
+
+const log = require('./lib/log');
+const turso = require('./lib/turso');
+const qdrant = require('./lib/qdrant');
+const embedder = require('./lib/embedder');
+const text = require('./lib/text');
+const cfg = require('./lib/config');
+
+const UPSERT_BATCH = 100;
+
+async function ensureIndexes() {
+    await turso.execute(`CREATE INDEX IF NOT EXISTS idx_podcasts_pending_show_vec
+                         ON podcasts(qdrant_podcast_vectorized) WHERE qdrant_podcast_vectorized = 0`);
+}
+
+async function main() {
+    turso.assertEnv();
+    qdrant.assertEnv();
+    turso.beginStep('vectorize-shows');
+    await turso.healthCheck();
+    await ensureIndexes();
+    await qdrant.ensureCollection(cfg.PODCASTS_COLLECTION, cfg.VECTOR_DIM);
+
+    if (cfg.FULL_TIER_COUNTRIES.length === 0) {
+        log.info('No full-tier countries configured - nothing to vectorize');
+        return;
+    }
+
+    const countryPlaceholders = cfg.FULL_TIER_COUNTRIES.map(() => '?').join(',');
+    const res = await turso.execute(`
+        SELECT p.id, p.title, p.categories, p.author, p.image_url, p.language,
+               p.description, p.feed_url, p.website_url
+        FROM podcasts p
+        WHERE (p.qdrant_podcast_vectorized = 0 OR p.qdrant_podcast_vectorized IS NULL)
+          AND p.itunes_id IN (
+              SELECT DISTINCT CAST(itunes_id AS INTEGER) FROM charts WHERE country IN (${countryPlaceholders})
+          )
+    `, cfg.FULL_TIER_COUNTRIES);
+
+    const pending = turso.rows(res).map(r => ({
+        id: String(r[0]),
+        title: r[1] || 'Unknown Show',
+        categories: r[2] || 'Podcast',
+        author: r[3] || '',
+        image_url: r[4] || '',
+        language: r[5] || 'en',
+        description: r[6] || '',
+        feed_url: r[7] || '',
+        website_url: r[8] || '',
+    }));
+    log.banner('Stage 5 · Vectorize Shows', {
+        'Pending shows': log.fmt(pending.length),
+        'Embedding budget': log.fmt(cfg.MAX_EMBEDDINGS_PER_RUN),
+        'Collection': cfg.PODCASTS_COLLECTION,
+    });
+    if (pending.length === 0) {
+        log.summaryTable('Stage 5: Vectorize Shows', [{
+            stage: 'vectorize-shows', reads: turso.getStats().reads,
+            writes: turso.getStats().writes, detail: 'queue empty',
+        }]);
+        return;
+    }
+
+    // Existence check: shows already in Qdrant just need their flag set.
+    const withUuid = pending.map(pod => ({ pod, uuid: qdrant.stableUUID(pod.id) }));
+    const existing = await qdrant.existingIds(cfg.PODCASTS_COLLECTION, withUuid.map(w => w.uuid));
+    const alreadyIndexed = withUuid.filter(w => existing.has(w.uuid));
+    const toEmbed = withUuid.filter(w => !existing.has(w.uuid));
+
+    if (alreadyIndexed.length > 0) {
+        const CHUNK = 100;
+        for (let i = 0; i < alreadyIndexed.length; i += CHUNK) {
+            const ids = alreadyIndexed.slice(i, i + CHUNK).map(w => w.pod.id);
+            const placeholders = ids.map(() => '?').join(',');
+            await turso.execute(
+                `UPDATE podcasts SET qdrant_podcast_vectorized = 1 WHERE id IN (${placeholders})`,
+                ids
+            );
+        }
+        log.info(`${alreadyIndexed.length} shows already indexed - flags set`);
+    }
+
+    // Cap embeds by the shared budget (1 embedding per show).
+    const budgeted = toEmbed.slice(0, cfg.MAX_EMBEDDINGS_PER_RUN);
+    let embedded = 0;
+    let errors = 0;
+    let pointsQueue = [];
+    let flagQueue = [];
+
+    async function flush() {
+        if (pointsQueue.length > 0) {
+            await qdrant.upsert(cfg.PODCASTS_COLLECTION, pointsQueue);
+            pointsQueue = [];
+        }
+        if (flagQueue.length > 0) {
+            const placeholders = flagQueue.map(() => '?').join(',');
+            await turso.execute(
+                `UPDATE podcasts SET qdrant_podcast_vectorized = 1 WHERE id IN (${placeholders})`,
+                flagQueue
+            );
+            flagQueue = [];
+        }
+        turso.flushStats();
+    }
+
+    const prog = log.progress(budgeted.length, 'show-vectorize', 5);
+    for (const { pod, uuid } of budgeted) {
+        try {
+            const vector = await embedder.embed(text.podcastEmbedText(pod));
+            pointsQueue.push({
+                id: uuid,
+                vector,
+                payload: {
+                    id: parseInt(pod.id, 10) || 0,
+                    title: pod.title,
+                    author: pod.author,
+                    description: (pod.description || '').substring(0, cfg.PAYLOAD_DESCRIPTION_MAX),
+                    image_url: pod.image_url,
+                    categories: pod.categories,
+                    language: pod.language,
+                    feed_url: pod.feed_url,
+                    website_url: pod.website_url,
+                },
+            });
+            flagQueue.push(pod.id);
+            embedded++;
+        } catch (e) {
+            errors++;
+            log.warn(`Show embedding failed for "${pod.title.substring(0, 40)}" (${pod.id}): ${e.message}`);
+        }
+
+        if (pointsQueue.length >= UPSERT_BATCH) {
+            try {
+                await flush();
+            } catch (e) {
+                errors += pointsQueue.length;
+                log.error(`Qdrant upsert batch failed: ${e.message}`);
+                pointsQueue = [];
+                flagQueue = [];
+            }
+        }
+        prog.tick();
+    }
+
+    try {
+        await flush();
+    } catch (e) {
+        errors += pointsQueue.length;
+        log.error(`Final Qdrant flush failed: ${e.message}`);
+    }
+
+    const backlog = toEmbed.length - budgeted.length;
+    const stats = turso.getStats();
+    log.costFooter('Stage 5 · Vectorize Shows', {
+        reads: stats.reads,
+        writes: stats.writes,
+        detail: `${log.fmt(embedded)} embedded · ${log.fmt(alreadyIndexed.length)} already indexed · backlog ${log.fmt(backlog)} · ${errors} errors`,
+    });
+    log.summaryTable('Stage 5: Vectorize Shows', [{
+        stage: 'vectorize-shows',
+        reads: stats.reads,
+        writes: stats.writes,
+        detail: `${embedded} embedded, ${alreadyIndexed.length} pre-existing, backlog ${backlog}, ${errors} errors`,
+    }]);
+}
+
+main()
+    .then(() => turso.flushStats())
+    .catch(err => {
+        log.error(`vectorize-shows failed: ${err.message}`);
+        turso.flushStats();
+        process.exit(1);
+    });

--- a/scripts/sync/06-cleanup-non-chart.js
+++ b/scripts/sync/06-cleanup-non-chart.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Stage 6 (20:00 run only): Delete shows that have been absent from ALL
+ * country charts for CLEANUP_GRACE_DAYS consecutive days.
+ *
+ * Grace period prevents delete/re-vectorize thrash: a show dipping out of
+ * the top 200 for a day keeps its Turso row and Qdrant vectors; only
+ * sustained absence triggers deletion. Last-seen timestamps live in the git
+ * state file (shows[id].s) - zero Turso cost.
+ *
+ * FTS safety: the podcasts_ad delete trigger does a full FTS-content scan
+ * PER ROW, so we drop it, bulk-delete, clean FTS orphans in one scan, and
+ * recreate it.
+ */
+
+const log = require('./lib/log');
+const turso = require('./lib/turso');
+const qdrant = require('./lib/qdrant');
+const state = require('./lib/state');
+const cfg = require('./lib/config');
+
+const QDRANT_CHUNK = 500;
+const DELETE_CHUNK = 200;
+
+async function main() {
+    turso.assertEnv();
+    qdrant.assertEnv();
+    turso.beginStep('cleanup-non-chart');
+    await turso.healthCheck();
+
+    log.banner('Stage 6 · Cleanup Non-chart Shows', {
+        'Grace period': `${cfg.CLEANUP_GRACE_DAYS} days`,
+        'Safety floor': `${log.fmt(cfg.CLEANUP_SAFETY_MIN_CHARTS)} chart shows`,
+    });
+
+    // --- Safety: charts must look healthy ---
+    const chartCountRes = await turso.execute(
+        'SELECT COUNT(DISTINCT itunes_id) FROM charts WHERE itunes_id IS NOT NULL'
+    );
+    const activeChartCount = parseInt(turso.scalar(chartCountRes), 10) || 0;
+    log.info(`Active chart shows: ${log.fmt(activeChartCount)}`);
+    if (activeChartCount < cfg.CLEANUP_SAFETY_MIN_CHARTS) {
+        log.error(`Safety abort: chart count ${activeChartCount} < ${cfg.CLEANUP_SAFETY_MIN_CHARTS} - charts table may be broken`);
+        process.exit(1);
+    }
+
+    // --- Compute chart membership + grace clock ---
+    const chartSetRes = await turso.execute(
+        'SELECT DISTINCT CAST(itunes_id AS INTEGER) FROM charts WHERE itunes_id IS NOT NULL'
+    );
+    const chartItunesIds = new Set(turso.rows(chartSetRes).map(r => String(r[0])));
+
+    const podsRes = await turso.execute('SELECT id, itunes_id, title FROM podcasts');
+    const allPods = turso.rows(podsRes).map(r => ({
+        id: String(r[0]),
+        itunesId: r[1] !== null ? String(r[1]) : null,
+        title: r[2] || 'Unknown',
+    }));
+    log.info(`Podcasts in DB: ${log.fmt(allPods.length)}`);
+
+    const st = state.load();
+    const now = Date.now();
+    const graceMs = cfg.CLEANUP_GRACE_DAYS * 24 * 60 * 60 * 1000;
+    const toDelete = [];
+    let inCharts = 0;
+    let inGrace = 0;
+
+    for (const pod of allPods) {
+        const rec = st.shows[pod.id] || (st.shows[pod.id] = {});
+        if (pod.itunesId && chartItunesIds.has(pod.itunesId)) {
+            rec.s = now;
+            inCharts++;
+        } else if (!rec.s) {
+            rec.s = now; // start the grace clock
+            inGrace++;
+        } else if (now - rec.s > graceMs) {
+            toDelete.push(pod);
+        } else {
+            inGrace++;
+        }
+    }
+
+    log.group('Cleanup plan');
+    log.info(`In charts:                ${log.fmt(inCharts)}`);
+    log.info(`In grace period (<${cfg.CLEANUP_GRACE_DAYS}d):   ${log.fmt(inGrace)}`);
+    log.info(`Past grace - deleting:    ${log.fmt(toDelete.length)}`);
+    log.endGroup();
+
+    if (toDelete.length === 0) {
+        state.save(st);
+        log.info('Nothing past the grace period - done');
+        log.summaryTable('Stage 6: Cleanup', [{
+            stage: 'cleanup-non-chart',
+            reads: turso.getStats().reads,
+            writes: turso.getStats().writes,
+            detail: `0 deleted, ${inGrace} in grace`,
+        }]);
+        return;
+    }
+
+    // --- Qdrant deletion first (needs the id list) ---
+    log.group('Qdrant vector deletion');
+    for (let i = 0; i < toDelete.length; i += QDRANT_CHUNK) {
+        const chunk = toDelete.slice(i, i + QDRANT_CHUNK);
+        const intIds = chunk.map(p => parseInt(p.id, 10)).filter(n => !isNaN(n));
+        const uuids = chunk.map(p => qdrant.stableUUID(p.id));
+        try {
+            await qdrant.deleteByFilter(cfg.EPISODES_COLLECTION, {
+                must: [{ key: 'podcast_id', match: { any: intIds } }],
+            });
+            await qdrant.deleteByIds(cfg.PODCASTS_COLLECTION, uuids);
+            log.info(`Deleted vectors for shows ${i + 1}-${Math.min(i + QDRANT_CHUNK, toDelete.length)} of ${toDelete.length}`);
+        } catch (e) {
+            log.error(`Qdrant deletion failed for chunk at ${i}: ${e.message}`);
+        }
+    }
+    log.endGroup();
+
+    // --- Turso deletion with trigger workaround ---
+    log.group('Turso deletion');
+    try {
+        log.info('Dropping podcasts_ad trigger (prevents per-row FTS scans)');
+        await turso.execute('DROP TRIGGER IF EXISTS podcasts_ad');
+
+        const ids = toDelete.map(p => p.id);
+        for (let i = 0; i < ids.length; i += DELETE_CHUNK) {
+            const chunk = ids.slice(i, i + DELETE_CHUNK);
+            const placeholders = chunk.map(() => '?').join(',');
+            await turso.execute(`DELETE FROM podcasts WHERE id IN (${placeholders})`, chunk);
+        }
+        log.info(`Deleted ${log.fmt(ids.length)} podcast rows`);
+
+        log.info('Cleaning FTS orphans (single scan)');
+        await turso.execute('DELETE FROM podcasts_fts WHERE podcast_id NOT IN (SELECT id FROM podcasts)');
+    } finally {
+        // Always restore the trigger, even if deletion failed midway.
+        await turso.execute(`
+            CREATE TRIGGER IF NOT EXISTS podcasts_ad AFTER DELETE ON podcasts BEGIN
+                DELETE FROM podcasts_fts WHERE podcast_id = old.id;
+            END
+        `);
+        log.info('podcasts_ad trigger restored');
+    }
+    log.endGroup();
+
+    // --- Prune state for deleted shows ---
+    const deletedIds = new Set(toDelete.map(p => p.id));
+    const keepIds = allPods.filter(p => !deletedIds.has(p.id)).map(p => p.id);
+    const pruned = state.pruneShows(st, keepIds);
+    if (st.candidateIds) {
+        st.candidateIds = st.candidateIds.filter(id => !deletedIds.has(id));
+    }
+    state.save(st);
+    log.info(`State pruned: ${pruned} dead entries removed`);
+
+    const stats = turso.getStats();
+    log.costFooter('Stage 6 · Cleanup', {
+        reads: stats.reads,
+        writes: stats.writes,
+        detail: `${log.fmt(toDelete.length)} shows deleted · ${log.fmt(inGrace)} in grace · ${pruned} state entries pruned`,
+    });
+    log.summaryTable('Stage 6: Cleanup', [{
+        stage: 'cleanup-non-chart',
+        reads: stats.reads,
+        writes: stats.writes,
+        detail: `${toDelete.length} shows deleted, ${inGrace} in grace, ${pruned} state entries pruned`,
+    }]);
+}
+
+main()
+    .then(() => turso.flushStats())
+    .catch(err => {
+        log.error(`cleanup-non-chart failed: ${err.message}`);
+        turso.flushStats();
+        process.exit(1);
+    });

--- a/scripts/sync/07-record-stats.js
+++ b/scripts/sync/07-record-stats.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Stage 7: Fold this run's DB cost counters (RUN_STATS_FILE, written
+ * incrementally by lib/turso.js) into the 30-day history and regenerate the
+ * markdown report.
+ *
+ * Fixes vs the old recorder:
+ * - ACCUMULATES per day across the 5 daily runs (the old code overwrote,
+ *   undercounting daily cost by up to 5x).
+ * - Tracks runs-per-day so the report shows both totals and run counts.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const log = require('./lib/log');
+const cfg = require('./lib/config');
+
+const SCOPE = 'global'; // single-pass pipeline; legacy history had per-country scopes
+
+// Turso free tier: 500M row reads / 10M row writes per month.
+const FREE_TIER_DAILY_READS = Math.floor(500_000_000 / 30);
+const FREE_TIER_DAILY_WRITES = Math.floor(10_000_000 / 30);
+
+function main() {
+    log.banner('Stage 7 · Record DB Cost Stats');
+    if (!fs.existsSync(cfg.RUN_STATS_FILE)) {
+        log.warn('No run stats file found - nothing to record');
+        return;
+    }
+    let runStats = {};
+    try {
+        runStats = JSON.parse(fs.readFileSync(cfg.RUN_STATS_FILE, 'utf8') || '{}');
+    } catch (e) {
+        log.error(`Failed to parse run stats: ${e.message}`);
+        return;
+    }
+
+    // --- Load + update history (accumulate per day) ---
+    let history = {};
+    if (fs.existsSync(cfg.HISTORY_FILE)) {
+        try {
+            history = JSON.parse(fs.readFileSync(cfg.HISTORY_FILE, 'utf8') || '{}');
+        } catch (e) {
+            log.warn(`History file unreadable, resetting: ${e.message}`);
+        }
+    }
+
+    const today = new Date().toISOString().split('T')[0];
+    if (!history[today]) history[today] = {};
+    if (!history[today][SCOPE]) history[today][SCOPE] = {};
+    const dayScope = history[today][SCOPE];
+
+    for (const [step, cost] of Object.entries(runStats)) {
+        const prev = dayScope[step] || { reads: 0, writes: 0, runs: 0 };
+        dayScope[step] = {
+            reads: prev.reads + (cost.reads || 0),
+            writes: prev.writes + (cost.writes || 0),
+            runs: (prev.runs || 0) + 1,
+        };
+    }
+
+    // 30-day sliding window
+    const dates = Object.keys(history).sort();
+    for (const d of dates.slice(0, Math.max(0, dates.length - 30))) {
+        delete history[d];
+    }
+
+    const dir = path.dirname(cfg.HISTORY_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(cfg.HISTORY_FILE, JSON.stringify(history, null, 1));
+    log.info(`History updated: ${cfg.HISTORY_FILE}`);
+
+    // --- Regenerate markdown report ---
+    let md = '# Turso Database Cost Report (Last 30 Days)\n\n';
+    md += 'Daily totals accumulated across all runs of the sync pipeline.\n\n';
+
+    for (const date of Object.keys(history).sort().reverse()) {
+        md += `## ${date}\n\n`;
+        md += '| Scope | Step | Runs | DB Reads | DB Writes |\n';
+        md += '| :--- | :--- | ---: | ---: | ---: |\n';
+        let dayReads = 0;
+        let dayWrites = 0;
+        for (const scope of Object.keys(history[date]).sort()) {
+            let first = true;
+            for (const step of Object.keys(history[date][scope]).sort()) {
+                const c = history[date][scope][step];
+                dayReads += c.reads || 0;
+                dayWrites += c.writes || 0;
+                md += `| ${first ? `\`${scope}\`` : ''} | \`${step}\` | ${c.runs || '-'} | ${(c.reads || 0).toLocaleString()} | ${(c.writes || 0).toLocaleString()} |\n`;
+                first = false;
+            }
+        }
+        md += `| | **Day total** | | **${dayReads.toLocaleString()}** | **${dayWrites.toLocaleString()}** |\n\n`;
+    }
+    fs.writeFileSync(cfg.REPORT_FILE, md);
+    log.info(`Report regenerated: ${cfg.REPORT_FILE}`);
+
+    // --- Totals: this run + accumulated today ---
+    let totalR = 0;
+    let totalW = 0;
+    for (const cost of Object.values(runStats)) {
+        totalR += cost.reads || 0;
+        totalW += cost.writes || 0;
+    }
+    let dayR = 0;
+    let dayW = 0;
+    for (const c of Object.values(dayScope)) {
+        dayR += c.reads || 0;
+        dayW += c.writes || 0;
+    }
+    const readPct = ((dayR / FREE_TIER_DAILY_READS) * 100).toFixed(1);
+    const writePct = ((dayW / FREE_TIER_DAILY_WRITES) * 100).toFixed(1);
+
+    // --- Aligned console table ---
+    console.log('');
+    console.log('  Step                        Reads       Writes');
+    console.log('  ' + '─'.repeat(48));
+    for (const [step, cost] of Object.entries(runStats)) {
+        console.log(`  ${step.padEnd(24)} ${(cost.reads || 0).toLocaleString().padStart(10)} ${(cost.writes || 0).toLocaleString().padStart(12)}`);
+    }
+    console.log('  ' + '─'.repeat(48));
+    console.log(`  ${'This run'.padEnd(24)} ${totalR.toLocaleString().padStart(10)} ${totalW.toLocaleString().padStart(12)}`);
+    console.log(`  ${'Today (all runs)'.padEnd(24)} ${dayR.toLocaleString().padStart(10)} ${dayW.toLocaleString().padStart(12)}`);
+    console.log(`  ${'Free-tier daily budget'.padEnd(24)} ${(readPct + '%').padStart(10)} ${(writePct + '%').padStart(12)}`);
+    console.log('');
+
+    // --- GHA step summary ---
+    let summary = '\n### 💾 Turso DB Cost\n\n| Step | Reads | Writes |\n| :--- | ---: | ---: |\n';
+    for (const [step, cost] of Object.entries(runStats)) {
+        summary += `| \`${step}\` | ${(cost.reads || 0).toLocaleString()} | ${(cost.writes || 0).toLocaleString()} |\n`;
+    }
+    summary += `| **This run** | **${totalR.toLocaleString()}** | **${totalW.toLocaleString()}** |\n`;
+    summary += `| **Today (all runs)** | **${dayR.toLocaleString()}** | **${dayW.toLocaleString()}** |\n`;
+    summary += `\nToday is at **${readPct}%** of the pro-rated daily read budget and **${writePct}%** of the write budget (free tier: 500M reads / 10M writes per month).\n`;
+    if (parseFloat(readPct) > 80 || parseFloat(writePct) > 80) {
+        log.warn(`Turso usage today is high: ${readPct}% reads / ${writePct}% writes of the pro-rated daily free-tier budget`);
+    }
+    log.stepSummary(summary);
+
+    // Clean the temp file so a rerun on the same runner starts fresh
+    try {
+        fs.unlinkSync(cfg.RUN_STATS_FILE);
+    } catch { /* best effort */ }
+}
+
+try {
+    main();
+} catch (err) {
+    log.error(`record-stats failed: ${err.message}`);
+    process.exit(1);
+}

--- a/scripts/sync/lib/config.js
+++ b/scripts/sync/lib/config.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * Central pipeline configuration.
+ * Countries: tier 'full' = charts + episode sync + vectors.
+ *            tier 'charts-only' = charts + podcast import + latest_ep sync, NO vectors.
+ * Phase 2 country additions happen HERE only - no country knowledge lives in
+ * the workflow YAML or individual stage scripts.
+ */
+const COUNTRIES = [
+    { code: 'us', tier: 'full' },
+    { code: 'in', tier: 'full' },
+    { code: 'gb', tier: 'full' },
+    { code: 'fr', tier: 'full' },
+];
+
+const FULL_TIER_COUNTRIES = COUNTRIES.filter(c => c.tier === 'full').map(c => c.code);
+const ALL_COUNTRIES = COUNTRIES.map(c => c.code);
+
+// iTunes chart categories (genre id map used by stage 1)
+const GENRE_MAP = {
+    'News': '1489',
+    'Technology': '1318',
+    'Business': '1321',
+    'Comedy': '1303',
+    'True Crime': '1488',
+    'Sports': '1545',
+    'Health': '1512',
+    'History': '1487',
+    'Arts': '1301',
+    'Society & Culture': '1324',
+    'Education': '1304',
+    'Science': '1533',
+    'TV & Film': '1309',
+    'Fiction': '1483',
+    'Music': '1310',
+    'Religion & Spirituality': '1314',
+    'Kids & Family': '1305',
+    'Leisure': '1502',
+    'Government': '1511',
+};
+const CATEGORIES = ['all', ...Object.keys(GENRE_MAP)];
+
+module.exports = {
+    COUNTRIES,
+    ALL_COUNTRIES,
+    FULL_TIER_COUNTRIES,
+    GENRE_MAP,
+    CATEGORIES,
+
+    // --- Vectorization ---
+    EMBED_MODEL: 'Xenova/bge-large-en-v1.5',
+    EPISODES_COLLECTION: 'episodes',
+    PODCASTS_COLLECTION: 'podcasts',
+    VECTOR_DIM: 1024,
+    EPISODES_PER_SHOW: 30,          // strict: latest 30 episodes per show
+    // Per-run embedding budget (NOT a show cap). Incremental updates cost ~1
+    // embedding per show; cold-start shows cost up to EPISODES_PER_SHOW.
+    MAX_EMBEDDINGS_PER_RUN: parseInt(process.env.MAX_EMBEDDINGS_PER_RUN || '3000', 10),
+    PAYLOAD_DESCRIPTION_MAX: 1000,  // cap description text stored in Qdrant payloads
+
+    // --- Episode sync staleness tiers ---
+    NEWS_STALE_MS: 8 * 60 * 60 * 1000,
+    REGULAR_STALE_MS: 24 * 60 * 60 * 1000,
+    // Hard cap on shows checked per run. Oldest-first ordering means deferred
+    // shows lead the queue next run, so a backlog self-distributes across the
+    // 5 daily runs instead of blowing one run's wall time (~20 min at 3.5 rps).
+    MAX_CHECKS_PER_RUN: parseInt(process.env.MAX_CHECKS_PER_RUN || '4000', 10),
+    // Deterministic per-show jitter (+/-10%) on staleness thresholds so
+    // check times spread instead of re-synchronizing into waves.
+    STALENESS_JITTER: 0.10,
+
+    // --- Import ---
+    // If more than this many chart shows are missing from Turso, use the PI
+    // dump; otherwise fetch individually from the PI API.
+    DUMP_THRESHOLD: 300,
+    API_IMPORT_CAP: 200,
+
+    // --- Cleanup ---
+    CLEANUP_GRACE_DAYS: 7,          // only delete shows absent from charts this long
+    CLEANUP_SAFETY_MIN_CHARTS: 500, // abort cleanup if charts look wiped
+
+    // --- State / files ---
+    STATE_FILE: 'data/sync_cache.json',
+    HISTORY_FILE: 'data/db_cost_history.json',
+    REPORT_FILE: 'data/db_cost_report.md',
+    RUN_STATS_FILE: '/tmp/db_run_stats.json',
+
+    // Fixed column whitelist for the podcasts table import path (no auto-ALTER).
+    PODCAST_IMPORT_COLUMNS: [
+        'id', 'itunes_id', 'title', 'author', 'description', 'image_url',
+        'feed_url', 'website_url', 'categories', 'language', 'explicit', 'type',
+    ],
+};

--- a/scripts/sync/lib/embedder.js
+++ b/scripts/sync/lib/embedder.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * Lazy-loaded CPU embedding generator (transformers.js).
+ * Model files cache to ./.cache (restored by the workflow's actions/cache).
+ */
+
+const log = require('./log');
+const { EMBED_MODEL } = require('./config');
+
+let extractorPromise = null;
+
+async function getExtractor() {
+    if (!extractorPromise) {
+        extractorPromise = (async () => {
+            const { env, pipeline } = await import('@xenova/transformers');
+            env.cacheDir = './.cache';
+            log.info(`[MODEL] Loading embedding model: ${EMBED_MODEL}`);
+            const extractor = await pipeline('feature-extraction', EMBED_MODEL);
+            log.info('[MODEL] Model ready');
+            return extractor;
+        })();
+    }
+    return extractorPromise;
+}
+
+/** Embed a single text -> number[] (mean-pooled, normalized). */
+async function embed(text) {
+    const extractor = await getExtractor();
+    const output = await extractor(text, { pooling: 'mean', normalize: true });
+    return Array.from(output.data);
+}
+
+module.exports = { embed };

--- a/scripts/sync/lib/log.js
+++ b/scripts/sync/lib/log.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/**
+ * GHA-friendly logging: collapsible groups, milestone progress, annotations,
+ * and a rich end-of-run Step Summary table.
+ */
+
+const fs = require('fs');
+
+const IS_GHA = !!process.env.GITHUB_ACTIONS;
+
+function info(msg) {
+    console.log(msg);
+}
+
+function warn(msg) {
+    if (IS_GHA) console.log(`::warning::${msg}`);
+    else console.warn(`[WARN] ${msg}`);
+}
+
+function error(msg) {
+    if (IS_GHA) console.log(`::error::${msg}`);
+    else console.error(`[ERROR] ${msg}`);
+}
+
+function group(title) {
+    if (IS_GHA) console.log(`::group::${title}`);
+    else console.log(`\n=== ${title} ===`);
+}
+
+function endGroup() {
+    if (IS_GHA) console.log('::endgroup::');
+}
+
+/**
+ * Boxed stage banner with aligned key-value config lines.
+ * banner('Stage 4: Vectorize Episodes', { Budget: '3,000', Pending: '3,586' })
+ */
+function banner(title, kvPairs = {}) {
+    const line = '━'.repeat(64);
+    console.log('');
+    console.log(line);
+    console.log(`  ${title}`);
+    const entries = Object.entries(kvPairs);
+    if (entries.length > 0) {
+        console.log('  ' + '─'.repeat(60));
+        for (const [k, v] of entries) {
+            console.log(`  ${(k + ':').padEnd(22)} ${v}`);
+        }
+    }
+    console.log(line);
+}
+
+/** Consistent end-of-stage cost/result footer. */
+function costFooter(stage, { reads, writes, apiCalls, detail } = {}) {
+    const line = '─'.repeat(64);
+    console.log('');
+    console.log(line);
+    const parts = [`Turso ${fmt(reads || 0)} reads · ${fmt(writes || 0)} writes`];
+    if (apiCalls) parts.push(`API ${fmt(apiCalls)} calls`);
+    console.log(`  ${stage} done · ${parts.join(' · ')}`);
+    if (detail) console.log(`  ${detail}`);
+    console.log(line);
+}
+
+/**
+ * Milestone progress logger with a text bar. Call tick() per item; prints at
+ * most every `intervalPct` percent (default 10%) with rate + ETA.
+ */
+function progress(total, label, intervalPct = 10) {
+    const start = Date.now();
+    let lastPct = -1;
+    let done = 0;
+    return {
+        tick(extra = '') {
+            done++;
+            const pct = total > 0 ? Math.floor((done / total) * 100) : 100;
+            if (pct >= lastPct + intervalPct || done === total) {
+                lastPct = pct - (pct % intervalPct);
+                const elapsed = (Date.now() - start) / 1000;
+                const rate = done / Math.max(elapsed, 0.001);
+                const eta = done < total ? Math.round((total - done) / Math.max(rate, 0.001)) : 0;
+                const filled = Math.round(pct / 10);
+                const bar = '▰'.repeat(filled) + '▱'.repeat(10 - filled);
+                info(`  ${bar} ${String(pct).padStart(3)}%  ${label} ${done}/${total} · ${rate.toFixed(1)}/s · ETA ${eta}s${extra ? ' · ' + extra : ''}`);
+            }
+        },
+        get count() { return done; },
+    };
+}
+
+/** Append markdown to the GHA step summary (no-op locally). */
+function stepSummary(markdown) {
+    if (process.env.GITHUB_STEP_SUMMARY) {
+        try {
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown + '\n');
+        } catch (e) {
+            warn(`Failed to write step summary: ${e.message}`);
+        }
+    }
+}
+
+/**
+ * Render a stage-result row table for the step summary.
+ * rows: [{ stage, duration, apiCalls, reads, writes, detail }]
+ */
+function summaryTable(title, rows) {
+    let md = `\n### ${title}\n\n`;
+    md += '| Stage | Duration | API calls | DB reads | DB writes | Detail |\n';
+    md += '| :--- | ---: | ---: | ---: | ---: | :--- |\n';
+    for (const r of rows) {
+        md += `| ${r.stage} | ${r.duration || '-'} | ${fmt(r.apiCalls)} | ${fmt(r.reads)} | ${fmt(r.writes)} | ${r.detail || ''} |\n`;
+    }
+    stepSummary(md);
+}
+
+function fmt(n) {
+    return typeof n === 'number' ? n.toLocaleString() : (n || '-');
+}
+
+function duration(ms) {
+    if (ms < 1000) return `${ms}ms`;
+    const s = ms / 1000;
+    if (s < 60) return `${s.toFixed(1)}s`;
+    const m = Math.floor(s / 60);
+    return `${m}m ${Math.round(s - m * 60)}s`;
+}
+
+module.exports = { info, warn, error, group, endGroup, banner, costFooter, progress, stepSummary, summaryTable, duration, fmt };

--- a/scripts/sync/lib/podcast-index.js
+++ b/scripts/sync/lib/podcast-index.js
@@ -1,0 +1,109 @@
+'use strict';
+
+/**
+ * Shared Podcast Index API client with a global token-bucket rate limiter
+ * (~3.5 req/s) and 429 exponential backoff. All pipeline PI calls go
+ * through here so total API pressure is bounded regardless of stage.
+ */
+
+const crypto = require('crypto');
+const log = require('./log');
+
+const API_KEY = process.env.PODCAST_INDEX_API_KEY;
+const API_SECRET = process.env.PODCAST_INDEX_API_SECRET;
+const API_BASE = 'https://api.podcastindex.org/api/1.0';
+
+const RATE_LIMIT_RPS = 3.5;
+const MAX_RETRIES = 3;
+
+let apiCallCount = 0;
+let nextSlotAt = 0;
+
+function assertEnv() {
+    if (!API_KEY || !API_SECRET) {
+        log.error('Missing PODCAST_INDEX_API_KEY or PODCAST_INDEX_API_SECRET');
+        process.exit(1);
+    }
+}
+
+function getApiCallCount() {
+    return apiCallCount;
+}
+
+function authHeaders() {
+    const t = Math.floor(Date.now() / 1000);
+    const hash = crypto.createHash('sha1').update(API_KEY + API_SECRET + t).digest('hex');
+    return {
+        'User-Agent': 'BoxLore/1.0',
+        'X-Auth-Key': API_KEY,
+        'X-Auth-Date': String(t),
+        'Authorization': hash,
+    };
+}
+
+/** Global rate limiter: serializes request start times at RATE_LIMIT_RPS. */
+async function acquireSlot() {
+    const interval = 1000 / RATE_LIMIT_RPS;
+    const now = Date.now();
+    const slot = Math.max(nextSlotAt, now);
+    nextSlotAt = slot + interval;
+    if (slot > now) {
+        await new Promise(r => setTimeout(r, slot - now));
+    }
+}
+
+async function apiGet(path, retries = MAX_RETRIES) {
+    for (let attempt = 1; attempt <= retries + 1; attempt++) {
+        await acquireSlot();
+        try {
+            apiCallCount++;
+            const res = await fetch(`${API_BASE}${path}`, { headers: authHeaders() });
+            if (res.status === 429) {
+                if (attempt <= retries) {
+                    const backoff = 1000 * Math.pow(2, attempt - 1);
+                    log.warn(`PI API 429 on ${path}; retrying in ${backoff}ms (attempt ${attempt}/${retries})`);
+                    await new Promise(r => setTimeout(r, backoff));
+                    continue;
+                }
+                throw new Error('PI API 429: Too Many Requests');
+            }
+            if (!res.ok) throw new Error(`PI API error: ${res.status}`);
+            return await res.json();
+        } catch (e) {
+            if (attempt <= retries && /fetch failed|socket|timeout|UND_ERR/.test(e.message)) {
+                const backoff = 1000 * Math.pow(2, attempt - 1);
+                log.warn(`PI API request failed on ${path}: ${e.message}; retrying in ${backoff}ms`);
+                await new Promise(r => setTimeout(r, backoff));
+                continue;
+            }
+            throw e;
+        }
+    }
+}
+
+/** Latest episodes for a feed (newest first). Throws on failure. */
+async function episodesByFeedId(feedId, max) {
+    const data = await apiGet(`/episodes/byfeedid?id=${feedId}&max=${max}`);
+    return data.items || [];
+}
+
+/** Feed metadata by PI feed id. Returns null when not found. */
+async function podcastByFeedId(feedId) {
+    const data = await apiGet(`/podcasts/byfeedid?id=${feedId}`);
+    const feed = data.feed;
+    if (!feed || (Array.isArray(feed) && feed.length === 0) || !feed.id) return null;
+    return feed;
+}
+
+/** Feed metadata by iTunes id. Returns null when not found. */
+async function podcastByItunesId(itunesId) {
+    const data = await apiGet(`/podcasts/byitunesid?id=${itunesId}`);
+    const feed = data.feed;
+    if (!feed || (Array.isArray(feed) && feed.length === 0) || !feed.id) return null;
+    return feed;
+}
+
+module.exports = {
+    assertEnv, getApiCallCount,
+    episodesByFeedId, podcastByFeedId, podcastByItunesId,
+};

--- a/scripts/sync/lib/qdrant.js
+++ b/scripts/sync/lib/qdrant.js
@@ -1,0 +1,173 @@
+'use strict';
+
+/**
+ * Shared Qdrant REST client: retries, stable UUIDs, existence checks,
+ * upserts (wait=true so flags are only flipped after durable writes),
+ * deletes, scroll, and collection info.
+ */
+
+const crypto = require('crypto');
+const log = require('./log');
+
+const QDRANT_URL = process.env.QDRANT_URL;
+const QDRANT_API_KEY = process.env.QDRANT_API_KEY;
+
+const MAX_RETRIES = 5;
+const INITIAL_DELAY_MS = 2000;
+
+function assertEnv() {
+    if (!QDRANT_URL || !QDRANT_API_KEY) {
+        log.error('Missing QDRANT_URL or QDRANT_API_KEY');
+        process.exit(1);
+    }
+}
+
+/** Stable UUID from any string id (md5-derived, matches existing points). */
+function stableUUID(strId) {
+    const h = crypto.createHash('md5').update(String(strId)).digest('hex');
+    return `${h.substring(0, 8)}-${h.substring(8, 12)}-${h.substring(12, 16)}-${h.substring(16, 20)}-${h.substring(20)}`;
+}
+
+async function request(path, options = {}, retries = MAX_RETRIES) {
+    for (let attempt = 1; attempt <= retries; attempt++) {
+        try {
+            const response = await fetch(`${QDRANT_URL}${path}`, {
+                ...options,
+                headers: {
+                    'api-key': QDRANT_API_KEY,
+                    'Content-Type': 'application/json',
+                    ...(options.headers || {}),
+                },
+            });
+            if (response.status === 429 || response.status >= 500) {
+                const text = await response.text();
+                if (attempt < retries) {
+                    const backoff = INITIAL_DELAY_MS * Math.pow(2, attempt - 1);
+                    log.warn(`Qdrant ${response.status} on ${path} (attempt ${attempt}/${retries}). Retrying in ${backoff}ms`);
+                    await new Promise(r => setTimeout(r, backoff));
+                    continue;
+                }
+                throw new Error(`Qdrant HTTP ${response.status}: ${text}`);
+            }
+            if (!response.ok) {
+                const text = await response.text();
+                throw new Error(`Qdrant HTTP ${response.status}: ${text}`);
+            }
+            return await response.json();
+        } catch (e) {
+            if (attempt < retries && /fetch failed|socket|timeout|UND_ERR/.test(e.message)) {
+                const backoff = INITIAL_DELAY_MS * Math.pow(2, attempt - 1);
+                log.warn(`Qdrant request failed (attempt ${attempt}/${retries}): ${e.message}. Retrying in ${backoff}ms`);
+                await new Promise(r => setTimeout(r, backoff));
+                continue;
+            }
+            throw e;
+        }
+    }
+}
+
+/** Collection info: { pointsCount, status, vectorSize } or null on 404. */
+async function collectionInfo(collection) {
+    try {
+        const res = await request(`/collections/${collection}`);
+        return {
+            pointsCount: res.result?.points_count ?? null,
+            status: res.result?.status ?? null,
+            vectorSize: res.result?.config?.params?.vectors?.size ?? null,
+        };
+    } catch (e) {
+        if (e.message.includes('404')) return null;
+        throw e;
+    }
+}
+
+async function ensureCollection(collection, dim) {
+    const info = await collectionInfo(collection);
+    if (info) return info;
+    log.info(`[QDRANT] Creating collection '${collection}' (dim=${dim})`);
+    await request(`/collections/${collection}`, {
+        method: 'PUT',
+        body: JSON.stringify({ vectors: { size: dim, distance: 'Cosine' } }),
+    });
+    return collectionInfo(collection);
+}
+
+/** Which of these point ids exist? Returns Set of string ids. */
+async function existingIds(collection, ids) {
+    if (ids.length === 0) return new Set();
+    const res = await request(`/collections/${collection}/points`, {
+        method: 'POST',
+        body: JSON.stringify({ ids, with_vector: false, with_payload: false }),
+    });
+    return new Set((res.result || []).map(p => String(p.id)));
+}
+
+/**
+ * Upsert points with wait=true: the call returns only after the write is
+ * durable, so callers can safely mark work as complete afterwards.
+ */
+async function upsert(collection, points) {
+    if (points.length === 0) return;
+    await request(`/collections/${collection}/points?wait=true`, {
+        method: 'PUT',
+        body: JSON.stringify({ points }),
+    });
+}
+
+/** Delete points by id list. */
+async function deleteByIds(collection, ids, wait = false) {
+    if (ids.length === 0) return;
+    await request(`/collections/${collection}/points/delete?wait=${wait}`, {
+        method: 'POST',
+        body: JSON.stringify({ points: ids }),
+    });
+}
+
+/** Delete points matching a filter. */
+async function deleteByFilter(collection, filter, wait = false) {
+    await request(`/collections/${collection}/points/delete?wait=${wait}`, {
+        method: 'POST',
+        body: JSON.stringify({ filter }),
+    });
+}
+
+/**
+ * Scroll all points matching a filter. Returns array of {id, payload}.
+ * Payload selector defaults to false (ids only) to keep responses small.
+ */
+async function scrollAll(collection, filter, withPayload = false, pageLimit = 500) {
+    const out = [];
+    let offset = null;
+    for (;;) {
+        const body = { limit: pageLimit, with_vector: false, with_payload: withPayload };
+        if (filter) body.filter = filter;
+        if (offset !== null) body.offset = offset;
+        const res = await request(`/collections/${collection}/points/scroll`, {
+            method: 'POST',
+            body: JSON.stringify(body),
+        });
+        const points = res.result?.points || [];
+        out.push(...points.map(p => ({ id: String(p.id), payload: p.payload || null })));
+        offset = res.result?.next_page_offset ?? null;
+        if (offset === null || points.length === 0) break;
+    }
+    return out;
+}
+
+/** Enable int8 scalar quantization + on-disk originals on a collection. */
+async function enableQuantization(collection) {
+    await request(`/collections/${collection}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+            vectors: { on_disk: true },
+            quantization_config: {
+                scalar: { type: 'int8', quantile: 0.99, always_ram: true },
+            },
+        }),
+    });
+}
+
+module.exports = {
+    assertEnv, stableUUID, request, collectionInfo, ensureCollection,
+    existingIds, upsert, deleteByIds, deleteByFilter, scrollAll, enableQuantization,
+};

--- a/scripts/sync/lib/state.js
+++ b/scripts/sync/lib/state.js
@@ -1,0 +1,92 @@
+'use strict';
+
+/**
+ * Pipeline state persisted in git (data/sync_cache.json).
+ *
+ * Format v2 (compact keys to keep the committed file small):
+ * {
+ *   "version": 2,
+ *   "candidatesRefreshedAt": <ms epoch of last DB candidate refresh>,
+ *   "chartsRefreshedAt": <ms epoch of last charts refresh>,
+ *   "candidateIds": ["<podId>", ...],
+ *   "shows": {
+ *     "<podId>": {
+ *       "c": <lastCheckedMs>, "e": "<latestEpId>", "m": "<medium>",
+ *       "n": 1 (present only for News shows), "s": <lastSeenInChartsMs>
+ *     }
+ *   }
+ * }
+ *
+ * Migrates transparently from the legacy v1 flat map { podId: lastCheckedMs }.
+ * This file is pipeline bookkeeping ONLY - the app never reads it.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const log = require('./log');
+const { STATE_FILE } = require('./config');
+
+function load() {
+    let raw = {};
+    try {
+        if (fs.existsSync(STATE_FILE)) {
+            raw = JSON.parse(fs.readFileSync(STATE_FILE, 'utf8') || '{}');
+        }
+    } catch (e) {
+        log.warn(`Failed to parse ${STATE_FILE}, starting fresh: ${e.message}`);
+        raw = {};
+    }
+
+    if (raw.version === 2 && raw.shows) {
+        return raw;
+    }
+
+    // v1 migration: flat { podId: timestamp }
+    const shows = {};
+    let migrated = 0;
+    for (const [id, val] of Object.entries(raw)) {
+        if (typeof val === 'number') {
+            shows[id] = { c: val };
+            migrated++;
+        }
+    }
+    if (migrated > 0) {
+        log.info(`[STATE] Migrated ${migrated} legacy v1 cache entries to v2 format`);
+    }
+    return { version: 2, candidatesRefreshedAt: 0, shows };
+}
+
+/** Save compact (single line) - this file is committed on every run. */
+function save(state) {
+    const dir = path.dirname(STATE_FILE);
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state));
+}
+
+function getShow(state, podId) {
+    return state.shows[String(podId)] || null;
+}
+
+function recordCheck(state, podId, { latestEpId } = {}) {
+    const id = String(podId);
+    const rec = state.shows[id] || {};
+    rec.c = Date.now();
+    if (latestEpId !== undefined && latestEpId !== null) rec.e = String(latestEpId);
+    state.shows[id] = rec;
+    return rec;
+}
+
+/** Remove entries for shows no longer present. Returns count pruned. */
+function pruneShows(state, keepIds) {
+    const keep = new Set([...keepIds].map(String));
+    let pruned = 0;
+    for (const id of Object.keys(state.shows)) {
+        if (!keep.has(id)) {
+            delete state.shows[id];
+            pruned++;
+        }
+    }
+    return pruned;
+}
+
+module.exports = { load, save, getShow, recordCheck, pruneShows };

--- a/scripts/sync/lib/text.js
+++ b/scripts/sync/lib/text.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Text utilities: description cleaning for embeddings/storage and
+ * embed-text construction. Single copy of what previously lived in
+ * sync-episodes.js, vectorize.js, and vectorize-podcasts.js.
+ */
+
+const SPONSOR_PATTERNS = [
+    /^.*sponsored by.*$/gim,
+    /^.*brought to you by.*$/gim,
+    /^.*use code\b.*$/gim,
+    /^.*promo code\b.*$/gim,
+    /^.*discount code\b.*$/gim,
+    /^.*sign up at\b.*$/gim,
+    /^.*go to\b.*for\b.*$/gim,
+    /^.*visit\b.*\.com.*$/gim,
+];
+
+const BOILERPLATE_PATTERNS = [
+    /learn more at\b.*/gi,
+    /for more info(rmation)?\b.*/gi,
+    /subscribe (to|on|at|in)\b.*/gi,
+    /follow us (on|at)\b.*/gi,
+    /rate (and|&) review\b.*/gi,
+    /leave a review\b.*/gi,
+    /support (the|this) (show|podcast)\b.*/gi,
+    /available on\b.*/gi,
+    /listen on\b.*/gi,
+    /download the app\b.*/gi,
+    /all rights reserved\.?/gi,
+    /copyright ©?\s*\d{4}.*/gi,
+    /see privacy policy at\b.*/gi,
+    /see omnystudio\.com.*/gi,
+    /advertising inquiries\b.*/gi,
+];
+
+/**
+ * Strip HTML, URLs, emails, handles, timestamps, sponsor blocks, and
+ * boilerplate. Truncates to maxLen (default 1000).
+ */
+function cleanDescription(raw, maxLen = 1000) {
+    if (!raw || typeof raw !== 'string') return '';
+    let text = raw.replace(/<[^>]+>/g, ' ');
+    text = text
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&#x27;/g, "'")
+        .replace(/&#\d+;/g, ' ')
+        .replace(/&\w+;/g, ' ');
+    text = text.replace(/https?:\/\/[^\s)"\]]+/gi, '');
+    text = text.replace(/www\.[^\s)"\]]+/gi, '');
+    text = text.replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '');
+    text = text.replace(/[@#]\w+/g, '');
+    text = text.replace(/\b\d{1,2}:\d{2}(:\d{2})?\b/g, '');
+    for (const p of SPONSOR_PATTERNS) text = text.replace(p, '');
+    for (const p of BOILERPLATE_PATTERNS) text = text.replace(p, '');
+    return text.replace(/\s+/g, ' ').trim().substring(0, maxLen);
+}
+
+/** Text fed to the embedding model for an episode point. */
+function episodeEmbedText(episode, podcast) {
+    const parts = [
+        `Episode: ${episode.title || ''}`,
+        episode.cleanedDescription ? `Description: ${episode.cleanedDescription}` : null,
+        `Podcast: ${podcast.title}`,
+        podcast.categories ? `Genres: ${podcast.categories}` : null,
+        podcast.author ? `Host: ${podcast.author}` : null,
+    ].filter(Boolean);
+    return parts.join('. ').replace(/[\n\r]+/g, ' ').substring(0, 1000);
+}
+
+/** Text fed to the embedding model for a show point. */
+function podcastEmbedText(podcast) {
+    const cleaned = cleanDescription(podcast.description);
+    const parts = [
+        `Podcast: ${podcast.title}`,
+        podcast.author ? `Host: ${podcast.author}` : null,
+        cleaned ? `Description: ${cleaned}` : null,
+        podcast.categories ? `Genres: ${podcast.categories}` : null,
+        podcast.language ? `Language: ${podcast.language}` : null,
+    ].filter(Boolean);
+    return parts.join('. ').replace(/[\n\r]+/g, ' ').substring(0, 1000);
+}
+
+module.exports = { cleanDescription, episodeEmbedText, podcastEmbedText };

--- a/scripts/sync/lib/turso.js
+++ b/scripts/sync/lib/turso.js
@@ -1,0 +1,183 @@
+'use strict';
+
+/**
+ * Shared Turso HTTP pipeline client.
+ * - Single implementation of retries/backoff, arg typing, and row extraction.
+ * - Single source of truth for rows read/written stat counters, flushed
+ *   incrementally to RUN_STATS_FILE so partial failures still report cost.
+ */
+
+const fs = require('fs');
+const log = require('./log');
+const { RUN_STATS_FILE } = require('./config');
+
+const TURSO_URL = process.env.TURSO_URL?.replace('libsql://', 'https://');
+const TURSO_TOKEN = process.env.TURSO_AUTH_TOKEN;
+
+const MAX_RETRIES = 5;
+const INITIAL_DELAY_MS = 1000;
+
+let stepName = 'unknown';
+let reads = 0;
+let writes = 0;
+let lastFlushedReads = 0;
+let lastFlushedWrites = 0;
+
+function assertEnv() {
+    if (!TURSO_URL || !TURSO_TOKEN) {
+        log.error('Missing TURSO_URL or TURSO_AUTH_TOKEN');
+        process.exit(1);
+    }
+}
+
+/** Set the step name used for stat attribution and reset counters. */
+function beginStep(name) {
+    stepName = name;
+    reads = 0;
+    writes = 0;
+    lastFlushedReads = 0;
+    lastFlushedWrites = 0;
+}
+
+function getStats() {
+    return { reads, writes };
+}
+
+/**
+ * Flush current counters into RUN_STATS_FILE (delta-based, safe to call
+ * repeatedly; used incrementally and from finally blocks).
+ */
+function flushStats() {
+    try {
+        let current = {};
+        if (fs.existsSync(RUN_STATS_FILE)) {
+            current = JSON.parse(fs.readFileSync(RUN_STATS_FILE, 'utf8') || '{}');
+        }
+        const prev = current[stepName] || { reads: 0, writes: 0 };
+        current[stepName] = {
+            reads: prev.reads + (reads - lastFlushedReads),
+            writes: prev.writes + (writes - lastFlushedWrites),
+        };
+        fs.writeFileSync(RUN_STATS_FILE, JSON.stringify(current, null, 2));
+        lastFlushedReads = reads;
+        lastFlushedWrites = writes;
+    } catch (e) {
+        log.warn(`Failed to flush run stats: ${e.message}`);
+    }
+}
+
+/** Map JS values to Turso pipeline arg types. */
+function mapArgType(val) {
+    if (val === null || val === undefined || val === '') {
+        return { type: 'null', value: null };
+    }
+    if (typeof val === 'number') {
+        return { type: Number.isInteger(val) ? 'integer' : 'float', value: String(val) };
+    }
+    if (typeof val === 'string' && /^\d+$/.test(val)) {
+        return { type: 'integer', value: val };
+    }
+    return { type: 'text', value: String(val) };
+}
+
+function isTransient(message) {
+    return /fetch failed|socket|UND_ERR|timeout|502|503|504|429/.test(message);
+}
+
+async function pipelineRequest(requests) {
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            const response = await fetch(`${TURSO_URL}/v2/pipeline`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `Bearer ${TURSO_TOKEN}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ requests }),
+            });
+            if (!response.ok) {
+                throw new Error(`Turso HTTP error ${response.status}: ${response.statusText}`);
+            }
+            const res = await response.json();
+            if (res.results) {
+                for (const result of res.results) {
+                    if (result.type === 'error') {
+                        throw new Error(`Turso SQL error: ${result.error.message}`);
+                    }
+                    const r = result.response?.result;
+                    if (r) {
+                        reads += r.rows_read || 0;
+                        writes += r.rows_written || 0;
+                    }
+                }
+            }
+            return res;
+        } catch (e) {
+            if (isTransient(e.message) && attempt < MAX_RETRIES) {
+                const backoff = INITIAL_DELAY_MS * Math.pow(2, attempt - 1);
+                log.warn(`Turso request failed (attempt ${attempt}/${MAX_RETRIES}): ${e.message}. Retrying in ${backoff}ms`);
+                await new Promise(r => setTimeout(r, backoff));
+                continue;
+            }
+            throw e;
+        }
+    }
+}
+
+/** Execute a single SQL statement. */
+async function execute(sql, args = []) {
+    return pipelineRequest([
+        { type: 'execute', stmt: { sql, args: args.map(mapArgType) } },
+        { type: 'close' },
+    ]);
+}
+
+/** Execute multiple statements in one pipeline request (single round trip). */
+async function batch(statements) {
+    if (statements.length === 0) return null;
+    const requests = statements.map(s => ({
+        type: 'execute',
+        stmt: { sql: s.sql, args: (s.args || []).map(mapArgType) },
+    }));
+    requests.push({ type: 'close' });
+    return pipelineRequest(requests);
+}
+
+/** Execute statements wrapped in BEGIN/COMMIT. */
+async function transaction(statements) {
+    if (statements.length === 0) return null;
+    const requests = [
+        { type: 'execute', stmt: { sql: 'BEGIN' } },
+        ...statements.map(s => ({
+            type: 'execute',
+            stmt: { sql: s.sql, args: (s.args || []).map(mapArgType) },
+        })),
+        { type: 'execute', stmt: { sql: 'COMMIT' } },
+        { type: 'close' },
+    ];
+    return pipelineRequest(requests);
+}
+
+/** Extract row arrays of plain values from an execute() result. */
+function rows(res, resultIndex = 0) {
+    const raw = res?.results?.[resultIndex]?.response?.result?.rows || [];
+    return raw.map(r => r.map(cell => (cell && cell.value !== undefined ? cell.value : null)));
+}
+
+/** Extract a single scalar (first row, first column). */
+function scalar(res, resultIndex = 0) {
+    const r = rows(res, resultIndex);
+    return r.length > 0 ? r[0][0] : null;
+}
+
+async function healthCheck() {
+    const res = await execute('SELECT 1');
+    if (!res?.results?.[0] || res.results[0].type !== 'ok') {
+        throw new Error('Turso health check returned unexpected response');
+    }
+}
+
+module.exports = {
+    assertEnv, beginStep, getStats, flushStats,
+    execute, batch, transaction, rows, scalar, healthCheck,
+};

--- a/scripts/sync/remediate-qdrant.js
+++ b/scripts/sync/remediate-qdrant.js
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * One-time (idempotent) Qdrant remediation for the overfill caused by the
+ * uncapped vectorization window:
+ *
+ *   1. Measure current collection state.
+ *   2. Delete episode points belonging to non-chart shows.
+ *   3. Trim every chart show to its latest EPISODES_PER_SHOW episode points.
+ *   4. Cross-check Turso qdrant_vectorized flags against actual point counts;
+ *      reset false positives (flag=1 but zero points) so the pipeline heals them.
+ *   5. Report before/after point counts.
+ *   6. Enable int8 scalar quantization + on-disk originals (skippable).
+ *
+ * Usage:
+ *   node scripts/sync/remediate-qdrant.js [--dry-run] [--skip-quantization]
+ */
+
+const log = require('./lib/log');
+const turso = require('./lib/turso');
+const qdrant = require('./lib/qdrant');
+const cfg = require('./lib/config');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const SKIP_QUANTIZATION = process.argv.includes('--skip-quantization');
+
+const DELETE_CHUNK = 500;
+
+async function main() {
+    turso.assertEnv();
+    qdrant.assertEnv();
+    turso.beginStep('remediate-qdrant');
+    log.banner('Qdrant Remediation', {
+        'Mode': DRY_RUN ? 'DRY RUN (no writes)' : 'LIVE',
+        'Episodes per show': String(cfg.EPISODES_PER_SHOW),
+        'Quantization': SKIP_QUANTIZATION ? 'skipped' : 'int8 scalar + on-disk originals',
+    });
+
+    // ---------------------------------------------------------------
+    log.group('Step 1: Measure current state');
+    const beforeEpisodes = await qdrant.collectionInfo(cfg.EPISODES_COLLECTION);
+    const beforePodcasts = await qdrant.collectionInfo(cfg.PODCASTS_COLLECTION);
+    if (!beforeEpisodes) {
+        log.error(`Collection '${cfg.EPISODES_COLLECTION}' not found - nothing to remediate`);
+        process.exit(1);
+    }
+    log.info(`episodes collection: ${log.fmt(beforeEpisodes.pointsCount)} points, status=${beforeEpisodes.status}`);
+    if (beforePodcasts) {
+        log.info(`podcasts collection: ${log.fmt(beforePodcasts.pointsCount)} points, status=${beforePodcasts.status}`);
+    }
+    log.endGroup();
+
+    // ---------------------------------------------------------------
+    log.group('Step 2: Load chart shows from Turso');
+    await turso.healthCheck();
+    const chartShowRes = await turso.execute(`
+        SELECT DISTINCT p.id
+        FROM podcasts p
+        WHERE p.itunes_id IN (SELECT DISTINCT CAST(itunes_id AS INTEGER) FROM charts WHERE itunes_id IS NOT NULL)
+    `);
+    const chartShowIds = new Set(turso.rows(chartShowRes).map(r => String(r[0])));
+    log.info(`Chart shows in Turso: ${log.fmt(chartShowIds.size)}`);
+    if (chartShowIds.size < cfg.CLEANUP_SAFETY_MIN_CHARTS) {
+        log.error(`Safety abort: only ${chartShowIds.size} chart shows found (< ${cfg.CLEANUP_SAFETY_MIN_CHARTS}). Charts table may be broken.`);
+        process.exit(1);
+    }
+    log.endGroup();
+
+    // ---------------------------------------------------------------
+    log.group('Step 3: Scan episode points (podcast_id + published_date)');
+    const scanStart = Date.now();
+    const allPoints = await qdrant.scrollAll(
+        cfg.EPISODES_COLLECTION,
+        null,
+        ['podcast_id', 'published_date'],
+        1000
+    );
+    log.info(`Scanned ${log.fmt(allPoints.length)} points in ${log.duration(Date.now() - scanStart)}`);
+
+    const byShow = new Map();
+    let unknownPodcastId = 0;
+    for (const pt of allPoints) {
+        const pid = pt.payload?.podcast_id;
+        if (pid === undefined || pid === null) {
+            unknownPodcastId++;
+            continue;
+        }
+        const key = String(pid);
+        if (!byShow.has(key)) byShow.set(key, []);
+        byShow.get(key).push({ id: pt.id, date: pt.payload?.published_date || 0 });
+    }
+    log.info(`Distinct shows in collection: ${log.fmt(byShow.size)} (${unknownPodcastId} points without podcast_id)`);
+    log.endGroup();
+
+    // ---------------------------------------------------------------
+    log.group('Step 4: Delete non-chart show points');
+    const nonChartShowIds = [...byShow.keys()].filter(id => !chartShowIds.has(id));
+    let nonChartPoints = 0;
+    for (const id of nonChartShowIds) nonChartPoints += byShow.get(id).length;
+    log.info(`Non-chart shows in Qdrant: ${log.fmt(nonChartShowIds.length)} (${log.fmt(nonChartPoints)} points)`);
+
+    if (!DRY_RUN && nonChartShowIds.length > 0) {
+        for (let i = 0; i < nonChartShowIds.length; i += DELETE_CHUNK) {
+            const chunk = nonChartShowIds.slice(i, i + DELETE_CHUNK).map(id => parseInt(id, 10)).filter(n => !isNaN(n));
+            await qdrant.deleteByFilter(cfg.EPISODES_COLLECTION, {
+                must: [{ key: 'podcast_id', match: { any: chunk } }],
+            });
+            log.info(`Deleted points for shows ${i + 1}-${Math.min(i + DELETE_CHUNK, nonChartShowIds.length)} of ${nonChartShowIds.length}`);
+        }
+    }
+    log.endGroup();
+
+    // ---------------------------------------------------------------
+    log.group(`Step 5: Trim chart shows to latest ${cfg.EPISODES_PER_SHOW} points`);
+    let trimmedShows = 0;
+    let trimmedPoints = 0;
+    const trimDeleteIds = [];
+    const touchedShowIds = [];
+
+    for (const [showId, points] of byShow.entries()) {
+        if (!chartShowIds.has(showId)) continue;
+        if (points.length <= cfg.EPISODES_PER_SHOW) continue;
+        points.sort((a, b) => b.date - a.date);
+        const excess = points.slice(cfg.EPISODES_PER_SHOW);
+        trimDeleteIds.push(...excess.map(p => p.id));
+        trimmedShows++;
+        trimmedPoints += excess.length;
+        touchedShowIds.push(showId);
+    }
+    log.info(`Shows over the ${cfg.EPISODES_PER_SHOW}-episode limit: ${log.fmt(trimmedShows)} (${log.fmt(trimmedPoints)} excess points)`);
+
+    if (!DRY_RUN && trimDeleteIds.length > 0) {
+        for (let i = 0; i < trimDeleteIds.length; i += DELETE_CHUNK) {
+            await qdrant.deleteByIds(cfg.EPISODES_COLLECTION, trimDeleteIds.slice(i, i + DELETE_CHUNK));
+        }
+        log.info(`Deleted ${log.fmt(trimDeleteIds.length)} excess points`);
+    }
+    log.endGroup();
+
+    // ---------------------------------------------------------------
+    log.group('Step 6: Cross-check qdrant_vectorized flags');
+    const flaggedRes = await turso.execute(`
+        SELECT p.id FROM podcasts p
+        WHERE p.qdrant_vectorized = 1
+          AND p.itunes_id IN (SELECT DISTINCT CAST(itunes_id AS INTEGER) FROM charts WHERE itunes_id IS NOT NULL)
+    `);
+    const flaggedIds = turso.rows(flaggedRes).map(r => String(r[0]));
+    const holes = flaggedIds.filter(id => !byShow.has(id) || byShow.get(id).length === 0);
+    log.info(`Shows flagged vectorized=1 with ZERO points in Qdrant (holes): ${log.fmt(holes.length)}`);
+
+    const toReset = [...new Set([...holes, ...touchedShowIds])];
+    log.info(`Flags to reset (holes + trimmed shows): ${log.fmt(toReset.length)}`);
+
+    if (!DRY_RUN && toReset.length > 0) {
+        const CHUNK = 100;
+        for (let i = 0; i < toReset.length; i += CHUNK) {
+            const chunk = toReset.slice(i, i + CHUNK);
+            const placeholders = chunk.map(() => '?').join(',');
+            await turso.execute(
+                `UPDATE podcasts SET qdrant_vectorized = 0 WHERE id IN (${placeholders})`,
+                chunk
+            );
+        }
+        log.info('Flags reset - the pipeline will heal these shows under the embedding budget');
+    }
+    log.endGroup();
+
+    // ---------------------------------------------------------------
+    log.group('Step 7: Verify space reclamation');
+    if (!DRY_RUN) {
+        await new Promise(r => setTimeout(r, 15000)); // let optimizer start merging
+        const after = await qdrant.collectionInfo(cfg.EPISODES_COLLECTION);
+        log.info(`episodes points: ${log.fmt(beforeEpisodes.pointsCount)} -> ${log.fmt(after.pointsCount)} (status=${after.status})`);
+        const expectedRemoved = nonChartPoints + trimmedPoints;
+        log.info(`Expected removal: ~${log.fmt(expectedRemoved)} points. Optimizer merges segments in background; disk frees over the next minutes.`);
+        if (after.pointsCount >= beforeEpisodes.pointsCount && expectedRemoved > 0) {
+            log.warn('Point count did not decrease - deletes may still be processing. Re-run this script to verify; if it never drops, consider the drop-and-rebuild fallback.');
+        }
+    }
+    log.endGroup();
+
+    // ---------------------------------------------------------------
+    log.group('Step 8: Enable quantization');
+    if (SKIP_QUANTIZATION) {
+        log.info('Skipped (--skip-quantization)');
+    } else if (DRY_RUN) {
+        log.info('Dry run - would enable int8 scalar quantization + on-disk originals on episodes');
+    } else {
+        await qdrant.enableQuantization(cfg.EPISODES_COLLECTION);
+        log.info('int8 scalar quantization + on-disk originals enabled on episodes collection (background rebuild)');
+    }
+    log.endGroup();
+
+    // ---------------------------------------------------------------
+    const stats = turso.getStats();
+    log.summaryTable('Qdrant Remediation', [
+        { stage: 'Scan', reads: allPoints.length, detail: `${byShow.size} shows in collection` },
+        { stage: 'Non-chart deletion', detail: `${nonChartShowIds.length} shows / ${nonChartPoints} points${DRY_RUN ? ' (dry run)' : ''}` },
+        { stage: 'Trim to latest ' + cfg.EPISODES_PER_SHOW, detail: `${trimmedShows} shows / ${trimmedPoints} points${DRY_RUN ? ' (dry run)' : ''}` },
+        { stage: 'Flag resets', reads: stats.reads, writes: stats.writes, detail: `${toReset.length} shows queued for healing` },
+    ]);
+    log.info(`\nDone. Turso cost: ${log.fmt(stats.reads)} reads / ${log.fmt(stats.writes)} writes`);
+}
+
+main()
+    .then(() => turso.flushStats())
+    .catch(err => {
+        log.error(`Remediation failed: ${err.message}`);
+        turso.flushStats();
+        process.exit(1);
+    });


### PR DESCRIPTION
## Summary

Complete rewrite of the `sync-pi-data` GitHub Action and its scripts. The old workflow ran a 4-country serial matrix that re-did most work 4x per run, had an uncapped vectorization path that overfilled the Qdrant cluster (683K points, cluster status **red**), silently swallowed failures, and undercounted daily Turso costs by up to 5x. This PR replaces it with a single global pass over seven staged scripts built on a shared library layer.

## Architecture

**Workflow (`.github/workflows/sync-pi-data.yml`)**
- One `sync` job instead of a 4-country matrix: charts for all countries are fetched in a single stage, so podcast import, episode sync, and vectorization each run exactly once per schedule.
- 5 daily runs; the charts refresh is gated to the 00:00 UTC run, cleanup to a separate job on the 20:00 UTC run, and Qdrant remediation is `workflow_dispatch`-only (with a dry-run option).
- `concurrency` queues runs instead of cancelling half-done vector batches.
- Single state-commit step with a rebase-and-retry push loop (replaces `git reset --hard` + `|| true`).

**Shared library (`scripts/sync/lib/`)**
- `config.js` – all tunables in one place, including a tiered country list (`full` vs `charts-only`) so future country expansion is a config change, not a code change.
- `turso.js` – one HTTP pipeline client: retries with backoff, typed args, and read/write counters flushed incrementally to a temp file so partial failures still report cost.
- `qdrant.js` – REST client with retries, stable UUIDs, existence checks, filtered deletes, scroll, and `wait=true` upserts so `qdrant_vectorized=1` is only set after vectors are durable.
- `podcast-index.js` – global token-bucket rate limiter + 429 backoff.
- `state.js` – compact git-persisted state (`data/sync_cache.json`) for per-show check times, latest episode ids, and cleanup grace clocks (zero Turso cost for bookkeeping).
- `log.js` – GHA-native logging: stage banners, progress bars with rate/ETA, collapsible groups, warning/error annotations, and step-summary tables.
- `embedder.js` / `text.js` – lazy transformers.js model loading and shared text cleaning.

**Stages (`scripts/sync/01…07`)**
1. **Refresh charts** – reads the charts table once, diffs in memory, writes only changed rows; a failed iTunes fetch skips both upserts *and* deletes for that country/category so a 403 can never masquerade as an empty chart and wipe rows.
2. **Import podcasts** – precheck computes missing shows; >300 missing triggers the PI dump path, otherwise incremental API import. Fixed column whitelist (no more auto-`ALTER TABLE` schema drift).
3. **Sync episodes** – candidate list cached in git state (near-zero Turso reads on 4 of 5 runs); staleness tiers (News 8h / others 24h) with deterministic ±10% per-show jitter; per-run check cap with oldest-first ordering so backlogs self-distribute across runs.
4. **Vectorize episodes** – per-run **embedding budget** (default 3,000 vectors) instead of an uncapped show count; prune-before-insert keeps every show at strictly its latest 30 episodes; payload descriptions capped.
5. **Vectorize shows** – same budget philosophy, 1 vector per show.
6. **Cleanup non-chart shows** – 7-day grace period before deletion (kills the delete/re-vectorize thrash); FTS trigger drop/bulk-delete/recreate to avoid per-row FTS scans; safety abort if the charts table looks broken.
7. **Record stats** – accumulates reads/writes **per day across all 5 runs** (old recorder overwrote, undercounting up to 5x), regenerates `data/db_cost_report.md` (30-day window), and posts a step summary comparing today's usage against the pro-rated Turso free-tier budget with a warning annotation above 80%.

**Remediation (`scripts/sync/remediate-qdrant.js`)** – one-time, idempotent: deletes points of non-chart shows, trims every show to its latest 30 episodes, resets `qdrant_vectorized` flags that have no backing points, verifies reclamation, and optionally enables int8 scalar quantization. Supports `--dry-run` / `--skip-quantization`.

## Key fixes

| Problem | Fix |
| :--- | :--- |
| Qdrant overfilled (683K pts, status red) | Remediation script + strict 30-ep cap + embedding budget |
| 4x redundant work per run | Single global pass |
| Daily cost undercounted up to 5x | Per-day accumulation across runs |
| Chart rows wiped on iTunes 403 | Failed fetch skips deletes for that pair |
| Flags set before vectors durable | `wait=true` upserts, flag flip after |
| Cleanup thrash on chart churn | 7-day grace period |
| Schema drift from auto-ALTER | Fixed column whitelist |
| Silent failures | Non-zero exits + stats flushed in `finally` |

## Rollout plan

1. Merge; scheduled runs pick up the new pipeline immediately.
2. Dispatch `remediate-qdrant-dry-run` to review the deletion plan (a local dry-run against the live cluster is in progress).
3. Dispatch `remediate-qdrant` to execute and enable quantization.
4. Legacy scripts under `scripts/` (`vectorize.js`, `populate-charts.js`, etc.) are intentionally kept for one release and will be removed in a follow-up PR once the new pipeline has run clean for a few days.

## Test plan

- [x] `node --check` on all 17 new files
- [x] Remediation dry-run connects to live Qdrant + Turso and measures state correctly
- [ ] Review remediation dry-run deletion plan
- [ ] First scheduled run: verify step summary tables, cost report, and state commit
- [ ] Dispatch remediation (live) and confirm cluster returns to green

Made with [Cursor](https://cursor.com)