### PR TITLE
fix(explore): optimize palette request and lock play button clicks on loading

### DIFF
--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -381,7 +381,7 @@ private fun CircularPlayButton(
             .padding(4.dp)
             .clip(CircleShape)
             .then(buttonBackground)
-            .expressiveClickable(onClick = onClick),
+            .expressiveClickable(enabled = !isLoading, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         if (isLoading) {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -89,6 +89,7 @@ import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
 import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import cx.aswin.boxcast.core.designsystem.components.optimizedImageUrl
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.network.model.CuratedCuriosityPodcastDto
@@ -169,9 +170,11 @@ fun LearnScreen(
         }
         try {
             val loader = coil.Coil.imageLoader(context)
+            val optimizedUrl = activeCardImage.optimizedImageUrl(width = 200)
             val request = ImageRequest.Builder(context)
-                .data(activeCardImage)
+                .data(optimizedUrl)
                 .allowHardware(false) // Must be a software bitmap for Palette pixel extraction
+                .size(100, 100) // Constrain decode size in memory for palette extraction
                 .build()
             val result = loader.execute(request)
             if (result is coil.request.SuccessResult) {
@@ -182,6 +185,8 @@ fun LearnScreen(
                         extractDominantColor(bitmap)
                     }
                     extractedColor = color
+                } else {
+                    extractedColor = null
                 }
             } else {
                 extractedColor = null


### PR DESCRIPTION
Resolves remaining Qodo bugs on PR 808.

1. **Unbounded palette decode**: Accent color extraction downloaded and decoded raw, full-resolution cover art solely to build the Palette. Fix: applied optimizedImageUrl(width = 200) to downsize the proxy URL and constrained Coil decode size to 100x100 to optimize memory footprint.

2. **Stale accent color**: When SuccessResult was returned with a null bitmap, extractedColor was left unchanged, leaking the old card's accent color. Fix: clear extractedColor (set to null) in that branch.

3. **Play button clickable when loading**: CircularPlayButton showed a loading spinner but was still clickable. Fix: passed  to the expressiveClickable modifier.