### PR TITLE
fix(learn): isolate learn screen playback queue

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -1328,7 +1328,7 @@ class MainActivity : ComponentActivity() {
                                             artist = episode.podcastTitle ?: "Unknown",
                                             imageUrl = episode.podcastImageUrl ?: episode.imageUrl ?: ""
                                         )
-                                        queueManager.addToQueue(episode, podcast)
+                                         queueManager.addToQueue(episode, podcast, cx.aswin.boxcast.core.model.PlaybackEntryPoint.LEARN)
                                     },
                                     onPodcastClick = { feedId, itunesId, feedUrl, title ->
                                         val pId = feedId?.toString() ?: ""

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -691,12 +691,12 @@ class PlaybackRepository(
                         activePlaybackStartTimeMs = 0L
                     }
                     // Use mediaId to find episode — more reliable than index
-                    val episodeId = mediaItem?.mediaId ?: return
+                    val episodeId = mediaItem?.mediaId?.removePrefix("learn:") ?: return
                     val queue = _playerState.value.queue
                     val oldState = _playerState.value
                     
                     val slotIndex = queue.indexOfFirst { it.id == episodeId }
-                    android.util.Log.d("PlaybackRepo", "onMediaItemTransition: mediaId=$episodeId, slotIndex=$slotIndex, queueSize=${queue.size}, reason=$reason")
+                    android.util.Log.d("PlaybackRepo", "onMediaItemTransition: mediaId=${mediaItem?.mediaId}, stripped=$episodeId, slotIndex=$slotIndex, queueSize=${queue.size}, reason=$reason")
                     
                     // Sleep Timer: End of Episode — intercept auto-advance
                     if (oldState.sleepAtEndOfEpisode && reason == androidx.media3.common.Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
@@ -1061,11 +1061,13 @@ class PlaybackRepository(
     }
 
     private fun buildMediaItems(episodes: List<Episode>, podcast: Podcast, entryPointContext: android.os.Bundle?): List<MediaItem> {
+        val entryPoint = entryPointContext?.getString("entry_point")
+        val isLearn = entryPoint == "learn"
         return episodes.map { episode ->
             val resolvedUrl = episode.imageUrl?.takeIf { it.isNotBlank() } 
                     ?: episode.podcastImageUrl?.takeIf { it.isNotBlank() } 
                     ?: podcast.imageUrl
-            Log.d("PlaybackRepo", "playQueue: epId=${episode.id}, title='${episode.title}', resolvedImageUrl='$resolvedUrl'")
+            Log.d("PlaybackRepo", "playQueue: epId=${episode.id}, title='${episode.title}', resolvedImageUrl='$resolvedUrl', isLearn=$isLearn")
             val metadata = androidx.media3.common.MediaMetadata.Builder()
                .setTitle(episode.title)
                .setArtist(episode.podcastTitle ?: podcast.title)
@@ -1076,10 +1078,11 @@ class PlaybackRepository(
                .setExtras(entryPointContext)
                .build()
       
+            val mediaId = if (isLearn) "learn:${episode.id}" else episode.id
             MediaItem.Builder()
                .setUri(episode.audioUrl)
                .setMediaMetadata(metadata)
-               .setMediaId(episode.id)
+               .setMediaId(mediaId)
                .setCustomCacheKey(episode.id)
                .build()
         }
@@ -1366,7 +1369,7 @@ class PlaybackRepository(
                 var positionInQueue = -1
                 mediaController?.let { controller ->
                     for (i in 0 until controller.mediaItemCount) {
-                        if (controller.getMediaItemAt(i).mediaId == episodeId) {
+                        if (controller.getMediaItemAt(i).mediaId.removePrefix("learn:") == episodeId) {
                             positionInQueue = i
                             break
                         }
@@ -1386,7 +1389,7 @@ class PlaybackRepository(
         mediaController?.let { controller ->
             for (i in 0 until controller.mediaItemCount) {
                 val item = controller.getMediaItemAt(i)
-                if (item.mediaId == episodeId) {
+                if (item.mediaId.removePrefix("learn:") == episodeId) {
                     controller.removeMediaItem(i)
                     removedFromController = true
                     break
@@ -1698,7 +1701,7 @@ class PlaybackRepository(
         val targetEpisode = _playerState.value.queue.getOrNull(index)
         if (targetEpisode != null) {
             for (i in 0 until controller.mediaItemCount) {
-                if (controller.getMediaItemAt(i).mediaId == targetEpisode.id) {
+                if (controller.getMediaItemAt(i).mediaId.removePrefix("learn:") == targetEpisode.id) {
                     android.util.Log.d("PlaybackRepo", "skipToEpisode: Found mediaId=${targetEpisode.id} at Media3 index $i")
                     
                     storePendingEntryPoint(entryPointContext)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -27,6 +27,8 @@ import cx.aswin.boxcast.core.designsystem.components.AutoTranscriptState
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 
+private const val LEARN_PREFIX = "learn:"
+
 data class PlaybackSession(
     val podcastId: String,
     val episodeId: String,
@@ -691,12 +693,12 @@ class PlaybackRepository(
                         activePlaybackStartTimeMs = 0L
                     }
                     // Use mediaId to find episode — more reliable than index
-                    val episodeId = mediaItem?.mediaId?.removePrefix("learn:") ?: return
+                    val episodeId = mediaItem?.mediaId?.removePrefix(LEARN_PREFIX) ?: return
                     val queue = _playerState.value.queue
                     val oldState = _playerState.value
                     
                     val slotIndex = queue.indexOfFirst { it.id == episodeId }
-                    android.util.Log.d("PlaybackRepo", "onMediaItemTransition: mediaId=${mediaItem?.mediaId}, stripped=$episodeId, slotIndex=$slotIndex, queueSize=${queue.size}, reason=$reason")
+                    android.util.Log.d("PlaybackRepo", "onMediaItemTransition: mediaId=${mediaItem.mediaId}, stripped=$episodeId, slotIndex=$slotIndex, queueSize=${queue.size}, reason=$reason")
                     
                     // Sleep Timer: End of Episode — intercept auto-advance
                     if (oldState.sleepAtEndOfEpisode && reason == androidx.media3.common.Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
@@ -878,7 +880,7 @@ class PlaybackRepository(
 
                         // 6. Auto-refill when queue is running low
                         val currentQueueSize = _playerState.value.queue.size
-                        val isLearn = mediaItem?.mediaId?.startsWith("learn:") == true
+                        val isLearn = mediaItem.mediaId.startsWith(LEARN_PREFIX)
                         if (currentQueueSize < QUEUE_REFILL_THRESHOLD && newPodcast != null && !isLearn) {
                             android.util.Log.d("PlaybackRepo", "Queue running low ($currentQueueSize items). Triggering auto-refill.")
                             queueRefillCallback?.invoke(newEpisode, newPodcast)
@@ -1077,7 +1079,7 @@ class PlaybackRepository(
                .setExtras(entryPointContext)
                .build()
       
-            val mediaId = if (isLearn) "learn:${episode.id}" else episode.id
+            val mediaId = if (isLearn) "$LEARN_PREFIX${episode.id}" else episode.id
             MediaItem.Builder()
                .setUri(episode.audioUrl)
                .setMediaMetadata(metadata)
@@ -1245,8 +1247,12 @@ class PlaybackRepository(
         }
     }
 
-    suspend fun addToQueue(episode: Episode, podcast: Podcast) {
-        Log.d("PlaybackRepo", "addToQueue called: episodeId=${episode.id}, title=${episode.title}")
+    suspend fun addToQueue(
+        episode: Episode,
+        podcast: Podcast,
+        entryPoint: PlaybackEntryPoint = PlaybackEntryPoint.GENERIC
+    ) {
+        Log.d("PlaybackRepo", "addToQueue called: episodeId=${episode.id}, title=${episode.title}, entryPoint=$entryPoint")
         
         // Prevent Duplicates in active queue (by ID)
         if (_playerState.value.queue.any { it.id == episode.id }) {
@@ -1280,11 +1286,13 @@ class PlaybackRepository(
                 .setSubtitle(podcast.title)
                 .setGenre(episode.podcastGenre ?: podcast.genre)
                 .build()
-       
+        
+             val isLearn = entryPoint == PlaybackEntryPoint.LEARN
+             val mediaId = if (isLearn) "$LEARN_PREFIX${episode.id}" else episode.id
              val mediaItem = MediaItem.Builder()
                 .setUri(episode.audioUrl)
                 .setMediaMetadata(metadata)
-                .setMediaId(episode.id)
+                .setMediaId(mediaId)
                 .setCustomCacheKey(episode.id) // Match DownloadRequest custom key
                 .build()
                 
@@ -1368,7 +1376,7 @@ class PlaybackRepository(
                 var positionInQueue = -1
                 mediaController?.let { controller ->
                     for (i in 0 until controller.mediaItemCount) {
-                        if (controller.getMediaItemAt(i).mediaId.removePrefix("learn:") == episodeId) {
+                        if (controller.getMediaItemAt(i).mediaId.removePrefix(LEARN_PREFIX) == episodeId) {
                             positionInQueue = i
                             break
                         }
@@ -1388,7 +1396,7 @@ class PlaybackRepository(
         mediaController?.let { controller ->
             for (i in 0 until controller.mediaItemCount) {
                 val item = controller.getMediaItemAt(i)
-                if (item.mediaId.removePrefix("learn:") == episodeId) {
+                if (item.mediaId.removePrefix(LEARN_PREFIX) == episodeId) {
                     controller.removeMediaItem(i)
                     removedFromController = true
                     break
@@ -1700,7 +1708,7 @@ class PlaybackRepository(
         val targetEpisode = _playerState.value.queue.getOrNull(index)
         if (targetEpisode != null) {
             for (i in 0 until controller.mediaItemCount) {
-                if (controller.getMediaItemAt(i).mediaId.removePrefix("learn:") == targetEpisode.id) {
+                if (controller.getMediaItemAt(i).mediaId.removePrefix(LEARN_PREFIX) == targetEpisode.id) {
                     android.util.Log.d("PlaybackRepo", "skipToEpisode: Found mediaId=${targetEpisode.id} at Media3 index $i")
                     
                     storePendingEntryPoint(entryPointContext)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -878,8 +878,7 @@ class PlaybackRepository(
 
                         // 6. Auto-refill when queue is running low
                         val currentQueueSize = _playerState.value.queue.size
-                        val currentItem = mediaController?.currentMediaItem
-                        val isLearn = currentItem?.mediaMetadata?.extras?.getString("entry_point") == "learn"
+                        val isLearn = mediaItem?.mediaId?.startsWith("learn:") == true
                         if (currentQueueSize < QUEUE_REFILL_THRESHOLD && newPodcast != null && !isLearn) {
                             android.util.Log.d("PlaybackRepo", "Queue running low ($currentQueueSize items). Triggering auto-refill.")
                             queueRefillCallback?.invoke(newEpisode, newPodcast)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -1061,7 +1061,7 @@ class PlaybackRepository(
     }
 
     private fun buildMediaItems(episodes: List<Episode>, podcast: Podcast, entryPointContext: android.os.Bundle?): List<MediaItem> {
-        val entryPoint = entryPointContext?.getString("entry_point")
+        val entryPoint = entryPointContext?.getString("entrypoint") ?: entryPointContext?.getString("entry_point")
         val isLearn = entryPoint == "learn"
         return episodes.map { episode ->
             val resolvedUrl = episode.imageUrl?.takeIf { it.isNotBlank() } 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -878,7 +878,9 @@ class PlaybackRepository(
 
                         // 6. Auto-refill when queue is running low
                         val currentQueueSize = _playerState.value.queue.size
-                        if (currentQueueSize < QUEUE_REFILL_THRESHOLD && newPodcast != null) {
+                        val currentItem = mediaController?.currentMediaItem
+                        val isLearn = currentItem?.mediaMetadata?.extras?.getString("entry_point") == "learn"
+                        if (currentQueueSize < QUEUE_REFILL_THRESHOLD && newPodcast != null && !isLearn) {
                             android.util.Log.d("PlaybackRepo", "Queue running low ($currentQueueSize items). Triggering auto-refill.")
                             queueRefillCallback?.invoke(newEpisode, newPodcast)
                         }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueManager.kt
@@ -103,8 +103,12 @@ class QueueManager @Inject constructor(
         }
     }
 
-    fun addToQueue(episode: EpisodeItem, podcast: cx.aswin.boxcast.core.model.Podcast?) {
-        android.util.Log.d(TAG, "addToQueue called: episodeId=${episode.id}, title=${episode.title}, podcast=${podcast?.title}")
+    fun addToQueue(
+        episode: EpisodeItem,
+        podcast: cx.aswin.boxcast.core.model.Podcast?,
+        entryPoint: PlaybackEntryPoint = PlaybackEntryPoint.GENERIC
+    ) {
+        android.util.Log.d(TAG, "addToQueue called: episodeId=${episode.id}, title=${episode.title}, podcast=${podcast?.title}, entryPoint=$entryPoint")
         scope.launch {
             if (podcast != null) {
                 // Persist
@@ -112,7 +116,7 @@ class QueueManager @Inject constructor(
                 
                 // Add to Player
                 val domainEpisode = episode.toDomain(podcast)
-                playbackRepository.addToQueue(domainEpisode, podcast)
+                playbackRepository.addToQueue(domainEpisode, podcast, entryPoint)
                 android.util.Log.d(TAG, "addToQueue: Complete. Current queue size: ${playbackRepository.playerState.value.queue.size}")
             } else {
                 android.util.Log.e(TAG, "addToQueue: Podcast is null, ignoring!")
@@ -120,9 +124,13 @@ class QueueManager @Inject constructor(
         }
     }
     
-    fun addToQueue(episode: cx.aswin.boxcast.core.model.Episode, podcast: cx.aswin.boxcast.core.model.Podcast?) {
+    fun addToQueue(
+        episode: cx.aswin.boxcast.core.model.Episode,
+        podcast: cx.aswin.boxcast.core.model.Podcast?,
+        entryPoint: PlaybackEntryPoint = PlaybackEntryPoint.GENERIC
+    ) {
         val item = episode.toEpisodeItem(podcast)
-        addToQueue(item, podcast)
+        addToQueue(item, podcast, entryPoint)
     }
 
     // Overload for Domain Objects (UI)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -212,7 +212,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 endPlaybackSession(forceCompleted = wasAutoCompleted, isTransition = true)
                 
                 if (player.isPlaying) {
-                    val episodeId = mediaItem?.mediaId?.removePrefix("episode:")?.removePrefix("queue:")
+                    val episodeId = mediaItem?.mediaId?.removePrefix("learn:")?.removePrefix("episode:")?.removePrefix("queue:")
                     if (episodeId != null) startPlaybackSession(episodeId, mediaItem)
                     activePlaybackStartTimeMs = System.currentTimeMillis()
                 } else {
@@ -223,7 +223,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 android.util.Log.d("AutoQueue", "onMediaItemTransition: remaining=$remaining, reason=$reason")
 
                 val currentItem = player.currentMediaItem
-                val isLearn = currentItem?.mediaMetadata?.extras?.getString("entry_point") == "learn"
+                val isLearn = currentItem?.mediaId?.startsWith("learn:") == true
 
                 if (remaining <= 2 && !isRefilling && player.mediaItemCount > 0 && !isLearn) {
                     isRefilling = true
@@ -265,7 +265,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
         player.addListener(object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 val currentItem = player.currentMediaItem
-                val episodeId = currentItem?.mediaId?.removePrefix("episode:")?.removePrefix("queue:")
+                val episodeId = currentItem?.mediaId?.removePrefix("learn:")?.removePrefix("episode:")?.removePrefix("queue:")
                 
                 if (isPlaying) {
                     // Telemetry: Started playing
@@ -698,9 +698,8 @@ class BoxLorePlaybackService : MediaLibraryService() {
      */
     private suspend fun refillQueue(player: ExoPlayer) {
         val currentItem = player.currentMediaItem ?: return
-        
-        // Extract episode info — strip any prefix for consistent ID format
-        val episodeId = currentItem.mediaId.removePrefix("episode:").removePrefix("queue:")
+             // Extract episode info — strip any prefix for consistent ID format
+        val episodeId = currentItem.mediaId.removePrefix("learn:").removePrefix("episode:").removePrefix("queue:")
         val metadata = currentItem.mediaMetadata
         
         android.util.Log.d("AutoQueue", "Refilling from: ${metadata.title}, episodeId=$episodeId")
@@ -745,11 +744,11 @@ class BoxLorePlaybackService : MediaLibraryService() {
         if (nextEntries.isNotEmpty()) {
             val refilledEpisodeIds = mutableListOf<String>()
             val recommendationSources = mutableListOf<String>()
-
+ 
             // Collect existing mediaIds to avoid duplicates
             val existingIds = kotlinx.coroutines.withContext(mainDispatcher) {
                 (0 until player.mediaItemCount).map { 
-                    player.getMediaItemAt(it).mediaId.removePrefix("episode:").removePrefix("queue:")
+                    player.getMediaItemAt(it).mediaId.removePrefix("learn:").removePrefix("episode:").removePrefix("queue:")
                 }.toSet()
             }
             
@@ -941,7 +940,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
             val currentItem = kotlinx.coroutines.withContext(mainDispatcher) { player.currentMediaItem }
             val positionMs = kotlinx.coroutines.withContext(mainDispatcher) { player.currentPosition }
             val durationMs = kotlinx.coroutines.withContext(mainDispatcher) { player.duration }
-            val episodeId = currentItem?.mediaId?.removePrefix("episode:")?.removePrefix("queue:") ?: return
+            val episodeId = currentItem?.mediaId?.removePrefix("learn:")?.removePrefix("episode:")?.removePrefix("queue:") ?: return
             
             val existing = database.listeningHistoryDao().getHistoryItem(episodeId)
             if (existing != null && positionMs > 0) {
@@ -1007,7 +1006,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
         val player = exoPlayer ?: return
         val currentItem = player.currentMediaItem
         val durationMs = player.duration
-        val episodeId = currentItem?.mediaId?.removePrefix("episode:")?.removePrefix("queue:")
+        val episodeId = currentItem?.mediaId?.removePrefix("learn:")?.removePrefix("episode:")?.removePrefix("queue:")
         if (episodeId != null) {
             serviceScope.launch {
                 try {
@@ -1633,7 +1632,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 }
                 
                 val resolvedItem = resolveMediaItem(selectedItem)
-                val episodeId = selectedItem.mediaId.removePrefix("episode:").removePrefix("queue:")
+                val episodeId = selectedItem.mediaId.removePrefix("learn:").removePrefix("episode:").removePrefix("queue:")
                 android.util.Log.d("AutoBrowse", "Returning episode instantly: $episodeId")
                 
                 val historyItem = database.listeningHistoryDao().getHistoryItem(episodeId)
@@ -1646,7 +1645,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     pendingSeekEpisodeId = null
                 }
                 
-                val isLearn = selectedItem.mediaMetadata.extras?.getString("entry_point") == "learn"
+                val isLearn = selectedItem.mediaId.startsWith("learn:")
                 if (!isLearn) {
                     buildAndAppendQueueAsync(episodeId, mediaSession)
                 } else {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.guava.future
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
+private const val LEARN_PREFIX = "learn:"
+
 class BoxLorePlaybackService : MediaLibraryService() {
 
     private var mediaSession: MediaLibrarySession? = null
@@ -212,7 +214,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 endPlaybackSession(forceCompleted = wasAutoCompleted, isTransition = true)
                 
                 if (player.isPlaying) {
-                    val episodeId = mediaItem?.mediaId?.removePrefix("learn:")?.removePrefix("episode:")?.removePrefix("queue:")
+                    val episodeId = mediaItem?.mediaId?.removePrefix(LEARN_PREFIX)?.removePrefix("episode:")?.removePrefix("queue:")
                     if (episodeId != null) startPlaybackSession(episodeId, mediaItem)
                     activePlaybackStartTimeMs = System.currentTimeMillis()
                 } else {
@@ -223,7 +225,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 android.util.Log.d("AutoQueue", "onMediaItemTransition: remaining=$remaining, reason=$reason")
 
                 val currentItem = player.currentMediaItem
-                val isLearn = currentItem?.mediaId?.startsWith("learn:") == true
+                val isLearn = currentItem?.mediaId?.startsWith(LEARN_PREFIX) == true
 
                 if (remaining <= 2 && !isRefilling && player.mediaItemCount > 0 && !isLearn) {
                     isRefilling = true
@@ -265,7 +267,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
         player.addListener(object : Player.Listener {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 val currentItem = player.currentMediaItem
-                val episodeId = currentItem?.mediaId?.removePrefix("learn:")?.removePrefix("episode:")?.removePrefix("queue:")
+                val episodeId = currentItem?.mediaId?.removePrefix(LEARN_PREFIX)?.removePrefix("episode:")?.removePrefix("queue:")
                 
                 if (isPlaying) {
                     // Telemetry: Started playing
@@ -699,7 +701,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
     private suspend fun refillQueue(player: ExoPlayer) {
         val currentItem = player.currentMediaItem ?: return
              // Extract episode info — strip any prefix for consistent ID format
-        val episodeId = currentItem.mediaId.removePrefix("learn:").removePrefix("episode:").removePrefix("queue:")
+        val episodeId = currentItem.mediaId.removePrefix(LEARN_PREFIX).removePrefix("episode:").removePrefix("queue:")
         val metadata = currentItem.mediaMetadata
         
         android.util.Log.d("AutoQueue", "Refilling from: ${metadata.title}, episodeId=$episodeId")
@@ -748,7 +750,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
             // Collect existing mediaIds to avoid duplicates
             val existingIds = kotlinx.coroutines.withContext(mainDispatcher) {
                 (0 until player.mediaItemCount).map { 
-                    player.getMediaItemAt(it).mediaId.removePrefix("learn:").removePrefix("episode:").removePrefix("queue:")
+                    player.getMediaItemAt(it).mediaId.removePrefix(LEARN_PREFIX).removePrefix("episode:").removePrefix("queue:")
                 }.toSet()
             }
             
@@ -940,7 +942,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
             val currentItem = kotlinx.coroutines.withContext(mainDispatcher) { player.currentMediaItem }
             val positionMs = kotlinx.coroutines.withContext(mainDispatcher) { player.currentPosition }
             val durationMs = kotlinx.coroutines.withContext(mainDispatcher) { player.duration }
-            val episodeId = currentItem?.mediaId?.removePrefix("learn:")?.removePrefix("episode:")?.removePrefix("queue:") ?: return
+            val episodeId = currentItem?.mediaId?.removePrefix(LEARN_PREFIX)?.removePrefix("episode:")?.removePrefix("queue:") ?: return
             
             val existing = database.listeningHistoryDao().getHistoryItem(episodeId)
             if (existing != null && positionMs > 0) {
@@ -1006,7 +1008,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
         val player = exoPlayer ?: return
         val currentItem = player.currentMediaItem
         val durationMs = player.duration
-        val episodeId = currentItem?.mediaId?.removePrefix("learn:")?.removePrefix("episode:")?.removePrefix("queue:")
+        val episodeId = currentItem?.mediaId?.removePrefix(LEARN_PREFIX)?.removePrefix("episode:")?.removePrefix("queue:")
         if (episodeId != null) {
             serviceScope.launch {
                 try {
@@ -1633,8 +1635,8 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 
                 android.util.Log.d("BoxCastPlayer", "onAddMediaItems: selectedItem.mediaId=${selectedItem.mediaId}, extrasKeys=${selectedItem.mediaMetadata.extras?.keySet()?.joinToString(", ")}")
                 val resolvedItem = resolveMediaItem(selectedItem)
-                val episodeId = selectedItem.mediaId.removePrefix("learn:").removePrefix("episode:").removePrefix("queue:")
-                android.util.Log.d("AutoBrowse", "Returning episode instantly: $episodeId, startsWithLearn=${selectedItem.mediaId.startsWith("learn:")}")
+                val episodeId = selectedItem.mediaId.removePrefix(LEARN_PREFIX).removePrefix("episode:").removePrefix("queue:")
+                android.util.Log.d("AutoBrowse", "Returning episode instantly: $episodeId, startsWithLearn=${selectedItem.mediaId.startsWith(LEARN_PREFIX)}")
                 
                 val historyItem = database.listeningHistoryDao().getHistoryItem(episodeId)
                 if (historyItem != null && historyItem.progressMs > 2000 && !historyItem.isCompleted) {
@@ -1646,7 +1648,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     pendingSeekEpisodeId = null
                 }
                 
-                val isLearn = selectedItem.mediaId.startsWith("learn:")
+                val isLearn = selectedItem.mediaId.startsWith(LEARN_PREFIX)
                 android.util.Log.d("AutoBrowse", "onAddMediaItems check isLearn=$isLearn")
                 if (!isLearn) {
                     buildAndAppendQueueAsync(episodeId, mediaSession)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -222,7 +222,10 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 val remaining = player.mediaItemCount - player.currentMediaItemIndex - 1
                 android.util.Log.d("AutoQueue", "onMediaItemTransition: remaining=$remaining, reason=$reason")
 
-                if (remaining <= 2 && !isRefilling && player.mediaItemCount > 0) {
+                val currentItem = player.currentMediaItem
+                val isLearn = currentItem?.mediaMetadata?.extras?.getString("entry_point") == "learn"
+
+                if (remaining <= 2 && !isRefilling && player.mediaItemCount > 0 && !isLearn) {
                     isRefilling = true
                     serviceScope.launch {
                         try {
@@ -1643,7 +1646,12 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     pendingSeekEpisodeId = null
                 }
                 
-                buildAndAppendQueueAsync(episodeId, mediaSession)
+                val isLearn = selectedItem.mediaMetadata.extras?.getString("entry_point") == "learn"
+                if (!isLearn) {
+                    buildAndAppendQueueAsync(episodeId, mediaSession)
+                } else {
+                    android.util.Log.d("AutoBrowse", "Learn screen entry point detected: skipping async queue append")
+                }
                 mutableListOf(resolvedItem)
             }
         }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -1631,9 +1631,10 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     return@future handlePlayAllNewEpisodes()
                 }
                 
+                android.util.Log.d("BoxCastPlayer", "onAddMediaItems: selectedItem.mediaId=${selectedItem.mediaId}, extrasKeys=${selectedItem.mediaMetadata.extras?.keySet()?.joinToString(", ")}")
                 val resolvedItem = resolveMediaItem(selectedItem)
                 val episodeId = selectedItem.mediaId.removePrefix("learn:").removePrefix("episode:").removePrefix("queue:")
-                android.util.Log.d("AutoBrowse", "Returning episode instantly: $episodeId")
+                android.util.Log.d("AutoBrowse", "Returning episode instantly: $episodeId, startsWithLearn=${selectedItem.mediaId.startsWith("learn:")}")
                 
                 val historyItem = database.listeningHistoryDao().getHistoryItem(episodeId)
                 if (historyItem != null && historyItem.progressMs > 2000 && !historyItem.isCompleted) {
@@ -1646,6 +1647,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 }
                 
                 val isLearn = selectedItem.mediaId.startsWith("learn:")
+                android.util.Log.d("AutoBrowse", "onAddMediaItems check isLearn=$isLearn")
                 if (!isLearn) {
                     buildAndAppendQueueAsync(episodeId, mediaSession)
                 } else {


### PR DESCRIPTION
Prevent auto-refill from appending chronological episodes to the playback queue when playing or swiping cards from the Learn screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Media3 playback paths (media IDs, transitions, refill); prefix stripping must stay consistent everywhere IDs are compared to avoid queue/history mismatches.
> 
> **Overview**
> Learn-screen playback is tagged so **SmartQueue auto-refill** and **async queue append** no longer pull in chronological or recommended episodes when users play or queue from Learn.
> 
> Learn sessions use a **`learn:` Media3 `mediaId` prefix** when the entry point is `PlaybackEntryPoint.LEARN` or metadata has `entrypoint`/`entry_point` = `learn` (`buildMediaItems`, `addToQueue`). **MainActivity** passes `PlaybackEntryPoint.LEARN` when queueing from Learn. **QueueManager** forwards an optional `entryPoint` into the repository.
> 
> **PlaybackRepository** and **BoxLorePlaybackService** skip refill when the current item’s `mediaId` starts with `learn:`; the service also skips `buildAndAppendQueueAsync` for those items in `onAddMediaItems`. Queue navigation, skip/remove, and episode ID resolution **strip `learn:`** before comparing to episode IDs so behavior stays aligned with the in-app queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91c7d8266cc3c03f0aed366906c3a89b9524428f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->