### PR TITLE
fix(explore): center podcast chip in daily curiosity card when title is long

### DIFF
--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -280,6 +280,7 @@ private fun CuriosityCardContent(
 
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
                     modifier = Modifier
                         .clip(RoundedCornerShape(8.dp))
                         .expressiveClickable(onClick = { onAction(CardAction.PodcastClick) })


### PR DESCRIPTION
Resolves 1 open Qodo bug on PR 810.

**Chip no longer centered in CuriosityCardContent**: Adding weight to the podcast title Text caused the Row container to fill maximum available width when the text is long. Because Row's default horizontal arrangement is Start, this caused the chip elements (text & right arrow icon) to align to the left side of the card rather than staying centered.

Fix: Added  to the containing Row.