### PR TITLE
fix(onboarding): pop onboarding and set completed flag before recreating activity, and normalize region code ind/uk aliases

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -2395,9 +2395,12 @@ class MainActivity : ComponentActivity() {
                                 // is effectively complete. Mark it unconditionally — idempotent when
                                 // already completed (e.g. restoring from Settings) — so an import
                                 // during onboarding never bounces the user back to the welcome screen.
-                                // Relying on currentRoute here was fragile: it falls back to "home"
-                                // whenever the nav back-stack entry is momentarily null. Then recreate
-                                // to load the restored library fresh.
+                                if (currentRoute == "onboarding") {
+                                    onboardingCompleted = true
+                                    navController.navigate("home") {
+                                        popUpTo("onboarding") { inclusive = true }
+                                    }
+                                }
                                 onboardingViewModel.markOnboardingCompletedSilent {
                                     this@MainActivity.recreate()
                                 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PodcastRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PodcastRepository.kt
@@ -37,7 +37,7 @@ private fun String?.toHttps(): String {
 fun mapRegionForBriefing(region: String): String {
     return when (region.lowercase().trim()) {
         "us" -> "us"
-        "in" -> "in"
+        "in", "ind" -> "in"
         "uk", "gb" -> "uk"
         else -> "global"
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
@@ -65,6 +65,15 @@ class UserPreferencesRepository(context: Context) {
         val AUTO_DOWNLOAD_DELETE_COMPLETED = androidx.datastore.preferences.core.booleanPreferencesKey("auto_download_delete_completed")
     }
 
+    private fun normalizeRegionCode(region: String): String {
+        val normalized = region.trim().lowercase()
+        return when (normalized) {
+            "ind" -> "in"
+            "uk" -> "gb"
+            else -> normalized
+        }
+    }
+
     val regionStream: Flow<String> = dataStore.data
         .catch { exception ->
             if (exception is IOException) {
@@ -74,10 +83,13 @@ class UserPreferencesRepository(context: Context) {
             }
         }
         .map { preferences ->
-            preferences[Keys.REGION] ?: run {
+            val stored = preferences[Keys.REGION]
+            if (stored != null) {
+                normalizeRegionCode(stored)
+            } else {
                 val localeCountry = java.util.Locale.getDefault().country.lowercase()
                 if (localeCountry == "in" || localeCountry == "gb" || localeCountry == "uk") {
-                    localeCountry
+                    normalizeRegionCode(localeCountry)
                 } else {
                     "us"
                 }
@@ -86,8 +98,9 @@ class UserPreferencesRepository(context: Context) {
         .distinctUntilChanged()
 
     suspend fun setRegion(region: String) {
+        val normalized = normalizeRegionCode(region)
         dataStore.edit { preferences ->
-            preferences[Keys.REGION] = region
+            preferences[Keys.REGION] = normalized
             preferences[Keys.HAS_DISMISSED_REGION_NUDGE] = true
         }
     }


### PR DESCRIPTION
Resolves the 2 open Qodo bugs on PR 825. Ensures the user is transitioned to the home route and the onboardingCompleted state is set before recreating the activity to avoid nav loop. Also introduces a normalizeRegionCode helper in UserPreferencesRepository to normalize region code inputs and updates mapRegionForBriefing to support the ind alias.