### PR TITLE
fix(timer): dismiss sleep nudge immediately if hidden while confirming

### DIFF
--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/SleepTimerPopup.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/SleepTimerPopup.kt
@@ -79,6 +79,10 @@ fun SleepTimerPopup(
     LaunchedEffect(visible) {
         if (visible) {
             isConfirming = false
+        } else {
+            if (isConfirming) {
+                onDismiss(SleepTimerPopupDismissReason.Confirmation)
+            }
         }
     }
 


### PR DESCRIPTION
Resolves the Cursor Bugbot issue on PR 830 where the sleep timer nudge would fail to dismiss in the repository if the popup was hidden or composition scope changed before the 1.8-second confirmation timer completed.