### PR TITLE
fix(image): remove double density scaling and add density to proxyUrl remember key

### DIFF
--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/ImageOptimization.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/ImageOptimization.kt
@@ -12,13 +12,14 @@ private fun calculateScaledWidth(originalWidth: Int): Int {
         val screenWidthPx = metrics.widthPixels
         val isLargeScreen = (screenWidthPx / density) >= 600f
         
-        val basePixelWidth = originalWidth * density
+        // originalWidth is already in pixels (callers pass dp * ~2), so only apply
+        // a quality multiplier — do NOT multiply by density again.
         val qualityMultiplier = when {
             isLargeScreen -> 2.0f
             density >= 3.5f -> 1.5f
             else -> 1.3f
         }
-        (basePixelWidth * qualityMultiplier).toInt().coerceIn(10, 2048)
+        (originalWidth * qualityMultiplier).toInt().coerceIn(10, 2048)
     } catch (e: Exception) {
         originalWidth
     }

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/OptimizedImage.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/OptimizedImage.kt
@@ -68,7 +68,7 @@ fun OptimizedImage(
     val context = LocalContext.current
     val density = context.resources.displayMetrics.density
     val pxWidth = remember(proxyWidth, density) { (proxyWidth * density).toInt() }
-    val proxyUrl = remember(url, proxyWidth) { url.optimizedImageUrl(proxyWidth) }
+    val proxyUrl = remember(url, proxyWidth, density) { url.optimizedImageUrl(proxyWidth) }
 
     // Check if this url has already failed on the proxy in this app session
     val isProxyKnownFailed = remember(url) { proxyFailedUrls.contains(url) }


### PR DESCRIPTION
Resolves 2 open Qodo bugs on PR 812.

1. **Double density scaling**: calculateScaledWidth() was multiplying originalWidth by density internally, but callers already pass pixel-scaled values (e.g. 400px for a ~180dp element). This double-applied density, frequently clamping to the 2048px cap and producing oversized image downloads. Fix: treat originalWidth as pixels and only apply the quality multiplier.

2. **ProxyUrl stale on density change**: proxyUrl was memoized with remember(url, proxyWidth) but optimizedImageUrl() internally reads displayMetrics.density. Added density to the remember key so the URL recomputes on density changes (foldable unfold, display switch).