### PR TITLE
fix(sync): skip chart refresh if already run within 20h

### DIFF
--- a/scripts/sync/01-refresh-charts.js
+++ b/scripts/sync/01-refresh-charts.js
@@ -71,15 +71,37 @@ function rowKey(country, category, itunesId) {
     return `${country}|${category}|${itunesId}`;
 }
 
+// Charts are expensive to refresh (~36k writes). Skip if already refreshed
+// within this window to protect the daily write budget when multiple runs
+// or manual dispatches fire close together.
+const CHARTS_REFRESH_MIN_GAP_MS = 20 * 60 * 60 * 1000; // 20 hours
+const FORCE = process.argv.includes('--force');
+
 async function main() {
     turso.assertEnv();
     turso.beginStep('refresh-charts');
     await turso.healthCheck();
 
+    // --- Skip-if-fresh gate ---
+    // Load state once here so we can reuse it when saving chartsRefreshedAt below.
+    const st = state.load();
+    const ageMs = Date.now() - (st.chartsRefreshedAt || 0);
+    const ageH = (ageMs / 3600000).toFixed(1);
+    if (!FORCE && ageMs < CHARTS_REFRESH_MIN_GAP_MS) {
+        log.banner('Stage 1 · Refresh Charts', {
+            'Countries': cfg.ALL_COUNTRIES.map(c => c.toUpperCase()).join(', '),
+            'Skipped': `Charts refreshed ${ageH}h ago (threshold 20h) — use --force to override`,
+        });
+        turso.flushStats();
+        return;
+    }
+    // (st is reused below when saving chartsRefreshedAt)
+
     log.banner('Stage 1 · Refresh Charts', {
         'Countries': cfg.ALL_COUNTRIES.map(c => c.toUpperCase()).join(', '),
         'Categories': String(cfg.CATEGORIES.length),
         'Chart fetches': String(cfg.ALL_COUNTRIES.length * cfg.CATEGORIES.length),
+        ...(FORCE ? { 'Mode': '--force (skip-if-fresh bypassed)' } : {}),
     });
 
     // --- Read the entire charts table once and index it ---
@@ -173,7 +195,6 @@ async function main() {
     }
 
     // Record charts refresh time in state so stage 3 refreshes its candidate cache
-    const st = state.load();
     st.chartsRefreshedAt = Date.now();
     state.save(st);
 


### PR DESCRIPTION
## Summary

- Charts cost ~36k writes per run due to iTunes rank churn. Multiple manual dispatches or back-to-back scheduled runs each paid this full cost, putting daily writes at ~58% of the free-tier budget.
- Adds a 20h skip-if-fresh gate at the top of stage 1 using the existing `chartsRefreshedAt` field in `scripts/data/sync_cache.json`. If the last refresh is < 20h old the stage exits cleanly with zero DB writes.
- `--force` flag bypasses the gate when an explicit fresh pull is needed locally.
- Reuses the `st` object already loaded at gate-check time for the final `state.save()` — no double read.

## Test plan

- [ ] Trigger a manual `workflow_dispatch` sync run after a recent scheduled run and confirm Stage 1 logs "Charts refreshed Xh ago — skipping" with 0 writes
- [ ] Confirm the 00:00 scheduled run (or a run > 20h after the last refresh) still runs the full chart fetch normally
- [ ] Confirm `--force` flag overrides the gate when needed locally

Made with [Cursor](https://cursor.com)