### PR TITLE
fix(sync): resolve Qdrant orphan, CSV newline, cost reporting, and budget bypass issues in sync pipeline

### DIFF
--- a/.github/workflows/sync-pi-data.yml
+++ b/.github/workflows/sync-pi-data.yml
@@ -94,7 +94,7 @@ jobs:
               p.itunesId AS itunes_id,
               p.title,
               p.itunesAuthor AS author,
-              p.description,
+              REPLACE(REPLACE(p.description, char(10), ' '), char(13), ' ') AS description,
               p.imageUrl AS image_url,
               p.url AS feed_url,
               p.link AS website_url,
@@ -119,6 +119,8 @@ jobs:
         run: node scripts/sync/04-vectorize-episodes.js
 
       - name: 'Stage 5: Vectorize shows'
+        env:
+          MAX_EMBEDDINGS_PER_RUN: ${{ inputs.embedding_budget || '6000' }}
         run: node scripts/sync/05-vectorize-shows.js
 
       - name: 'Stage 7: Record DB cost stats'
@@ -177,6 +179,10 @@ jobs:
       - name: 'Stage 6: Cleanup non-chart shows (7-day grace)'
         run: node scripts/sync/06-cleanup-non-chart.js
 
+      - name: 'Stage 7: Record DB cost stats'
+        if: always()
+        run: node scripts/sync/07-record-stats.js
+
       - name: Commit pipeline state
         run: |
           git config user.name "github-actions[bot]"
@@ -185,7 +191,7 @@ jobs:
           # Stage and commit BEFORE any rebase: an up-front pull fails on the
           # unstaged sync_cache.json changes stage 6 just wrote. The push
           # retry loop below rebases only after committing, like the sync job.
-          git add scripts/data/sync_cache.json
+          git add scripts/data/sync_cache.json scripts/data/db_cost_history.json scripts/data/db_cost_report.md
           if git diff --cached --quiet; then
             echo "No state changes to commit"
             exit 0

--- a/scripts/sync/06-cleanup-non-chart.js
+++ b/scripts/sync/06-cleanup-non-chart.js
@@ -103,6 +103,7 @@ async function main() {
 
     // --- Qdrant deletion first (needs the id list) ---
     log.group('Qdrant vector deletion');
+    let qdrantFailed = false;
     for (let i = 0; i < toDelete.length; i += QDRANT_CHUNK) {
         const chunk = toDelete.slice(i, i + QDRANT_CHUNK);
         const intIds = chunk.map(p => parseInt(p.id, 10)).filter(n => !isNaN(n));
@@ -115,9 +116,14 @@ async function main() {
             log.info(`Deleted vectors for shows ${i + 1}-${Math.min(i + QDRANT_CHUNK, toDelete.length)} of ${toDelete.length}`);
         } catch (e) {
             log.error(`Qdrant deletion failed for chunk at ${i}: ${e.message}`);
+            qdrantFailed = true;
         }
     }
     log.endGroup();
+
+    if (qdrantFailed) {
+        throw new Error('Aborting Turso cleanup because one or more Qdrant vector deletions failed');
+    }
 
     // --- Turso deletion with trigger workaround ---
     log.group('Turso deletion');


### PR DESCRIPTION
Resolves the 4 open Qodo bugs on PR 827: Aborts cleanup if Qdrant deletions fail, sanitizes descriptions at export time in sqlite3 to avoid multiline CSV corruption, aggregates DB cost stats for the cleanup job, and respects manual embedding budget overrides in Stage 5.