### PR TITLE
fix(explore): prevent pagination race when load/refresh is in-flight

### DIFF
--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -167,7 +167,7 @@ class LearnViewModel(
     }
 
     private fun fetchNextPage() {
-        if (isLoadingMore || isEndOfContent) return
+        if (isLoadingMore || isEndOfContent || fetchJob?.isActive == true) return
         if (_uiState.value !is LearnUiState.Success) return
 
         isLoadingMore = true


### PR DESCRIPTION
Resolves 1 open Qodo bug on PR 809.

**Pagination overwrites refreshed state**: If loadData() or refresh() is running, the UI state is either Loading or Success(isRefreshing = true). If the user dismisses a card, fetchNextPage() would be triggered and launch a new coroutine without checking or cancelling the active refresh/load job. This allowed the active refresh and pagination jobs to run concurrently and race to update _uiState.

Fix: Prevent fetchNextPage() from running if there's already an active fetch/load/refresh job (i.e. ).