### PR TITLE
feat(ci): enable CHANGELOG.md for Qodo auto-updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ missing_itunes_ids.txt
 scratch/
 
 # Local reference docs (not for repo)
-CHANGELOG.md
 rules.md
 RELEASE_NOTES.md
 ROADMAP.md

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -55,6 +55,10 @@ Do not output anything outside of this exact structure: \
 [pr_update_changelog]
 push_changelog_changes = true
 changelog_file = "CHANGELOG.md"
+extra_instructions = """\
+Only add entries under the [Unreleased] section. \
+Never modify, reorder, or remove any existing versioned sections (e.g. [1.0.0], [2.3.1]). \
+"""
 
 # Defines custom labels for the AI to apply based on code context
 [custom_labels."UI / Compose"]


### PR DESCRIPTION
Removes CHANGELOG.md from .gitignore and commits the existing changelog so Qodo PR-Agent can auto-update it on every PR.