### PR TITLE
fix(sync): normalize candidate IDs and force refresh on new imports

### DIFF
--- a/scripts/sync/02-import-podcasts.js
+++ b/scripts/sync/02-import-podcasts.js
@@ -227,6 +227,7 @@ function registerImportedCandidates(importedIds) {
         return;
     }
 
+    st.candidateIds = (st.candidateIds || []).map(String);
     const known = new Set(st.candidateIds);
     let added = 0;
     for (const podId of importedIds) {
@@ -239,6 +240,7 @@ function registerImportedCandidates(importedIds) {
     }
     if (added === 0) return;
 
+    st.candidatesRefreshedAt = 0; // Force Stage 3 to refresh from Turso and seed 'n' (News) flags
     state.save(st);
     log.info(`[CANDIDATES] Registered ${added} newly imported shows for episode sync (existing check history unchanged)`);
 }

--- a/scripts/sync/lib/state.js
+++ b/scripts/sync/lib/state.js
@@ -38,6 +38,9 @@ function load() {
     }
 
     if (raw.version === 2 && raw.shows) {
+        if (raw.candidateIds) {
+            raw.candidateIds = raw.candidateIds.map(String);
+        }
         return raw;
     }
 


### PR DESCRIPTION
Resolves the remaining open Qodo bugs on PR 829. Normalizes candidateIds to String to prevent type-mixed duplicate entries, and resets candidatesRefreshedAt to 0 when new shows are imported to force a candidate data refresh in Stage 3.