### PR TITLE
fix(download): resolve artwork cleanup race and ref-count shared podcast artwork

### DIFF
--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
@@ -171,22 +171,52 @@ class DownloadRepository(
     }
     
     fun removeDownload(episodeId: String) {
-         DownloadService.sendRemoveDownload(
-            context,
-            MediaDownloadService::class.java,
-            episodeId,
-            false
-        )
+        // Capture artwork paths BEFORE triggering removal to avoid a race with
+        // the DownloadManager listener (which deletes the DB row on STATE_REMOVING).
         CoroutineScope(Dispatchers.IO).launch {
+            var episodeImgPath: String? = null
+            var podcastImgPath: String? = null
+            var podcastId: String? = null
             try {
                 val existing = database.downloadedEpisodeDao().getDownload(episodeId)
                 if (existing != null) {
-                    deleteLocalFileIfValid(existing.episodeImageUrl)
-                    deleteLocalFileIfValid(existing.podcastImageUrl)
+                    episodeImgPath = existing.episodeImageUrl
+                    podcastImgPath = existing.podcastImageUrl
+                    podcastId = existing.podcastId
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("DownloadRepo", "Failed to read artwork paths for $episodeId", e)
+            }
+
+            // Now send the remove request
+            try {
+                DownloadService.sendRemoveDownload(
+                    context,
+                    MediaDownloadService::class.java,
+                    episodeId,
+                    false
+                )
+            } catch (e: Exception) {
+                android.util.Log.w("DownloadRepo", "sendRemoveDownload failed for $episodeId", e)
+            }
+
+            // Clean up artwork files
+            try {
+                deleteLocalFileIfValid(episodeImgPath)
+
+                // Only delete shared podcast artwork when no other episodes
+                // from the same podcast still reference it.
+                if (podcastId != null && podcastImgPath != null) {
+                    val othersCount = database.downloadedEpisodeDao()
+                        .countOthersByPodcastId(podcastId, episodeId)
+                    if (othersCount == 0) {
+                        deleteLocalFileIfValid(podcastImgPath)
+                    }
                 }
             } catch (e: Exception) {
                 android.util.Log.e("DownloadRepo", "Failed to clean up artwork files for $episodeId", e)
             }
+
             database.downloadedEpisodeDao().delete(episodeId)
         }
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/database/DownloadedEpisodeDao.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/database/DownloadedEpisodeDao.kt
@@ -26,6 +26,9 @@ interface DownloadedEpisodeDao {
     @Query("SELECT COALESCE(SUM(sizeBytes), 0) FROM downloaded_episodes")
     fun getTotalSizeBytes(): Flow<Long>
 
+    @Query("SELECT COUNT(*) FROM downloaded_episodes WHERE podcastId = :podcastId AND episodeId != :excludeEpisodeId")
+    suspend fun countOthersByPodcastId(podcastId: String, excludeEpisodeId: String): Int
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(entity: DownloadedEpisodeEntity)
 


### PR DESCRIPTION
Resolves 2 open Qodo bugs on PR 811.

1. **Shared podcast artwork deleted prematurely**: Podcast artwork is stored in a shared file (podcast_<podcastId>.png) referenced by all downloaded episodes from the same podcast. Removing one episode was deleting this file, breaking offline artwork for remaining episodes. Fix: added countOthersByPodcastId DAO query and only delete podcast artwork when no other episodes from the same podcast remain.

2. **Race condition — cleanup skipped on delete**: removeDownload() called sendRemoveDownload() first, then queried the DB for artwork paths. But the DownloadManager listener on STATE_REMOVING also deletes the DB row, creating a timing window where artwork paths can't be found. Fix: fetch artwork paths before triggering the remove request.