### PR TITLE
feat(engagement): native PostHog NPS surveys and unified prompts

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
@@ -12,13 +12,25 @@ import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderF
 import com.posthog.PostHog
 import com.posthog.android.PostHogAndroid
 import com.posthog.android.PostHogAndroidConfig
+import cx.aswin.boxcast.core.data.EngagementPromptCoordinator
+import cx.aswin.boxcast.core.data.UserPreferencesRepository
 import cx.aswin.boxcast.core.network.NetworkModule
+import cx.aswin.boxcast.surveys.BoxcastPostHogSurveysDelegate
 import java.util.concurrent.TimeUnit
 
 class BoxLoreApplication : Application() {
 
+    lateinit var userPreferencesRepository: UserPreferencesRepository
+        private set
+
+    lateinit var engagementPromptCoordinator: EngagementPromptCoordinator
+        private set
+
     override fun onCreate() {
         super.onCreate()
+
+        userPreferencesRepository = UserPreferencesRepository(this)
+        engagementPromptCoordinator = EngagementPromptCoordinator(userPreferencesRepository)
 
         val config = PostHogAndroidConfig(
             apiKey = BuildConfig.POSTHOG_API_KEY,
@@ -28,6 +40,15 @@ class BoxLoreApplication : Application() {
             captureScreenViews = false
             captureDeepLinks = false
             debug = BuildConfig.DEBUG
+            // PostHog Surveys with a Material3 1.5-compatible delegate (the published
+            // posthog-android-surveys-compose:0.1.0 module crashes against our M3 pin).
+            surveys = true
+            surveysConfig.surveysDelegate =
+                BoxcastPostHogSurveysDelegate(
+                    context = this@BoxLoreApplication,
+                    userPrefs = userPreferencesRepository,
+                    engagementCoordinator = engagementPromptCoordinator,
+                )
         }
         PostHogAndroid.setup(this, config)
 

--- a/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
@@ -23,6 +23,7 @@ class BoxLoreApplication : Application() {
     lateinit var userPreferencesRepository: UserPreferencesRepository
         private set
 
+    /** Shared orchestrator for NPS and Play review proactive prompts. */
     lateinit var engagementPromptCoordinator: EngagementPromptCoordinator
         private set
 

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -70,6 +70,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -151,8 +152,15 @@ class MainActivity : ComponentActivity() {
     
     // Analytics: Deduplicate cold vs warm starts
     private var isFirstResumeAfterLaunch = true
-    
 
+    // NPS survey trigger state (DataStore-backed; reads the same store as the UI layer)
+    private val surveyPrefs by lazy { cx.aswin.boxcast.core.data.UserPreferencesRepository(application) }
+    private val engagementCoordinator by lazy {
+        (application as BoxLoreApplication).engagementPromptCoordinator
+    }
+
+    @Volatile
+    private var isPlaybackActive = false
 
     // Google Play In-App Updates
     private val appUpdateManager by lazy { com.google.android.play.core.appupdate.AppUpdateManagerFactory.create(this) }
@@ -195,6 +203,9 @@ class MainActivity : ComponentActivity() {
         
         // Register the local time of day as a Super Property so it attaches to ALL events
         com.posthog.PostHog.register("local_time_of_day", java.util.Calendar.getInstance().get(java.util.Calendar.HOUR_OF_DAY))
+
+        // NPS survey triggers: deferred auto trigger (ep-3 pending) + console remote trigger.
+        checkNpsSurveyTriggers()
         
         // Check for in-progress updates
         try {
@@ -218,7 +229,50 @@ class MainActivity : ComponentActivity() {
             android.util.Log.e("AppUpdate", "Error checking update status", e)
         }
     }
-    
+
+    /**
+     * Fires NPS survey trigger events on app open.
+     *
+     * 1. Console remote trigger: if the `survey-nps-remote-trigger` flag is enabled for this
+     *    user, fire the manual trigger and reload flags so the one-shot trigger doesn't repeat.
+     * 2. Deferred auto trigger: if the survey was marked pending (ep 3 reached, possibly during
+     *    background playback) and hasn't fired yet, fire it now and mark it fired.
+     *
+     * PostHog owns the survey's display conditions (onboarding status, audience flag, wait
+     * period), so this only emits the trigger events.
+     */
+    private fun checkNpsSurveyTriggers() {
+        try {
+            if (com.posthog.PostHog.isFeatureEnabled("survey-nps-remote-trigger")) {
+                if (engagementCoordinator.canShowProactivePrompt(isPlaybackActive)) {
+                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSurveyNpsManualTrigger(
+                        source = "remote_flag",
+                    )
+                    com.posthog.PostHog.reloadFeatureFlags()
+                }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("NpsSurvey", "Remote trigger check failed", e)
+        }
+
+        lifecycleScope.launch {
+            try {
+                if (surveyPrefs.isNpsSurveyPending() && !surveyPrefs.hasNpsSurveyFired()) {
+                    if (!engagementCoordinator.canShowProactivePrompt(isPlaybackActive)) return@launch
+                    if (!surveyPrefs.isEngagementCooldownElapsed()) return@launch
+
+                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSurveyNpsEligible(
+                        completedEpisodes = surveyPrefs.npsSurveyCompletedCount(),
+                        triggerContext = "app_open",
+                    )
+                    surveyPrefs.markNpsSurveyFired()
+                }
+            } catch (e: Exception) {
+                android.util.Log.e("NpsSurvey", "Deferred trigger check failed", e)
+            }
+        }
+    }
+
     override fun onPause() {
         super.onPause()
     }
@@ -459,6 +513,9 @@ class MainActivity : ComponentActivity() {
             val isPlaying by remember(playbackRepository) {
                 playbackRepository.playerState.map { it.isPlaying }.distinctUntilChanged()
             }.collectAsState(initial = false)
+            LaunchedEffect(isPlaying) {
+                isPlaybackActive = isPlaying
+            }
             val showLateNightNudge by remember(playbackRepository) {
                 playbackRepository.playerState.map { it.showLateNightNudge }.distinctUntilChanged()
             }.collectAsState(initial = false)
@@ -1140,6 +1197,7 @@ class MainActivity : ComponentActivity() {
                                     apiBaseUrl = apiBaseUrl,
                                     publicKey = publicKey,
                                     playbackRepository = playbackRepository,
+                                    engagementPromptCoordinator = (application as BoxLoreApplication).engagementPromptCoordinator,
                                     navController = navController,
                                     onPodcastClick = { podcast, entryPointStr, genreStr, depthVal ->
                                         var route = "podcast/${podcast.id}"

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -160,7 +160,10 @@ class MainActivity : ComponentActivity() {
     }
 
     @Volatile
-    private var isPlaybackActive = false
+    private var playbackRepositoryRef: cx.aswin.boxcast.core.data.PlaybackRepository? = null
+
+    private fun isCurrentlyPlaying(): Boolean =
+        playbackRepositoryRef?.playerState?.value?.isPlaying == true
 
     // Google Play In-App Updates
     private val appUpdateManager by lazy { com.google.android.play.core.appupdate.AppUpdateManagerFactory.create(this) }
@@ -243,13 +246,14 @@ class MainActivity : ComponentActivity() {
      */
     private fun checkNpsSurveyTriggers() {
         try {
-            if (com.posthog.PostHog.isFeatureEnabled("survey-nps-remote-trigger")) {
-                if (engagementCoordinator.canShowProactivePrompt(isPlaybackActive)) {
-                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSurveyNpsManualTrigger(
-                        source = "remote_flag",
-                    )
-                    com.posthog.PostHog.reloadFeatureFlags()
-                }
+            if (
+                com.posthog.PostHog.isFeatureEnabled("survey-nps-remote-trigger") &&
+                engagementCoordinator.canShowProactivePrompt(isCurrentlyPlaying())
+            ) {
+                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSurveyNpsManualTrigger(
+                    source = "remote_flag",
+                )
+                com.posthog.PostHog.reloadFeatureFlags()
             }
         } catch (e: Exception) {
             android.util.Log.e("NpsSurvey", "Remote trigger check failed", e)
@@ -257,10 +261,12 @@ class MainActivity : ComponentActivity() {
 
         lifecycleScope.launch {
             try {
-                if (surveyPrefs.isNpsSurveyPending() && !surveyPrefs.hasNpsSurveyFired()) {
-                    if (!engagementCoordinator.canShowProactivePrompt(isPlaybackActive)) return@launch
-                    if (!surveyPrefs.isEngagementCooldownElapsed()) return@launch
-
+                if (
+                    surveyPrefs.isNpsSurveyPending() &&
+                    !surveyPrefs.hasNpsSurveyFired() &&
+                    engagementCoordinator.canShowProactivePrompt(isCurrentlyPlaying()) &&
+                    surveyPrefs.isEngagementCooldownElapsed()
+                ) {
                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSurveyNpsEligible(
                         completedEpisodes = surveyPrefs.npsSurveyCompletedCount(),
                         triggerContext = "app_open",
@@ -391,6 +397,9 @@ class MainActivity : ComponentActivity() {
 
             // 3. Playback Repository (Depends on QueueRepo)
             val playbackRepository = remember { cx.aswin.boxcast.core.data.PlaybackRepository(application, database.listeningHistoryDao(), queueRepository, podcastRepository) }
+            androidx.compose.runtime.SideEffect {
+                playbackRepositoryRef = playbackRepository
+            }
             val downloadRepository = remember { cx.aswin.boxcast.core.data.DownloadRepository(application, database) }
             
             // 4. Subscription Repository
@@ -513,9 +522,6 @@ class MainActivity : ComponentActivity() {
             val isPlaying by remember(playbackRepository) {
                 playbackRepository.playerState.map { it.isPlaying }.distinctUntilChanged()
             }.collectAsState(initial = false)
-            LaunchedEffect(isPlaying) {
-                isPlaybackActive = isPlaying
-            }
             val showLateNightNudge by remember(playbackRepository) {
                 playbackRepository.playerState.map { it.showLateNightNudge }.distinctUntilChanged()
             }.collectAsState(initial = false)

--- a/app/src/main/java/cx/aswin/boxcast/surveys/BoxcastPostHogSurveysDelegate.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/BoxcastPostHogSurveysDelegate.kt
@@ -1,0 +1,67 @@
+package cx.aswin.boxcast.surveys
+
+import android.app.Application
+import android.content.Context
+import com.posthog.surveys.OnPostHogSurveyClosed
+import com.posthog.surveys.OnPostHogSurveyResponse
+import com.posthog.surveys.OnPostHogSurveyShown
+import com.posthog.surveys.PostHogDisplaySurvey
+import com.posthog.surveys.PostHogSurveysDelegate
+import cx.aswin.boxcast.core.data.EngagementPromptCoordinator
+import cx.aswin.boxcast.core.data.UserPreferencesRepository
+import cx.aswin.boxcast.core.data.analytics.AnalyticsHelper
+import cx.aswin.boxcast.surveys.internal.ActivityProvider
+import cx.aswin.boxcast.surveys.internal.BoxcastSurveyHost
+
+/**
+ * Material3 1.5-compatible survey UI delegate.
+ *
+ * Replaces `posthog-android-surveys-compose:0.1.0`, which crashes at runtime
+ * against Material3 1.5 because it calls a removed `ModalBottomSheetProperties`
+ * constructor.
+ */
+class BoxcastPostHogSurveysDelegate(
+    context: Context,
+    private val userPrefs: UserPreferencesRepository,
+    private val engagementCoordinator: EngagementPromptCoordinator,
+) : PostHogSurveysDelegate {
+    private val application: Application = context.applicationContext as Application
+    private val activityProvider = ActivityProvider()
+    private val host =
+        BoxcastSurveyHost(
+            activityProvider = activityProvider,
+            userPrefs = userPrefs,
+            onSurveyDisplayed = {
+                engagementCoordinator.onSurveyDisplayed()
+                AnalyticsHelper.trackEngagementPromptShown(
+                    promptType = "nps_survey",
+                    source = "posthog",
+                )
+            },
+            onFirstRatingSubmitted = { score ->
+                engagementCoordinator.onNpsRatingSubmitted(score)
+            },
+        )
+
+    init {
+        application.registerActivityLifecycleCallbacks(activityProvider)
+    }
+
+    override fun renderSurvey(
+        survey: PostHogDisplaySurvey,
+        onSurveyShown: OnPostHogSurveyShown,
+        onSurveyResponse: OnPostHogSurveyResponse,
+        onSurveyClosed: OnPostHogSurveyClosed,
+    ) {
+        host.show(
+            survey = survey,
+            onSurveyShown = onSurveyShown,
+            onSurveyResponse = onSurveyResponse,
+            onSurveyClosed = onSurveyClosed,
+        )
+    }
+
+    override fun cleanupSurveys() {
+        host.cleanup()
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ActivityProvider.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ActivityProvider.kt
@@ -1,0 +1,45 @@
+package cx.aswin.boxcast.surveys.internal
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import java.lang.ref.WeakReference
+
+internal class ActivityProvider : Application.ActivityLifecycleCallbacks {
+    @Volatile
+    private var foreground: WeakReference<Activity>? = null
+
+    var onActivityDestroyedListener: ((Activity) -> Unit)? = null
+    var onActivityResumedListener: ((Activity) -> Unit)? = null
+
+    val foregroundActivity: Activity?
+        get() = foreground?.get()
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) = Unit
+
+    override fun onActivityStarted(activity: Activity) {
+        foreground = WeakReference(activity)
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        foreground = WeakReference(activity)
+        onActivityResumedListener?.invoke(activity)
+    }
+
+    override fun onActivityPaused(activity: Activity) = Unit
+
+    override fun onActivityStopped(activity: Activity) {
+        if (foreground?.get() === activity) {
+            foreground = null
+        }
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) = Unit
+
+    override fun onActivityDestroyed(activity: Activity) {
+        if (foreground?.get() === activity) {
+            foreground = null
+        }
+        onActivityDestroyedListener?.invoke(activity)
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ActivityProvider.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ActivityProvider.kt
@@ -5,13 +5,21 @@ import android.app.Application
 import android.os.Bundle
 import java.lang.ref.WeakReference
 
+/**
+ * Tracks the foreground [Activity] so survey UI can attach to the visible window.
+ * Uses [WeakReference] to avoid leaking destroyed activities.
+ */
 internal class ActivityProvider : Application.ActivityLifecycleCallbacks {
     @Volatile
     private var foreground: WeakReference<Activity>? = null
 
+    /** Invoked when a tracked activity is destroyed (used to dismiss survey dialogs). */
     var onActivityDestroyedListener: ((Activity) -> Unit)? = null
+
+    /** Invoked on resume so surveys can reattach after config changes or backgrounding. */
     var onActivityResumedListener: ((Activity) -> Unit)? = null
 
+    /** The activity currently in the foreground, if any. */
     val foregroundActivity: Activity?
         get() = foreground?.get()
 

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/BoxcastSurveyHost.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/BoxcastSurveyHost.kt
@@ -1,0 +1,266 @@
+package cx.aswin.boxcast.surveys.internal
+
+import android.app.Activity
+import android.graphics.Color
+import android.os.Handler
+import android.os.Looper
+import android.view.Window
+import android.view.WindowManager
+import androidx.activity.ComponentDialog
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.SaveableStateRegistry
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.graphics.drawable.toDrawable
+import com.posthog.PostHog
+import com.posthog.surveys.OnPostHogSurveyClosed
+import com.posthog.surveys.OnPostHogSurveyResponse
+import com.posthog.surveys.OnPostHogSurveyShown
+import com.posthog.surveys.PostHogDisplaySurvey
+import cx.aswin.boxcast.core.data.UserPreferencesRepository
+import cx.aswin.boxcast.core.designsystem.theme.BoxCastTheme
+import cx.aswin.boxcast.surveys.internal.ui.SurveySheet
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+internal class BoxcastSurveyHost(
+    private val activityProvider: ActivityProvider,
+    private val userPrefs: UserPreferencesRepository,
+    private val onSurveyDisplayed: () -> Unit,
+    private val onFirstRatingSubmitted: (Int?) -> Unit,
+) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private var dialog: ComponentDialog? = null
+    private var composeView: ComposeView? = null
+    private var hostActivity: Activity? = null
+    private var currentSurvey: PostHogDisplaySurvey? = null
+    private var onShownCallback: OnPostHogSurveyShown? = null
+    private var onResponseCallback: OnPostHogSurveyResponse? = null
+    private var onClosedCallback: OnPostHogSurveyClosed? = null
+    private var pendingShow: Runnable? = null
+    private var shownReported = false
+    private var awaitingForeground = false
+    private var saveableRegistry: SaveableStateRegistry? = null
+    private var savedSurveyState: Map<String, List<Any?>>? = null
+
+    init {
+        activityProvider.onActivityDestroyedListener = { destroyed ->
+            if (destroyed === hostActivity) {
+                if (destroyed.isChangingConfigurations) {
+                    preserveForConfigChange()
+                } else {
+                    dismissInternal(notifyClosed = true)
+                }
+            }
+        }
+        activityProvider.onActivityResumedListener = { resumed ->
+            if (currentSurvey != null && (savedSurveyState != null || awaitingForeground)) {
+                present(resumed)
+            }
+        }
+    }
+
+    fun show(
+        survey: PostHogDisplaySurvey,
+        onSurveyShown: OnPostHogSurveyShown,
+        onSurveyResponse: OnPostHogSurveyResponse,
+        onSurveyClosed: OnPostHogSurveyClosed,
+    ) {
+        runOnMain {
+            dismissInternal(notifyClosed = true)
+
+            currentSurvey = survey
+            onShownCallback = onSurveyShown
+            onResponseCallback = onSurveyResponse
+            onClosedCallback = onSurveyClosed
+
+            val presentRunnable = Runnable {
+                pendingShow = null
+                present(activityProvider.foregroundActivity)
+            }
+            presentRunnable.run()
+        }
+    }
+
+    fun cleanup() {
+        runOnMain { dismissInternal(notifyClosed = false) }
+    }
+
+    private fun present(activity: Activity?) {
+        val survey = currentSurvey ?: return
+
+        if (activity == null || activity.isFinishing) {
+            awaitingForeground = true
+            return
+        }
+
+        val presented =
+            guard("presenting the survey") {
+                awaitingForeground = false
+                hostActivity = activity
+
+                val registry =
+                    SaveableStateRegistry(
+                        restoredValues = savedSurveyState,
+                        canBeSaved = { true },
+                    )
+                saveableRegistry = registry
+                savedSurveyState = null
+
+                val themeConfig = userPrefs.cachedThemeConfig
+
+                val view =
+                    ComposeView(activity).apply {
+                        setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                        setContent {
+                            val darkTheme =
+                                when (themeConfig) {
+                                    "light" -> false
+                                    "dark" -> true
+                                    else -> isSystemInDarkTheme()
+                                }
+                            BoxCastTheme(
+                                darkTheme = darkTheme,
+                                dynamicColor = userPrefs.cachedUseDynamicColor,
+                                themeBrand = userPrefs.cachedThemeBrand,
+                                surfaceStyle = userPrefs.cachedSurfaceStyle,
+                            ) {
+                                CompositionLocalProvider(LocalSaveableStateRegistry provides registry) {
+                                    SurveySheet(
+                                        survey = survey,
+                                        onSurveyShown = { reportShownOnce() },
+                                        onSubmit = { questionIndex, response ->
+                                            onResponseCallback?.invoke(survey, questionIndex, response)
+                                        },
+                                        onClose = { dismissInternal(notifyClosed = true) },
+                                        onFirstRatingSubmitted = onFirstRatingSubmitted,
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                val componentDialog =
+                    ComponentDialog(activity).apply {
+                        setContentView(view)
+                        setCancelable(false)
+                        setCanceledOnTouchOutside(false)
+                        configureWindow(window)
+                    }
+
+                dialog = componentDialog
+                composeView = view
+                componentDialog.show()
+            }
+
+        if (!presented) {
+            dismissInternal(notifyClosed = false)
+        }
+    }
+
+    private fun reportShownOnce() {
+        if (shownReported) return
+        val survey = currentSurvey ?: return
+        shownReported = true
+        onSurveyDisplayed()
+        scope.launch {
+            if (!userPrefs.hasNpsSurveyFired()) {
+                userPrefs.markNpsSurveyFired()
+            }
+        }
+        onShownCallback?.invoke(survey)
+    }
+
+    private fun configureWindow(window: Window?) {
+        window ?: return
+        window.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
+        window.setLayout(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.MATCH_PARENT,
+        )
+        window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+    }
+
+    private fun preserveForConfigChange() {
+        cancelPendingShow()
+
+        guard("preserving the survey across a configuration change") {
+            savedSurveyState = saveableRegistry?.performSave()
+            saveableRegistry = null
+            composeView?.disposeComposition()
+            dialog?.let { if (it.isShowing) it.dismiss() }
+        }
+
+        dialog = null
+        composeView = null
+        hostActivity = null
+    }
+
+    private fun dismissInternal(notifyClosed: Boolean) {
+        cancelPendingShow()
+
+        val activeDialog = dialog
+        val activeView = composeView
+        val survey = currentSurvey
+        val onClosed = onClosedCallback
+        val wasShown = shownReported
+
+        dialog = null
+        composeView = null
+        hostActivity = null
+        currentSurvey = null
+        onShownCallback = null
+        onResponseCallback = null
+        onClosedCallback = null
+        shownReported = false
+        awaitingForeground = false
+        saveableRegistry = null
+        savedSurveyState = null
+
+        guard("tearing down the survey") {
+            activeView?.disposeComposition()
+            activeDialog?.let { d ->
+                if (d.isShowing) {
+                    d.dismiss()
+                }
+            }
+        }
+
+        if (notifyClosed && wasShown && survey != null && onClosed != null) {
+            onClosed(survey)
+        }
+    }
+
+    private fun cancelPendingShow() {
+        pendingShow?.let {
+            mainHandler.removeCallbacks(it)
+            pendingShow = null
+        }
+    }
+
+    private inline fun guard(action: String, block: () -> Unit): Boolean {
+        return try {
+            block()
+            true
+        } catch (t: Throwable) {
+            PostHog.getConfig<com.posthog.PostHogConfig>()?.logger?.log(
+                "Surveys: $action failed, skipping the survey. $t",
+            )
+            false
+        }
+    }
+
+    private fun runOnMain(block: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            block()
+        } else {
+            mainHandler.post(block)
+        }
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/BoxcastSurveyHost.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/BoxcastSurveyHost.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.graphics.Color
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import android.view.Window
 import android.view.WindowManager
 import androidx.activity.ComponentDialog
@@ -22,6 +23,7 @@ import com.posthog.surveys.PostHogDisplaySurvey
 import cx.aswin.boxcast.core.data.UserPreferencesRepository
 import cx.aswin.boxcast.core.designsystem.theme.BoxCastTheme
 import cx.aswin.boxcast.surveys.internal.ui.SurveySheet
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -34,7 +36,14 @@ internal class BoxcastSurveyHost(
     private val onFirstRatingSubmitted: (Int?) -> Unit,
 ) {
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope =
+        CoroutineScope(
+            SupervisorJob() +
+                Dispatchers.IO +
+                CoroutineExceptionHandler { _, throwable ->
+                    Log.e(TAG, "Survey host side-effect failed", throwable)
+                },
+        )
 
     private var dialog: ComponentDialog? = null
     private var composeView: ComposeView? = null
@@ -43,7 +52,6 @@ internal class BoxcastSurveyHost(
     private var onShownCallback: OnPostHogSurveyShown? = null
     private var onResponseCallback: OnPostHogSurveyResponse? = null
     private var onClosedCallback: OnPostHogSurveyClosed? = null
-    private var pendingShow: Runnable? = null
     private var shownReported = false
     private var awaitingForeground = false
     private var saveableRegistry: SaveableStateRegistry? = null
@@ -79,12 +87,7 @@ internal class BoxcastSurveyHost(
             onShownCallback = onSurveyShown
             onResponseCallback = onSurveyResponse
             onClosedCallback = onSurveyClosed
-
-            val presentRunnable = Runnable {
-                pendingShow = null
-                present(activityProvider.foregroundActivity)
-            }
-            presentRunnable.run()
+            present(activityProvider.foregroundActivity)
         }
     }
 
@@ -170,9 +173,11 @@ internal class BoxcastSurveyHost(
         shownReported = true
         onSurveyDisplayed()
         scope.launch {
-            if (!userPrefs.hasNpsSurveyFired()) {
-                userPrefs.markNpsSurveyFired()
-            }
+            runCatching {
+                if (!userPrefs.hasNpsSurveyFired()) {
+                    userPrefs.markNpsSurveyFired()
+                }
+            }.onFailure { Log.e(TAG, "Failed to mark NPS survey fired", it) }
         }
         onShownCallback?.invoke(survey)
     }
@@ -188,8 +193,6 @@ internal class BoxcastSurveyHost(
     }
 
     private fun preserveForConfigChange() {
-        cancelPendingShow()
-
         guard("preserving the survey across a configuration change") {
             savedSurveyState = saveableRegistry?.performSave()
             saveableRegistry = null
@@ -203,8 +206,6 @@ internal class BoxcastSurveyHost(
     }
 
     private fun dismissInternal(notifyClosed: Boolean) {
-        cancelPendingShow()
-
         val activeDialog = dialog
         val activeView = composeView
         val survey = currentSurvey
@@ -237,20 +238,13 @@ internal class BoxcastSurveyHost(
         }
     }
 
-    private fun cancelPendingShow() {
-        pendingShow?.let {
-            mainHandler.removeCallbacks(it)
-            pendingShow = null
-        }
-    }
-
     private inline fun guard(action: String, block: () -> Unit): Boolean {
         return try {
             block()
             true
-        } catch (t: Throwable) {
+        } catch (e: Exception) {
             PostHog.getConfig<com.posthog.PostHogConfig>()?.logger?.log(
-                "Surveys: $action failed, skipping the survey. $t",
+                "Surveys: $action failed, skipping the survey. $e",
             )
             false
         }
@@ -262,5 +256,9 @@ internal class BoxcastSurveyHost(
         } else {
             mainHandler.post(block)
         }
+    }
+
+    companion object {
+        private const val TAG = "BoxcastSurveyHost"
     }
 }

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/BoxcastSurveyHost.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/BoxcastSurveyHost.kt
@@ -29,6 +29,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
+/**
+ * Presents PostHog surveys in a Compose [ComponentDialog] attached to the foreground activity.
+ * Survives configuration changes by preserving saveable state and reattaching on resume.
+ */
 internal class BoxcastSurveyHost(
     private val activityProvider: ActivityProvider,
     private val userPrefs: UserPreferencesRepository,
@@ -74,6 +78,7 @@ internal class BoxcastSurveyHost(
         }
     }
 
+    /** Queues the survey and presents it on the current foreground activity. */
     fun show(
         survey: PostHogDisplaySurvey,
         onSurveyShown: OnPostHogSurveyShown,
@@ -91,6 +96,7 @@ internal class BoxcastSurveyHost(
         }
     }
 
+    /** Dismisses any visible survey without notifying PostHog of a close event. */
     fun cleanup() {
         runOnMain { dismissInternal(notifyClosed = false) }
     }

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyAppearance.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyAppearance.kt
@@ -1,0 +1,146 @@
+package cx.aswin.boxcast.surveys.internal.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.graphics.Color
+import com.posthog.surveys.PostHogDisplaySurveyAppearance
+import com.posthog.surveys.PostHogDisplaySurveyTextContentType
+
+internal data class ResolvedSurveyAppearance(
+    val backgroundColor: Color,
+    val borderColor: Color,
+    val submitButtonColor: Color,
+    val submitButtonTextColor: Color,
+    val submitButtonText: String,
+    val textColor: Color,
+    val questionTextColor: Color,
+    val descriptionTextColor: Color,
+    val placeholder: String,
+    val placeholderTextColor: Color,
+    val inputBackgroundColor: Color,
+    val inputTextColor: Color,
+    val ratingButtonColor: Color,
+    val ratingButtonActiveColor: Color,
+    val ratingButtonActiveTextColor: Color,
+    val displayThankYouMessage: Boolean,
+    val thankYouMessageHeader: String,
+    val thankYouMessageDescription: String?,
+    val thankYouMessageDescriptionContentType: PostHogDisplaySurveyTextContentType,
+    val thankYouMessageCloseButtonText: String,
+)
+
+internal val LocalSurveyAppearance =
+    compositionLocalOf<ResolvedSurveyAppearance> {
+        error("LocalSurveyAppearance not provided")
+    }
+
+@Composable
+@ReadOnlyComposable
+internal fun localAppearance(): ResolvedSurveyAppearance = LocalSurveyAppearance.current
+
+internal data class MaterialSurveyDefaults(
+    val background: Color,
+    val onSurface: Color,
+    val onSurfaceVariant: Color,
+    val primary: Color,
+    val onPrimary: Color,
+    val primaryContainer: Color,
+    val onPrimaryContainer: Color,
+    val surfaceContainerHigh: Color,
+    val surfaceContainerHighest: Color,
+    val outlineVariant: Color,
+)
+
+@Composable
+@ReadOnlyComposable
+private fun materialSurveyDefaults(): MaterialSurveyDefaults {
+    val scheme = MaterialTheme.colorScheme
+    return MaterialSurveyDefaults(
+        background = scheme.surface,
+        onSurface = scheme.onSurface,
+        onSurfaceVariant = scheme.onSurfaceVariant,
+        primary = scheme.primary,
+        onPrimary = scheme.onPrimary,
+        primaryContainer = scheme.primaryContainer,
+        onPrimaryContainer = scheme.onPrimaryContainer,
+        surfaceContainerHigh = scheme.surfaceContainerHigh,
+        surfaceContainerHighest = scheme.surfaceContainerHighest,
+        outlineVariant = scheme.outlineVariant,
+    )
+}
+
+private const val DEFAULT_PLACEHOLDER = "Start typing..."
+private const val DEFAULT_THANK_YOU_HEADER = "Thank you for your feedback!"
+private const val DEFAULT_THANK_YOU_CLOSE = "Close"
+
+@Composable
+@ReadOnlyComposable
+internal fun PostHogDisplaySurveyAppearance?.resolveAppearance(): ResolvedSurveyAppearance {
+    val defaults = materialSurveyDefaults()
+    return resolve(defaults)
+}
+
+internal fun PostHogDisplaySurveyAppearance?.resolve(
+    defaults: MaterialSurveyDefaults,
+): ResolvedSurveyAppearance {
+    val backgroundColor = parseSurveyColorOrDefault(this?.backgroundColor, defaults.background)
+    val submitButtonColor = parseSurveyColorOrDefault(this?.submitButtonColor, defaults.primary)
+    val submitButtonTextColor =
+        parseSurveyColorOrDefault(this?.submitButtonTextColor, defaults.onPrimary)
+    val textColor = parseSurveyColorOrDefault(this?.textColor, defaults.onSurface)
+    val descriptionTextColor =
+        parseSurveyColorOrDefault(this?.descriptionTextColor, defaults.onSurfaceVariant)
+    val borderColor = parseSurveyColorOrDefault(this?.borderColor, defaults.outlineVariant)
+    val ratingButtonColor =
+        parseSurveyColorOrDefault(this?.ratingButtonColor, defaults.surfaceContainerHigh)
+    val ratingButtonActiveColor =
+        parseSurveyColorOrDefault(this?.ratingButtonActiveColor, defaults.primaryContainer)
+    val ratingButtonActiveTextColor = defaults.onPrimaryContainer
+    val submitButtonText = this?.submitButtonText?.takeIf { it.isNotBlank() } ?: "Submit"
+    val questionTextColor = parseSurveyColorOrDefault(this?.textColor, defaults.onSurface)
+    val inputBackgroundColor =
+        parseSurveyColorOrDefault(this?.inputBackground, defaults.surfaceContainerHighest)
+    val inputTextColor =
+        parseSurveyColorOrDefault(this?.inputTextColor, defaults.onSurface)
+    val placeholderTextColor = defaults.onSurfaceVariant.copy(alpha = 0.7f)
+    val placeholder = this?.placeholder?.takeIf { it.isNotBlank() } ?: DEFAULT_PLACEHOLDER
+    val displayThankYouMessage = this?.displayThankYouMessage ?: false
+    val thankYouMessageHeader =
+        this?.thankYouMessageHeader?.takeIf { it.isNotBlank() } ?: DEFAULT_THANK_YOU_HEADER
+    val thankYouMessageDescription = this?.thankYouMessageDescription?.takeIf { it.isNotBlank() }
+    val thankYouMessageDescriptionContentType =
+        this?.thankYouMessageDescriptionContentType ?: PostHogDisplaySurveyTextContentType.TEXT
+    val thankYouMessageCloseButtonText =
+        this?.thankYouMessageCloseButtonText?.takeIf { it.isNotBlank() } ?: DEFAULT_THANK_YOU_CLOSE
+
+    return ResolvedSurveyAppearance(
+        backgroundColor = backgroundColor,
+        borderColor = borderColor,
+        submitButtonColor = submitButtonColor,
+        submitButtonTextColor = submitButtonTextColor,
+        submitButtonText = submitButtonText,
+        textColor = textColor,
+        questionTextColor = questionTextColor,
+        descriptionTextColor = descriptionTextColor,
+        placeholder = placeholder,
+        placeholderTextColor = placeholderTextColor,
+        inputBackgroundColor = inputBackgroundColor,
+        inputTextColor = inputTextColor,
+        ratingButtonColor = ratingButtonColor,
+        ratingButtonActiveColor = ratingButtonActiveColor,
+        ratingButtonActiveTextColor = ratingButtonActiveTextColor,
+        displayThankYouMessage = displayThankYouMessage,
+        thankYouMessageHeader = thankYouMessageHeader,
+        thankYouMessageDescription = thankYouMessageDescription,
+        thankYouMessageDescriptionContentType = thankYouMessageDescriptionContentType,
+        thankYouMessageCloseButtonText = thankYouMessageCloseButtonText,
+    )
+}
+
+private fun parseSurveyColorOrDefault(input: String?, default: Color): Color {
+    if (input.isNullOrBlank()) return default
+    val parsed = parseSurveyColor(input)
+    return if (parsed == Color.Transparent) default else parsed
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyAppearance.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyAppearance.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import com.posthog.surveys.PostHogDisplaySurveyAppearance
 import com.posthog.surveys.PostHogDisplaySurveyTextContentType
 
+/** Resolved survey colors and copy, merged from PostHog appearance and Material theme defaults. */
 internal data class ResolvedSurveyAppearance(
     val backgroundColor: Color,
     val borderColor: Color,
@@ -31,11 +32,13 @@ internal data class ResolvedSurveyAppearance(
     val thankYouMessageCloseButtonText: String,
 )
 
+/** CompositionLocal holding the active survey appearance for child composables. */
 internal val LocalSurveyAppearance =
     compositionLocalOf<ResolvedSurveyAppearance> {
         error("LocalSurveyAppearance not provided")
     }
 
+/** Reads the current survey appearance from [LocalSurveyAppearance]. */
 @Composable
 @ReadOnlyComposable
 internal fun localAppearance(): ResolvedSurveyAppearance = LocalSurveyAppearance.current
@@ -75,6 +78,7 @@ private const val DEFAULT_PLACEHOLDER = "Start typing..."
 private const val DEFAULT_THANK_YOU_HEADER = "Thank you for your feedback!"
 private const val DEFAULT_THANK_YOU_CLOSE = "Close"
 
+/** Maps PostHog survey appearance settings onto Material theme defaults. */
 @Composable
 @ReadOnlyComposable
 internal fun PostHogDisplaySurveyAppearance?.resolveAppearance(): ResolvedSurveyAppearance {

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyColor.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyColor.kt
@@ -1,0 +1,207 @@
+package cx.aswin.boxcast.surveys.internal.theme
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Parses a survey-appearance color string into a Compose [Color].
+ *
+ * Supports the web color forms PostHog appearance settings produce: named CSS
+ * colors (`"red"`, `"transparent"`), `#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`,
+ * and the same forms without the leading `#`. Returns [Color.Transparent] when
+ * the input is null, blank, or unrecognized.
+ */
+internal fun parseSurveyColor(input: String?): Color {
+    val raw = input?.trim()?.takeIf { it.isNotEmpty() } ?: return Color.Transparent
+    val keyed = cssColorTable[raw.uppercase()]
+    val withAlphaPadding: String = keyed?.let { if (it.length == 8) it else it + "ff" } ?: raw
+    val noHash = if (withAlphaPadding.startsWith("#")) withAlphaPadding.drop(1) else withAlphaPadding
+    val expanded =
+        when (noHash.length) {
+            3, 4 -> noHash.map { c -> "$c$c" }.joinToString(separator = "")
+            else -> noHash
+        }
+    val full = if (expanded.length <= 7) expanded + "ff" else expanded
+    if (full.length != 8 || full.any { !isHexDigit(it) }) return Color.Transparent
+
+    val v = full.toLong(16)
+    val r = ((v shr 24) and 0xFF) / 255f
+    val g = ((v shr 16) and 0xFF) / 255f
+    val b = ((v shr 8) and 0xFF) / 255f
+    val a = (v and 0xFF) / 255f
+    return Color(r, g, b, a)
+}
+
+/**
+ * Returns black or white text that meets WCAG-ish contrast against the
+ * receiver (luminance < 0.6 → white).
+ */
+internal fun Color.contrastingTextColor(): Color = if (isLight()) Color.Black else Color.White
+
+/**
+ * Whether the color reads as "light" (luminance ≥ 0.6, the threshold used for
+ * picking contrasting text).
+ */
+internal fun Color.isLight(): Boolean {
+    val luminance = 0.2126f * red + 0.7152f * green + 0.0722f * blue
+    return luminance >= 0.6f
+}
+
+private fun isHexDigit(c: Char): Boolean = c in '0'..'9' || c in 'a'..'f' || c in 'A'..'F'
+
+// CSS named-color table (140 entries + transparency aliases). Uppercased keys.
+// Values are 6- or 8-char hex without the leading "#". 8-char entries already
+// include an alpha byte; 6-char entries get "ff" appended at lookup time.
+private val cssColorTable: Map<String, String> =
+    mapOf(
+        "" to "00000000",
+        "CLEAR" to "00000000",
+        "TRANSPARENT" to "00000000",
+        "ALICEBLUE" to "F0F8FF",
+        "ANTIQUEWHITE" to "FAEBD7",
+        "AQUA" to "00FFFF",
+        "AQUAMARINE" to "7FFFD4",
+        "AZURE" to "F0FFFF",
+        "BEIGE" to "F5F5DC",
+        "BISQUE" to "FFE4C4",
+        "BLACK" to "000000",
+        "BLANCHEDALMOND" to "FFEBCD",
+        "BLUE" to "0000FF",
+        "BLUEVIOLET" to "8A2BE2",
+        "BROWN" to "A52A2A",
+        "BURLYWOOD" to "DEB887",
+        "CADETBLUE" to "5F9EA0",
+        "CHARTREUSE" to "7FFF00",
+        "CHOCOLATE" to "D2691E",
+        "CORAL" to "FF7F50",
+        "CORNFLOWERBLUE" to "6495ED",
+        "CORNSILK" to "FFF8DC",
+        "CRIMSON" to "DC143C",
+        "CYAN" to "00FFFF",
+        "DARKBLUE" to "00008B",
+        "DARKCYAN" to "008B8B",
+        "DARKGOLDENROD" to "B8860B",
+        "DARKGRAY" to "A9A9A9",
+        "DARKGREY" to "A9A9A9",
+        "DARKGREEN" to "006400",
+        "DARKKHAKI" to "BDB76B",
+        "DARKMAGENTA" to "8B008B",
+        "DARKOLIVEGREEN" to "556B2F",
+        "DARKORANGE" to "FF8C00",
+        "DARKORCHID" to "9932CC",
+        "DARKRED" to "8B0000",
+        "DARKSALMON" to "E9967A",
+        "DARKSEAGREEN" to "8FBC8F",
+        "DARKSLATEBLUE" to "483D8B",
+        "DARKSLATEGRAY" to "2F4F4F",
+        "DARKSLATEGREY" to "2F4F4F",
+        "DARKTURQUOISE" to "00CED1",
+        "DARKVIOLET" to "9400D3",
+        "DEEPPINK" to "FF1493",
+        "DEEPSKYBLUE" to "00BFFF",
+        "DIMGRAY" to "696969",
+        "DIMGREY" to "696969",
+        "DODGERBLUE" to "1E90FF",
+        "FIREBRICK" to "B22222",
+        "FLORALWHITE" to "FFFAF0",
+        "FORESTGREEN" to "228B22",
+        "FUCHSIA" to "FF00FF",
+        "GAINSBORO" to "DCDCDC",
+        "GHOSTWHITE" to "F8F8FF",
+        "GOLD" to "FFD700",
+        "GOLDENROD" to "DAA520",
+        "GRAY" to "808080",
+        "GREY" to "808080",
+        "GREEN" to "008000",
+        "GREENYELLOW" to "ADFF2F",
+        "HONEYDEW" to "F0FFF0",
+        "HOTPINK" to "FF69B4",
+        "INDIANRED" to "CD5C5C",
+        "INDIGO" to "4B0082",
+        "IVORY" to "FFFFF0",
+        "KHAKI" to "F0E68C",
+        "LAVENDER" to "E6E6FA",
+        "LAVENDERBLUSH" to "FFF0F5",
+        "LAWNGREEN" to "7CFC00",
+        "LEMONCHIFFON" to "FFFACD",
+        "LIGHTBLUE" to "ADD8E6",
+        "LIGHTCORAL" to "F08080",
+        "LIGHTCYAN" to "E0FFFF",
+        "LIGHTGOLDENRODYELLOW" to "FAFAD2",
+        "LIGHTGRAY" to "D3D3D3",
+        "LIGHTGREY" to "D3D3D3",
+        "LIGHTGREEN" to "90EE90",
+        "LIGHTPINK" to "FFB6C1",
+        "LIGHTSALMON" to "FFA07A",
+        "LIGHTSEAGREEN" to "20B2AA",
+        "LIGHTSKYBLUE" to "87CEFA",
+        "LIGHTSLATEGRAY" to "778899",
+        "LIGHTSLATEGREY" to "778899",
+        "LIGHTSTEELBLUE" to "B0C4DE",
+        "LIGHTYELLOW" to "FFFFE0",
+        "LIME" to "00FF00",
+        "LIMEGREEN" to "32CD32",
+        "LINEN" to "FAF0E6",
+        "MAGENTA" to "FF00FF",
+        "MAROON" to "800000",
+        "MEDIUMAQUAMARINE" to "66CDAA",
+        "MEDIUMBLUE" to "0000CD",
+        "MEDIUMORCHID" to "BA55D3",
+        "MEDIUMPURPLE" to "9370DB",
+        "MEDIUMSEAGREEN" to "3CB371",
+        "MEDIUMSLATEBLUE" to "7B68EE",
+        "MEDIUMSPRINGGREEN" to "00FA9A",
+        "MEDIUMTURQUOISE" to "48D1CC",
+        "MEDIUMVIOLETRED" to "C71585",
+        "MIDNIGHTBLUE" to "191970",
+        "MINTCREAM" to "F5FFFA",
+        "MISTYROSE" to "FFE4E1",
+        "MOCCASIN" to "FFE4B5",
+        "NAVAJOWHITE" to "FFDEAD",
+        "NAVY" to "000080",
+        "OLDLACE" to "FDF5E6",
+        "OLIVE" to "808000",
+        "OLIVEDRAB" to "6B8E23",
+        "ORANGE" to "FFA500",
+        "ORANGERED" to "FF4500",
+        "ORCHID" to "DA70D6",
+        "PALEGOLDENROD" to "EEE8AA",
+        "PALEGREEN" to "98FB98",
+        "PALETURQUOISE" to "AFEEEE",
+        "PALEVIOLETRED" to "DB7093",
+        "PAPAYAWHIP" to "FFEFD5",
+        "PEACHPUFF" to "FFDAB9",
+        "PERU" to "CD853F",
+        "PINK" to "FFC0CB",
+        "PLUM" to "DDA0DD",
+        "POWDERBLUE" to "B0E0E6",
+        "PURPLE" to "800080",
+        "REBECCAPURPLE" to "663399",
+        "RED" to "FF0000",
+        "ROSYBROWN" to "BC8F8F",
+        "ROYALBLUE" to "4169E1",
+        "SADDLEBROWN" to "8B4513",
+        "SALMON" to "FA8072",
+        "SANDYBROWN" to "F4A460",
+        "SEAGREEN" to "2E8B57",
+        "SEASHELL" to "FFF5EE",
+        "SIENNA" to "A0522D",
+        "SILVER" to "C0C0C0",
+        "SKYBLUE" to "87CEEB",
+        "SLATEBLUE" to "6A5ACD",
+        "SLATEGRAY" to "708090",
+        "SLATEGREY" to "708090",
+        "SNOW" to "FFFAFA",
+        "SPRINGGREEN" to "00FF7F",
+        "STEELBLUE" to "4682B4",
+        "TAN" to "D2B48C",
+        "TEAL" to "008080",
+        "THISTLE" to "D8BFD8",
+        "TOMATO" to "FF6347",
+        "TURQUOISE" to "40E0D0",
+        "VIOLET" to "EE82EE",
+        "WHEAT" to "F5DEB3",
+        "WHITE" to "FFFFFF",
+        "WHITESMOKE" to "F5F5F5",
+        "YELLOW" to "FFFF00",
+        "YELLOWGREEN" to "9ACD32",
+    )

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/BottomSection.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/BottomSection.kt
@@ -1,0 +1,39 @@
+package cx.aswin.boxcast.surveys.internal.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import cx.aswin.boxcast.surveys.internal.theme.localAppearance
+
+@Composable
+internal fun BottomSection(
+    label: String,
+    enabled: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    val appearance = localAppearance()
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        shape = RoundedCornerShape(16.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(52.dp),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = appearance.submitButtonColor,
+                contentColor = appearance.submitButtonTextColor,
+            ),
+    ) {
+        Text(text = label)
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/BottomSection.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/BottomSection.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cx.aswin.boxcast.surveys.internal.theme.localAppearance
 
+/** Primary submit button for survey and confirmation screens. */
 @Composable
 internal fun BottomSection(
     label: String,

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/ConfirmationScreen.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/ConfirmationScreen.kt
@@ -1,0 +1,74 @@
+package cx.aswin.boxcast.surveys.internal.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.posthog.surveys.PostHogDisplaySurveyTextContentType
+import cx.aswin.boxcast.surveys.internal.theme.localAppearance
+
+@Composable
+internal fun ConfirmationScreen(onClose: () -> Unit) {
+    val appearance = localAppearance()
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.tertiaryContainer,
+            modifier = Modifier.size(56.dp),
+        ) {
+            androidx.compose.foundation.layout.Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Rounded.Favorite,
+                    contentDescription = null,
+                    modifier = Modifier.size(28.dp),
+                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = appearance.thankYouMessageHeader,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center,
+        )
+        val description = appearance.thankYouMessageDescription
+        if (!description.isNullOrBlank() &&
+            appearance.thankYouMessageDescriptionContentType == PostHogDisplaySurveyTextContentType.TEXT
+        ) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+        BottomSection(
+            label = appearance.thankYouMessageCloseButtonText,
+            enabled = true,
+            onClick = onClose,
+        )
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/ConfirmationScreen.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/ConfirmationScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import com.posthog.surveys.PostHogDisplaySurveyTextContentType
 import cx.aswin.boxcast.surveys.internal.theme.localAppearance
 
+/** Post-submit thank-you screen shown when the survey appearance enables it. */
 @Composable
 internal fun ConfirmationScreen(onClose: () -> Unit) {
     val appearance = localAppearance()

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/FocusRestorer.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/FocusRestorer.kt
@@ -1,0 +1,28 @@
+package cx.aswin.boxcast.surveys.internal.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+
+@Composable
+internal fun Modifier.restoreFocusOnReentry(): Modifier {
+    val focusRequester = remember { FocusRequester() }
+    var wasFocused by rememberSaveable { mutableStateOf(false) }
+    val restoreFocus = remember { wasFocused }
+    LaunchedEffect(Unit) {
+        if (restoreFocus) {
+            focusRequester.requestFocus()
+        }
+    }
+    return this
+        .focusRequester(focusRequester)
+        .onFocusChanged { wasFocused = it.isFocused }
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/FocusRestorer.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/FocusRestorer.kt
@@ -12,6 +12,10 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 
+/**
+ * Restores text-field focus after configuration changes or dialog re-entry.
+ * Used by [OpenText] so keyboard focus survives activity recreation.
+ */
 @Composable
 internal fun Modifier.restoreFocusOnReentry(): Modifier {
     val focusRequester = remember { FocusRequester() }

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/NumberRating.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/NumberRating.kt
@@ -1,0 +1,133 @@
+package cx.aswin.boxcast.surveys.internal.ui
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.posthog.surveys.PostHogDisplayRatingQuestion
+import cx.aswin.boxcast.surveys.internal.theme.localAppearance
+
+@Composable
+internal fun NumberRating(
+    question: PostHogDisplayRatingQuestion,
+    selectedValue: Int?,
+    onSelect: (Int?) -> Unit,
+) {
+    val appearance = localAppearance()
+    val values = (question.scaleLowerBound..question.scaleUpperBound).toList()
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(52.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(appearance.ratingButtonColor)
+                    .border(1.dp, appearance.borderColor, RoundedCornerShape(16.dp)),
+        ) {
+            values.forEachIndexed { index, value ->
+                val isSelected = selectedValue == value
+                val targetBg =
+                    if (isSelected) appearance.ratingButtonActiveColor else Color.Transparent
+                val animatedBg by animateColorAsState(
+                    targetValue = targetBg,
+                    label = "rating-segment-bg",
+                )
+                val textColor =
+                    if (isSelected) {
+                        appearance.ratingButtonActiveTextColor
+                    } else {
+                        appearance.textColor.copy(alpha = 0.55f)
+                    }
+                val drawBorderRight = index < values.lastIndex
+                Box(
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .background(animatedBg)
+                            .clickable {
+                                onSelect(if (isSelected) null else value)
+                            }
+                            .drawBehind {
+                                if (drawBorderRight) {
+                                    val strokeWidthPx = 1.dp.toPx()
+                                    drawLine(
+                                        color = appearance.borderColor,
+                                        start = Offset(size.width - strokeWidthPx / 2f, 8.dp.toPx()),
+                                        end =
+                                            Offset(
+                                                size.width - strokeWidthPx / 2f,
+                                                size.height - 8.dp.toPx(),
+                                            ),
+                                        strokeWidth = strokeWidthPx,
+                                    )
+                                }
+                            },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = value.toString(),
+                        color = textColor,
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+                        textAlign = TextAlign.Center,
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+
+        val lower = question.lowerBoundLabel
+        val upper = question.upperBoundLabel
+        if (lower.isNotBlank() || upper.isNotBlank()) {
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 2.dp),
+            ) {
+                Text(
+                    text = lower,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = appearance.descriptionTextColor,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = upper,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = appearance.descriptionTextColor,
+                    textAlign = TextAlign.End,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/NumberRating.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/NumberRating.kt
@@ -33,6 +33,7 @@ import com.posthog.surveys.PostHogDisplayRatingQuestion
 import cx.aswin.boxcast.surveys.internal.theme.ResolvedSurveyAppearance
 import cx.aswin.boxcast.surveys.internal.theme.localAppearance
 
+/** Connected 0–10 (or custom-range) rating bar with scale endpoint labels. */
 @Composable
 internal fun NumberRating(
     question: PostHogDisplayRatingQuestion,

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/NumberRating.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/NumberRating.kt
@@ -8,11 +8,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -24,10 +25,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.posthog.surveys.PostHogDisplayRatingQuestion
+import cx.aswin.boxcast.surveys.internal.theme.ResolvedSurveyAppearance
 import cx.aswin.boxcast.surveys.internal.theme.localAppearance
 
 @Composable
@@ -53,81 +56,110 @@ internal fun NumberRating(
                     .border(1.dp, appearance.borderColor, RoundedCornerShape(16.dp)),
         ) {
             values.forEachIndexed { index, value ->
-                val isSelected = selectedValue == value
-                val targetBg =
-                    if (isSelected) appearance.ratingButtonActiveColor else Color.Transparent
-                val animatedBg by animateColorAsState(
-                    targetValue = targetBg,
-                    label = "rating-segment-bg",
+                RatingSegment(
+                    value = value,
+                    isSelected = selectedValue == value,
+                    appearance = appearance,
+                    drawBorderRight = index < values.lastIndex,
+                    onSelect = onSelect,
                 )
-                val textColor =
-                    if (isSelected) {
-                        appearance.ratingButtonActiveTextColor
-                    } else {
-                        appearance.textColor.copy(alpha = 0.55f)
-                    }
-                val drawBorderRight = index < values.lastIndex
-                Box(
-                    modifier =
-                        Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .background(animatedBg)
-                            .clickable {
-                                onSelect(if (isSelected) null else value)
-                            }
-                            .drawBehind {
-                                if (drawBorderRight) {
-                                    val strokeWidthPx = 1.dp.toPx()
-                                    drawLine(
-                                        color = appearance.borderColor,
-                                        start = Offset(size.width - strokeWidthPx / 2f, 8.dp.toPx()),
-                                        end =
-                                            Offset(
-                                                size.width - strokeWidthPx / 2f,
-                                                size.height - 8.dp.toPx(),
-                                            ),
-                                        strokeWidth = strokeWidthPx,
-                                    )
-                                }
-                            },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = value.toString(),
-                        color = textColor,
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
-                        textAlign = TextAlign.Center,
-                        maxLines = 1,
-                    )
-                }
             }
         }
 
-        val lower = question.lowerBoundLabel
-        val upper = question.upperBoundLabel
-        if (lower.isNotBlank() || upper.isNotBlank()) {
-            Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 2.dp),
-            ) {
-                Text(
-                    text = lower,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = appearance.descriptionTextColor,
-                    modifier = Modifier.weight(1f),
-                )
-                Text(
-                    text = upper,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = appearance.descriptionTextColor,
-                    textAlign = TextAlign.End,
-                    modifier = Modifier.weight(1f),
-                )
-            }
+        RatingScaleLabels(
+            lower = question.lowerBoundLabel,
+            upper = question.upperBoundLabel,
+            appearance = appearance,
+        )
+    }
+}
+
+@Composable
+private fun RowScope.RatingSegment(
+    value: Int,
+    isSelected: Boolean,
+    appearance: ResolvedSurveyAppearance,
+    drawBorderRight: Boolean,
+    onSelect: (Int?) -> Unit,
+) {
+    val targetBg =
+        if (isSelected) appearance.ratingButtonActiveColor else Color.Transparent
+    val animatedBg by animateColorAsState(
+        targetValue = targetBg,
+        label = "rating-segment-bg",
+    )
+    val textColor =
+        if (isSelected) {
+            appearance.ratingButtonActiveTextColor
+        } else {
+            appearance.textColor.copy(alpha = 0.55f)
         }
+
+    Box(
+        modifier =
+            Modifier
+                .weight(1f)
+                .fillMaxHeight()
+                .background(animatedBg)
+                .selectable(
+                    selected = isSelected,
+                    onClick = { onSelect(if (isSelected) null else value) },
+                    role = Role.RadioButton,
+                )
+                .drawBehind {
+                    if (drawBorderRight) {
+                        val strokeWidthPx = 1.dp.toPx()
+                        drawLine(
+                            color = appearance.borderColor,
+                            start = Offset(size.width - strokeWidthPx / 2f, 8.dp.toPx()),
+                            end =
+                                Offset(
+                                    size.width - strokeWidthPx / 2f,
+                                    size.height - 8.dp.toPx(),
+                                ),
+                            strokeWidth = strokeWidthPx,
+                        )
+                    }
+                },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = value.toString(),
+            color = textColor,
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun RatingScaleLabels(
+    lower: String,
+    upper: String,
+    appearance: ResolvedSurveyAppearance,
+) {
+    if (lower.isBlank() && upper.isBlank()) return
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 2.dp),
+    ) {
+        Text(
+            text = lower,
+            style = MaterialTheme.typography.bodySmall,
+            color = appearance.descriptionTextColor,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = upper,
+            style = MaterialTheme.typography.bodySmall,
+            color = appearance.descriptionTextColor,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(1f),
+        )
     }
 }

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/OpenText.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/OpenText.kt
@@ -1,0 +1,47 @@
+package cx.aswin.boxcast.surveys.internal.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.posthog.surveys.PostHogDisplayOpenQuestion
+import cx.aswin.boxcast.surveys.internal.theme.localAppearance
+
+@Composable
+internal fun OpenText(
+    @Suppress("UnusedParameter") question: PostHogDisplayOpenQuestion,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    val appearance = localAppearance()
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(150.dp)
+                .restoreFocusOnReentry(),
+        placeholder = {
+            androidx.compose.material3.Text(
+                text = appearance.placeholder,
+                color = appearance.placeholderTextColor,
+            )
+        },
+        textStyle = MaterialTheme.typography.bodyMedium.copy(color = appearance.inputTextColor),
+        shape = RoundedCornerShape(16.dp),
+        colors =
+            OutlinedTextFieldDefaults.colors(
+                focusedContainerColor = appearance.inputBackgroundColor,
+                unfocusedContainerColor = appearance.inputBackgroundColor,
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = appearance.borderColor,
+                cursorColor = appearance.inputTextColor,
+            ),
+    )
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/OpenText.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/OpenText.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import cx.aswin.boxcast.surveys.internal.theme.localAppearance
 
+/** Multiline free-text answer field styled to match engagement sheets. */
 @Composable
 internal fun OpenText(
     value: String,

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/OpenText.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/OpenText.kt
@@ -9,12 +9,10 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.posthog.surveys.PostHogDisplayOpenQuestion
 import cx.aswin.boxcast.surveys.internal.theme.localAppearance
 
 @Composable
 internal fun OpenText(
-    @Suppress("UnusedParameter") question: PostHogDisplayOpenQuestion,
     value: String,
     onValueChange: (String) -> Unit,
 ) {

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/QuestionHeader.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/QuestionHeader.kt
@@ -1,0 +1,45 @@
+package cx.aswin.boxcast.surveys.internal.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.posthog.surveys.PostHogDisplaySurveyQuestion
+import com.posthog.surveys.PostHogDisplaySurveyTextContentType
+import cx.aswin.boxcast.surveys.internal.theme.localAppearance
+
+@Composable
+internal fun QuestionHeader(question: PostHogDisplaySurveyQuestion) {
+    val appearance = localAppearance()
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = question.question,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = appearance.questionTextColor,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        val description = question.questionDescription
+        if (!description.isNullOrBlank() &&
+            question.questionDescriptionContentType == PostHogDisplaySurveyTextContentType.TEXT
+        ) {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = appearance.descriptionTextColor,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/QuestionHeader.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/QuestionHeader.kt
@@ -14,6 +14,7 @@ import com.posthog.surveys.PostHogDisplaySurveyQuestion
 import com.posthog.surveys.PostHogDisplaySurveyTextContentType
 import cx.aswin.boxcast.surveys.internal.theme.localAppearance
 
+/** Centered question title and optional description for a survey step. */
 @Composable
 internal fun QuestionHeader(question: PostHogDisplaySurveyQuestion) {
     val appearance = localAppearance()

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/SurveySheet.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/SurveySheet.kt
@@ -1,0 +1,235 @@
+package cx.aswin.boxcast.surveys.internal.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.posthog.surveys.PostHogDisplayOpenQuestion
+import com.posthog.surveys.PostHogDisplayRatingQuestion
+import com.posthog.surveys.PostHogDisplaySurvey
+import com.posthog.surveys.PostHogDisplaySurveyQuestion
+import com.posthog.surveys.PostHogDisplaySurveyRatingType
+import com.posthog.surveys.PostHogNextSurveyQuestion
+import com.posthog.surveys.PostHogSurveyResponse
+import cx.aswin.boxcast.core.designsystem.components.EngagementBottomSheetScaffold
+import cx.aswin.boxcast.surveys.internal.theme.LocalSurveyAppearance
+import cx.aswin.boxcast.surveys.internal.theme.localAppearance
+import cx.aswin.boxcast.surveys.internal.theme.resolveAppearance
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SurveySheet(
+    survey: PostHogDisplaySurvey,
+    onSurveyShown: () -> Unit,
+    onSubmit: (questionIndex: Int, response: PostHogSurveyResponse) -> PostHogNextSurveyQuestion?,
+    onClose: () -> Unit,
+    onFirstRatingSubmitted: (Int?) -> Unit = {},
+) {
+    val appearance = survey.appearance.resolveAppearance()
+    val coroutineScope = rememberCoroutineScope()
+    val hostSaveableRegistry = LocalSaveableStateRegistry.current
+
+    val sheetState =
+        rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+        )
+
+    var currentQuestionIndex by rememberSaveable { mutableStateOf(0) }
+    var showingConfirmation by rememberSaveable { mutableStateOf(false) }
+    var hasReportedFirstRating by rememberSaveable { mutableStateOf(false) }
+    val question = survey.questions.getOrNull(currentQuestionIndex)
+
+    LaunchedEffect(survey.id) {
+        onSurveyShown()
+    }
+
+    if (question == null && !showingConfirmation) {
+        LaunchedEffect(Unit) { onClose() }
+        return
+    }
+
+    val dismissSheet: () -> Unit = {
+        coroutineScope.launch {
+            sheetState.hide()
+            onClose()
+        }
+        Unit
+    }
+
+    val onSubmitResponse: (PostHogSurveyResponse) -> Unit = { response ->
+        if (!hasReportedFirstRating && response is PostHogSurveyResponse.Rating) {
+            hasReportedFirstRating = true
+            onFirstRatingSubmitted(response.rating)
+        }
+        val next = onSubmit(currentQuestionIndex, response)
+        when {
+            next == null -> dismissSheet()
+            next.isSurveyCompleted ->
+                if (appearance.displayThankYouMessage) {
+                    showingConfirmation = true
+                } else {
+                    dismissSheet()
+                }
+            else -> currentQuestionIndex = next.questionIndex
+        }
+    }
+
+    EngagementBottomSheetScaffold(
+        onDismissRequest = onClose,
+        sheetState = sheetState,
+        onCloseClick = dismissSheet,
+    ) {
+        CompositionLocalProvider(
+            LocalSurveyAppearance provides appearance,
+            LocalSaveableStateRegistry provides hostSaveableRegistry,
+        ) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                if (showingConfirmation || question == null) {
+                    ConfirmationScreen(onClose = dismissSheet)
+                } else {
+                    SurveyQuestionBody(
+                        question = question,
+                        onSubmit = onSubmitResponse,
+                        onClose = dismissSheet,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SurveyQuestionBody(
+    question: PostHogDisplaySurveyQuestion,
+    onSubmit: (PostHogSurveyResponse) -> Unit,
+    onClose: () -> Unit,
+) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.primaryContainer,
+        modifier = Modifier.size(56.dp),
+    ) {
+        androidx.compose.foundation.layout.Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Rounded.Star,
+                contentDescription = null,
+                modifier = Modifier.size(28.dp),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(20.dp))
+
+    QuestionHeader(question)
+
+    Spacer(modifier = Modifier.height(28.dp))
+
+    when (question) {
+        is PostHogDisplayRatingQuestion -> RatingQuestionBody(question, onSubmit, onClose)
+        is PostHogDisplayOpenQuestion -> OpenTextQuestionBody(question, onSubmit)
+        else ->
+            UnsupportedQuestionPlaceholder(
+                buttonLabel = question.buttonText ?: "Close",
+                onClose = onClose,
+            )
+    }
+}
+
+@Composable
+private fun RatingQuestionBody(
+    question: PostHogDisplayRatingQuestion,
+    onSubmit: (PostHogSurveyResponse) -> Unit,
+    onClose: () -> Unit,
+) {
+    var rating by rememberSaveable(question.id) { mutableStateOf<Int?>(null) }
+    val canSubmit = question.isOptional || rating != null
+
+    if (question.ratingType == PostHogDisplaySurveyRatingType.EMOJI) {
+        UnsupportedQuestionPlaceholder(
+            buttonLabel = question.buttonText ?: localAppearance().submitButtonText,
+            onClose = { onSubmit(PostHogSurveyResponse.Rating(rating)) },
+        )
+    } else {
+        NumberRating(
+            question = question,
+            selectedValue = rating,
+            onSelect = { rating = it },
+        )
+        Spacer(modifier = Modifier.height(28.dp))
+        BottomSection(
+            label = question.buttonText ?: localAppearance().submitButtonText,
+            enabled = canSubmit,
+            onClick = { onSubmit(PostHogSurveyResponse.Rating(rating)) },
+        )
+    }
+}
+
+@Composable
+private fun OpenTextQuestionBody(
+    question: PostHogDisplayOpenQuestion,
+    onSubmit: (PostHogSurveyResponse) -> Unit,
+) {
+    var text by rememberSaveable(question.id) { mutableStateOf("") }
+    val canSubmit = question.isOptional || text.isNotBlank()
+
+    OpenText(question = question, value = text, onValueChange = { text = it })
+    Spacer(modifier = Modifier.height(28.dp))
+    BottomSection(
+        label = question.buttonText ?: localAppearance().submitButtonText,
+        enabled = canSubmit,
+        onClick = {
+            val trimmed = text.trim()
+            onSubmit(PostHogSurveyResponse.Text(if (trimmed.isEmpty()) null else trimmed))
+        },
+    )
+}
+
+@Composable
+private fun UnsupportedQuestionPlaceholder(
+    buttonLabel: String,
+    onClose: () -> Unit,
+) {
+    val appearance = localAppearance()
+    androidx.compose.material3.Text(
+        text =
+            "This question type is not yet supported in the app survey UI. " +
+                "Please update the app to respond to this survey.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = appearance.textColor,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Spacer(modifier = Modifier.height(28.dp))
+    BottomSection(label = buttonLabel, enabled = true, onClick = onClose)
+}

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/SurveySheet.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/SurveySheet.kt
@@ -49,6 +49,7 @@ private sealed interface SurveySubmitStep {
     data class NextQuestion(val index: Int) : SurveySubmitStep
 }
 
+/** Determines the next UI step after a survey answer is submitted. */
 private fun surveySubmitStep(
     next: PostHogNextSurveyQuestion?,
     displayThankYouMessage: Boolean,
@@ -64,6 +65,11 @@ private fun surveySubmitStep(
         else -> SurveySubmitStep.NextQuestion(next.questionIndex)
     }
 
+/**
+ * Root NPS survey bottom sheet: question flow, rating capture, and optional thank-you screen.
+ *
+ * @param onFirstRatingSubmitted Fired once when the user submits their first numeric rating.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SurveySheet(

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/SurveySheet.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/ui/SurveySheet.kt
@@ -41,6 +41,29 @@ import cx.aswin.boxcast.surveys.internal.theme.localAppearance
 import cx.aswin.boxcast.surveys.internal.theme.resolveAppearance
 import kotlinx.coroutines.launch
 
+private sealed interface SurveySubmitStep {
+    data object Dismiss : SurveySubmitStep
+
+    data object ShowConfirmation : SurveySubmitStep
+
+    data class NextQuestion(val index: Int) : SurveySubmitStep
+}
+
+private fun surveySubmitStep(
+    next: PostHogNextSurveyQuestion?,
+    displayThankYouMessage: Boolean,
+): SurveySubmitStep =
+    when {
+        next == null -> SurveySubmitStep.Dismiss
+        next.isSurveyCompleted ->
+            if (displayThankYouMessage) {
+                SurveySubmitStep.ShowConfirmation
+            } else {
+                SurveySubmitStep.Dismiss
+            }
+        else -> SurveySubmitStep.NextQuestion(next.questionIndex)
+    }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SurveySheet(
@@ -87,15 +110,10 @@ internal fun SurveySheet(
             onFirstRatingSubmitted(response.rating)
         }
         val next = onSubmit(currentQuestionIndex, response)
-        when {
-            next == null -> dismissSheet()
-            next.isSurveyCompleted ->
-                if (appearance.displayThankYouMessage) {
-                    showingConfirmation = true
-                } else {
-                    dismissSheet()
-                }
-            else -> currentQuestionIndex = next.questionIndex
+        when (val step = surveySubmitStep(next, appearance.displayThankYouMessage)) {
+            SurveySubmitStep.Dismiss -> dismissSheet()
+            SurveySubmitStep.ShowConfirmation -> showingConfirmation = true
+            is SurveySubmitStep.NextQuestion -> currentQuestionIndex = step.index
         }
     }
 
@@ -204,7 +222,7 @@ private fun OpenTextQuestionBody(
     var text by rememberSaveable(question.id) { mutableStateOf("") }
     val canSubmit = question.isOptional || text.isNotBlank()
 
-    OpenText(question = question, value = text, onValueChange = { text = it })
+    OpenText(value = text, onValueChange = { text = it })
     Spacer(modifier = Modifier.height(28.dp))
     BottomSection(
         label = question.buttonText ?: localAppearance().submitButtonText,

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptConstants.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptConstants.kt
@@ -1,0 +1,7 @@
+package cx.aswin.boxcast.core.data
+
+object EngagementPromptConstants {
+    const val PROMOTER_SCORE_THRESHOLD = 8
+    const val ENGAGEMENT_COOLDOWN_DAYS = 14
+    const val DETRACTOR_SCORE_MAX = 7
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptConstants.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptConstants.kt
@@ -1,7 +1,15 @@
 package cx.aswin.boxcast.core.data
 
+/**
+ * Shared thresholds for NPS scoring and proactive engagement cooldowns.
+ */
 object EngagementPromptConstants {
+    /** Minimum NPS score (inclusive) that qualifies for Play Store promoter handoff. */
     const val PROMOTER_SCORE_THRESHOLD = 8
+
+    /** Minimum days between unrelated proactive prompts (NPS, milestone review). */
     const val ENGAGEMENT_COOLDOWN_DAYS = 14
+
+    /** Maximum NPS score (inclusive) treated as a detractor for milestone review gating. */
     const val DETRACTOR_SCORE_MAX = 7
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptCoordinator.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptCoordinator.kt
@@ -1,0 +1,61 @@
+package cx.aswin.boxcast.core.data
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Coordinates proactive engagement prompts (NPS survey, Play review) so only one
+ * surfaces per session and promoter handoffs follow the unified strategy.
+ */
+class EngagementPromptCoordinator(
+    private val userPrefs: UserPreferencesRepository,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+) {
+    /** In-memory guard: at most one proactive modal per app process session. */
+    @Volatile
+    var sessionProactivePromptShown: Boolean = false
+        private set
+
+    fun canShowProactivePrompt(isPlaying: Boolean): Boolean =
+        !isPlaying && !sessionProactivePromptShown
+
+    fun recordProactivePromptShown() {
+        sessionProactivePromptShown = true
+        scope.launch { userPrefs.recordEngagementPromptShown() }
+    }
+
+    fun onSurveyDisplayed() {
+        recordProactivePromptShown()
+    }
+
+    fun onNpsRatingSubmitted(score: Int?) {
+        if (score == null) return
+        scope.launch {
+            userPrefs.setNpsLastScore(score)
+            if (score >= PROMOTER_SCORE_THRESHOLD) {
+                userPrefs.setPromoterReviewPending(true)
+            }
+        }
+    }
+
+    suspend fun shouldShowPromoterReview(isPlaying: Boolean): Boolean {
+        if (!canShowProactivePrompt(isPlaying)) return false
+        if (userPrefs.hasReviewedSync()) return false
+        if (!userPrefs.hasNpsSurveyFired()) return false
+        return userPrefs.isPromoterReviewPending()
+    }
+
+    suspend fun clearPromoterReviewPending() {
+        userPrefs.setPromoterReviewPending(false)
+    }
+
+    suspend fun isEngagementCooldownElapsed(): Boolean = userPrefs.isEngagementCooldownElapsed()
+
+    companion object {
+        const val PROMOTER_SCORE_THRESHOLD = 8
+        const val ENGAGEMENT_COOLDOWN_DAYS = 14
+        const val DETRACTOR_SCORE_MAX = 7
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptCoordinator.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptCoordinator.kt
@@ -1,6 +1,7 @@
 package cx.aswin.boxcast.core.data
 
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,8 +36,13 @@ class EngagementPromptCoordinator(
     fun recordProactivePromptShown() {
         sessionProactivePromptShown = true
         scope.launch {
-            runCatching { userPrefs.recordEngagementPromptShown() }
-                .onFailure { Log.e(TAG, "Failed to record engagement prompt", it) }
+            try {
+                userPrefs.recordEngagementPromptShown()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to record engagement prompt", e)
+            }
         }
     }
 
@@ -51,12 +57,16 @@ class EngagementPromptCoordinator(
     fun onNpsRatingSubmitted(score: Int?) {
         if (score == null) return
         scope.launch {
-            runCatching {
+            try {
                 userPrefs.setNpsLastScore(score)
                 if (score >= EngagementPromptConstants.PROMOTER_SCORE_THRESHOLD) {
                     userPrefs.setPromoterReviewPending(true)
                 }
-            }.onFailure { Log.e(TAG, "Failed to persist NPS score", it) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to persist NPS score", e)
+            }
         }
     }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptCoordinator.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptCoordinator.kt
@@ -1,5 +1,7 @@
 package cx.aswin.boxcast.core.data
 
+import android.util.Log
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -11,7 +13,14 @@ import kotlinx.coroutines.launch
  */
 class EngagementPromptCoordinator(
     private val userPrefs: UserPreferencesRepository,
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    private val scope: CoroutineScope =
+        CoroutineScope(
+            SupervisorJob() +
+                Dispatchers.IO +
+                CoroutineExceptionHandler { _, throwable ->
+                    Log.e(TAG, "Engagement prompt side-effect failed", throwable)
+                },
+        ),
 ) {
     /** In-memory guard: at most one proactive modal per app process session. */
     @Volatile
@@ -23,7 +32,10 @@ class EngagementPromptCoordinator(
 
     fun recordProactivePromptShown() {
         sessionProactivePromptShown = true
-        scope.launch { userPrefs.recordEngagementPromptShown() }
+        scope.launch {
+            runCatching { userPrefs.recordEngagementPromptShown() }
+                .onFailure { Log.e(TAG, "Failed to record engagement prompt", it) }
+        }
     }
 
     fun onSurveyDisplayed() {
@@ -33,10 +45,12 @@ class EngagementPromptCoordinator(
     fun onNpsRatingSubmitted(score: Int?) {
         if (score == null) return
         scope.launch {
-            userPrefs.setNpsLastScore(score)
-            if (score >= PROMOTER_SCORE_THRESHOLD) {
-                userPrefs.setPromoterReviewPending(true)
-            }
+            runCatching {
+                userPrefs.setNpsLastScore(score)
+                if (score >= EngagementPromptConstants.PROMOTER_SCORE_THRESHOLD) {
+                    userPrefs.setPromoterReviewPending(true)
+                }
+            }.onFailure { Log.e(TAG, "Failed to persist NPS score", it) }
         }
     }
 
@@ -54,8 +68,6 @@ class EngagementPromptCoordinator(
     suspend fun isEngagementCooldownElapsed(): Boolean = userPrefs.isEngagementCooldownElapsed()
 
     companion object {
-        const val PROMOTER_SCORE_THRESHOLD = 8
-        const val ENGAGEMENT_COOLDOWN_DAYS = 14
-        const val DETRACTOR_SCORE_MAX = 7
+        private const val TAG = "EngagementPromptCoordinator"
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptCoordinator.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/EngagementPromptCoordinator.kt
@@ -27,9 +27,11 @@ class EngagementPromptCoordinator(
     var sessionProactivePromptShown: Boolean = false
         private set
 
+    /** Returns true when playback is idle and no proactive prompt has shown this session. */
     fun canShowProactivePrompt(isPlaying: Boolean): Boolean =
         !isPlaying && !sessionProactivePromptShown
 
+    /** Marks the current session as having shown a proactive prompt and persists cooldown. */
     fun recordProactivePromptShown() {
         sessionProactivePromptShown = true
         scope.launch {
@@ -38,10 +40,14 @@ class EngagementPromptCoordinator(
         }
     }
 
+    /** Called when the PostHog NPS sheet becomes visible. */
     fun onSurveyDisplayed() {
         recordProactivePromptShown()
     }
 
+    /**
+     * Persists the first NPS rating and queues promoter Play review when [score] is 8+.
+     */
     fun onNpsRatingSubmitted(score: Int?) {
         if (score == null) return
         scope.launch {
@@ -54,6 +60,10 @@ class EngagementPromptCoordinator(
         }
     }
 
+    /**
+     * True when a deferred promoter handoff is pending and the user has not reviewed yet.
+     * Does not apply the 14-day cooldown — that prompt completes the NPS journey.
+     */
     suspend fun shouldShowPromoterReview(isPlaying: Boolean): Boolean {
         if (!canShowProactivePrompt(isPlaying)) return false
         if (userPrefs.hasReviewedSync()) return false
@@ -61,10 +71,12 @@ class EngagementPromptCoordinator(
         return userPrefs.isPromoterReviewPending()
     }
 
+    /** Clears the one-shot promoter handoff flag after the review sheet is shown or dismissed. */
     suspend fun clearPromoterReviewPending() {
         userPrefs.setPromoterReviewPending(false)
     }
 
+    /** Whether enough time has passed since the last proactive engagement prompt. */
     suspend fun isEngagementCooldownElapsed(): Boolean = userPrefs.isEngagementCooldownElapsed()
 
     companion object {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import java.io.IOException
 
@@ -391,6 +392,14 @@ class UserPreferencesRepository(context: Context) {
         val REVIEW_PROMPT_COUNT = androidx.datastore.preferences.core.intPreferencesKey("review_prompt_count")
         val REVIEW_HAS_REVIEWED = androidx.datastore.preferences.core.booleanPreferencesKey("review_has_reviewed")
         val REVIEW_FIRST_LAUNCH_AT = androidx.datastore.preferences.core.longPreferencesKey("review_first_launch_at")
+        // NPS survey: milestone marks eligibility (pending); the event fires on
+        // the next app open so it never surfaces during background playback.
+        val NPS_SURVEY_PENDING = androidx.datastore.preferences.core.booleanPreferencesKey("nps_survey_pending")
+        val NPS_SURVEY_FIRED = androidx.datastore.preferences.core.booleanPreferencesKey("nps_survey_fired")
+        val NPS_SURVEY_COMPLETED_COUNT = androidx.datastore.preferences.core.intPreferencesKey("nps_survey_completed_count")
+        val ENGAGEMENT_LAST_PROMPT_AT = androidx.datastore.preferences.core.longPreferencesKey("engagement_last_prompt_at")
+        val NPS_LAST_SCORE = androidx.datastore.preferences.core.intPreferencesKey("nps_last_score")
+        val PROMOTER_REVIEW_PENDING = androidx.datastore.preferences.core.booleanPreferencesKey("promoter_review_pending")
     }
 
     val hasLoggedFirstPlay: Flow<Boolean> = dataStore.data
@@ -478,51 +487,110 @@ class UserPreferencesRepository(context: Context) {
             val count = pref[AnalyticsKeys.REVIEW_PROMPT_COUNT] ?: 0
             pref[AnalyticsKeys.REVIEW_PROMPT_COUNT] = count + 1
             pref[AnalyticsKeys.REVIEW_LAST_PROMPT_AT] = System.currentTimeMillis()
+            pref[AnalyticsKeys.ENGAGEMENT_LAST_PROMPT_AT] = System.currentTimeMillis()
         }
     }
 
     /**
-     * Rules to show:
-     * - User has NOT reviewed yet
-     * - App installed for at least 2 days
-     * - Max 3 prompts lifetime
-     * - Minimum 30 days between prompts
-     * - They hit a milestone (5, 15, or 30 episodes completed)
+     * Rules to show milestone Play review:
+     * - NPS survey already fired; skip detractors (score &lt;= 7)
+     * - Shared 14-day engagement cooldown
+     * - User has NOT reviewed yet; app installed 2+ days; max 3 lifetime; 30-day review gap
+     * - Exact milestones: 5, 15, or 30 completed episodes; never during playback
      */
     suspend fun shouldShowReviewPrompt(completedCount: Int, isPlaying: Boolean): Boolean {
-        if (isPlaying) return false // Never interrupt playback
-        
-        // Only trigger on exact milestones so it doesn't prompt continuously
+        if (isPlaying) return false
         if (completedCount != 5 && completedCount != 15 && completedCount != 30) return false
 
-        var shouldShow = false
-        dataStore.edit { pref ->
-            val hasReviewed = pref[AnalyticsKeys.REVIEW_HAS_REVIEWED] ?: false
-            if (hasReviewed) return@edit // Early out
+        val prefs = dataStore.data.first()
+        if (prefs[AnalyticsKeys.REVIEW_HAS_REVIEWED] == true) return false
+        if (prefs[AnalyticsKeys.NPS_SURVEY_FIRED] != true) return false
 
-            val promptCount = pref[AnalyticsKeys.REVIEW_PROMPT_COUNT] ?: 0
-            if (promptCount >= 3) return@edit // Lifetime cap
+        val npsScore = prefs[AnalyticsKeys.NPS_LAST_SCORE]
+        if (npsScore != null && npsScore <= EngagementPromptCoordinator.DETRACTOR_SCORE_MAX) return false
 
-            // Initialize first launch time if empty
-            val firstLaunchStr = pref[AnalyticsKeys.REVIEW_FIRST_LAUNCH_AT]
-            if (firstLaunchStr == null) {
-                 pref[AnalyticsKeys.REVIEW_FIRST_LAUNCH_AT] = System.currentTimeMillis()
-                 return@edit // Don't show on very first day
-            }
-            
-            val daysSinceInstall = (System.currentTimeMillis() - firstLaunchStr) / (1000 * 60 * 60 * 24)
-            if (daysSinceInstall < 2) return@edit
+        if (!isEngagementCooldownElapsed(prefs)) return false
 
-            val lastPrompt = pref[AnalyticsKeys.REVIEW_LAST_PROMPT_AT] ?: 0L
-            val daysSinceLastPrompt = (System.currentTimeMillis() - lastPrompt) / (1000 * 60 * 60 * 24)
-            
-            if (lastPrompt == 0L || daysSinceLastPrompt >= 30) {
-                // We don't mark as shown here, we just check. The UI tier will mark it.
-                shouldShow = true
-            }
+        val promptCount = prefs[AnalyticsKeys.REVIEW_PROMPT_COUNT] ?: 0
+        if (promptCount >= 3) return false
+
+        val firstLaunch = prefs[AnalyticsKeys.REVIEW_FIRST_LAUNCH_AT]
+        if (firstLaunch == null) {
+            dataStore.edit { it[AnalyticsKeys.REVIEW_FIRST_LAUNCH_AT] = System.currentTimeMillis() }
+            return false
         }
-        
-        return shouldShow
+
+        val daysSinceInstall = (System.currentTimeMillis() - firstLaunch) / (1000 * 60 * 60 * 24)
+        if (daysSinceInstall < 2) return false
+
+        val lastPrompt = prefs[AnalyticsKeys.REVIEW_LAST_PROMPT_AT] ?: 0L
+        val daysSinceLastPrompt = (System.currentTimeMillis() - lastPrompt) / (1000 * 60 * 60 * 24)
+        return lastPrompt == 0L || daysSinceLastPrompt >= 30
+    }
+
+    suspend fun hasReviewedSync(): Boolean =
+        dataStore.data.first()[AnalyticsKeys.REVIEW_HAS_REVIEWED] ?: false
+
+    suspend fun recordEngagementPromptShown() {
+        dataStore.edit { pref ->
+            pref[AnalyticsKeys.ENGAGEMENT_LAST_PROMPT_AT] = System.currentTimeMillis()
+        }
+    }
+
+    suspend fun isEngagementCooldownElapsed(): Boolean =
+        isEngagementCooldownElapsed(dataStore.data.first())
+
+    private fun isEngagementCooldownElapsed(pref: Preferences): Boolean {
+        val last = pref[AnalyticsKeys.ENGAGEMENT_LAST_PROMPT_AT] ?: 0L
+        if (last == 0L) return true
+        val days = (System.currentTimeMillis() - last) / (1000 * 60 * 60 * 24)
+        return days >= EngagementPromptCoordinator.ENGAGEMENT_COOLDOWN_DAYS
+    }
+
+    suspend fun setNpsLastScore(score: Int) {
+        dataStore.edit { it[AnalyticsKeys.NPS_LAST_SCORE] = score }
+    }
+
+    suspend fun npsLastScore(): Int? = dataStore.data.first()[AnalyticsKeys.NPS_LAST_SCORE]
+
+    suspend fun setPromoterReviewPending(pending: Boolean) {
+        dataStore.edit { it[AnalyticsKeys.PROMOTER_REVIEW_PENDING] = pending }
+    }
+
+    suspend fun isPromoterReviewPending(): Boolean =
+        dataStore.data.first()[AnalyticsKeys.PROMOTER_REVIEW_PENDING] ?: false
+
+    // --- NPS SURVEY (PostHog) TRIGGER STATE ---
+    // The eligibility milestone (e.g. 3rd completed episode) can be reached
+    // while playback runs in the background. Rather than fire immediately, we
+    // mark the survey "pending" and let MainActivity fire the trigger event on
+    // the next app open. Firing happens at most once (guarded by the fired flag).
+
+    /** Mark the NPS survey pending (no-op if it has already fired). */
+    suspend fun markNpsSurveyPending(completedCount: Int) {
+        dataStore.edit { pref ->
+            if (pref[AnalyticsKeys.NPS_SURVEY_FIRED] == true) return@edit
+            pref[AnalyticsKeys.NPS_SURVEY_PENDING] = true
+            pref[AnalyticsKeys.NPS_SURVEY_COMPLETED_COUNT] = completedCount
+        }
+    }
+
+    suspend fun isNpsSurveyPending(): Boolean =
+        dataStore.data.first()[AnalyticsKeys.NPS_SURVEY_PENDING] ?: false
+
+    suspend fun hasNpsSurveyFired(): Boolean =
+        dataStore.data.first()[AnalyticsKeys.NPS_SURVEY_FIRED] ?: false
+
+    /** Completed-episode count captured when the survey became pending. */
+    suspend fun npsSurveyCompletedCount(): Int? =
+        dataStore.data.first()[AnalyticsKeys.NPS_SURVEY_COMPLETED_COUNT]
+
+    /** Mark the NPS survey as fired and clear the pending flag. */
+    suspend fun markNpsSurveyFired() {
+        dataStore.edit { pref ->
+            pref[AnalyticsKeys.NPS_SURVEY_FIRED] = true
+            pref[AnalyticsKeys.NPS_SURVEY_PENDING] = false
+        }
     }
 
     val hideCompletedInFeedsStream: Flow<Boolean> = dataStore.data

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
@@ -554,19 +554,23 @@ class UserPreferencesRepository(context: Context) {
     suspend fun reviewMilestonePending(): Int? =
         dataStore.data.first()[AnalyticsKeys.REVIEW_MILESTONE_PENDING]
 
+    /** Clears a stored milestone after the review prompt is shown or dismissed. */
     suspend fun clearReviewMilestonePending() {
         dataStore.edit { it.remove(AnalyticsKeys.REVIEW_MILESTONE_PENDING) }
     }
 
+    /** Synchronous read of whether the user has completed the Play Store review flow. */
     suspend fun hasReviewedSync(): Boolean =
         dataStore.data.first()[AnalyticsKeys.REVIEW_HAS_REVIEWED] ?: false
 
+    /** Updates the shared engagement cooldown timestamp after any proactive prompt. */
     suspend fun recordEngagementPromptShown() {
         dataStore.edit { pref ->
             pref[AnalyticsKeys.ENGAGEMENT_LAST_PROMPT_AT] = System.currentTimeMillis()
         }
     }
 
+    /** True when at least [EngagementPromptConstants.ENGAGEMENT_COOLDOWN_DAYS] have passed since the last prompt. */
     suspend fun isEngagementCooldownElapsed(): Boolean =
         isEngagementCooldownElapsed(dataStore.data.first())
 
@@ -577,12 +581,14 @@ class UserPreferencesRepository(context: Context) {
         return days >= EngagementPromptConstants.ENGAGEMENT_COOLDOWN_DAYS
     }
 
+    /** Persists the most recent NPS score for milestone gating and promoter handoff. */
     suspend fun setNpsLastScore(score: Int) {
         dataStore.edit { it[AnalyticsKeys.NPS_LAST_SCORE] = score }
     }
 
     suspend fun npsLastScore(): Int? = dataStore.data.first()[AnalyticsKeys.NPS_LAST_SCORE]
 
+    /** Sets whether a promoter Play review should show on the next eligible app open. */
     suspend fun setPromoterReviewPending(pending: Boolean) {
         dataStore.edit { it[AnalyticsKeys.PROMOTER_REVIEW_PENDING] = pending }
     }
@@ -608,6 +614,7 @@ class UserPreferencesRepository(context: Context) {
     suspend fun isNpsSurveyPending(): Boolean =
         dataStore.data.first()[AnalyticsKeys.NPS_SURVEY_PENDING] ?: false
 
+    /** Whether the NPS trigger event has already fired for this install. */
     suspend fun hasNpsSurveyFired(): Boolean =
         dataStore.data.first()[AnalyticsKeys.NPS_SURVEY_FIRED] ?: false
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/UserPreferencesRepository.kt
@@ -400,6 +400,7 @@ class UserPreferencesRepository(context: Context) {
         val ENGAGEMENT_LAST_PROMPT_AT = androidx.datastore.preferences.core.longPreferencesKey("engagement_last_prompt_at")
         val NPS_LAST_SCORE = androidx.datastore.preferences.core.intPreferencesKey("nps_last_score")
         val PROMOTER_REVIEW_PENDING = androidx.datastore.preferences.core.booleanPreferencesKey("promoter_review_pending")
+        val REVIEW_MILESTONE_PENDING = androidx.datastore.preferences.core.intPreferencesKey("review_milestone_pending")
     }
 
     val hasLoggedFirstPlay: Flow<Boolean> = dataStore.data
@@ -488,26 +489,30 @@ class UserPreferencesRepository(context: Context) {
             pref[AnalyticsKeys.REVIEW_PROMPT_COUNT] = count + 1
             pref[AnalyticsKeys.REVIEW_LAST_PROMPT_AT] = System.currentTimeMillis()
             pref[AnalyticsKeys.ENGAGEMENT_LAST_PROMPT_AT] = System.currentTimeMillis()
+            pref.remove(AnalyticsKeys.REVIEW_MILESTONE_PENDING)
         }
     }
 
     /**
      * Rules to show milestone Play review:
+     * - A milestone (5/15/30) was reached and stored as pending (survives playback gaps)
      * - NPS survey already fired; skip detractors (score &lt;= 7)
      * - Shared 14-day engagement cooldown
      * - User has NOT reviewed yet; app installed 2+ days; max 3 lifetime; 30-day review gap
-     * - Exact milestones: 5, 15, or 30 completed episodes; never during playback
+     * - Never during playback
      */
-    suspend fun shouldShowReviewPrompt(completedCount: Int, isPlaying: Boolean): Boolean {
+    suspend fun shouldShowReviewPrompt(isPlaying: Boolean): Boolean {
         if (isPlaying) return false
-        if (completedCount != 5 && completedCount != 15 && completedCount != 30) return false
 
         val prefs = dataStore.data.first()
+        val milestone = prefs[AnalyticsKeys.REVIEW_MILESTONE_PENDING] ?: return false
+        if (milestone != 5 && milestone != 15 && milestone != 30) return false
+
         if (prefs[AnalyticsKeys.REVIEW_HAS_REVIEWED] == true) return false
         if (prefs[AnalyticsKeys.NPS_SURVEY_FIRED] != true) return false
 
         val npsScore = prefs[AnalyticsKeys.NPS_LAST_SCORE]
-        if (npsScore != null && npsScore <= EngagementPromptCoordinator.DETRACTOR_SCORE_MAX) return false
+        if (npsScore != null && npsScore <= EngagementPromptConstants.DETRACTOR_SCORE_MAX) return false
 
         if (!isEngagementCooldownElapsed(prefs)) return false
 
@@ -528,6 +533,31 @@ class UserPreferencesRepository(context: Context) {
         return lastPrompt == 0L || daysSinceLastPrompt >= 30
     }
 
+    /** Remember the highest unreached milestone so prompts survive playback gaps. */
+    suspend fun syncReviewMilestonePending(completedCount: Int) {
+        val milestone =
+            when {
+                completedCount >= 30 -> 30
+                completedCount >= 15 -> 15
+                completedCount >= 5 -> 5
+                else -> return
+            }
+        dataStore.edit { pref ->
+            if (pref[AnalyticsKeys.REVIEW_HAS_REVIEWED] == true) return@edit
+            val current = pref[AnalyticsKeys.REVIEW_MILESTONE_PENDING]
+            if (current == null || milestone > current) {
+                pref[AnalyticsKeys.REVIEW_MILESTONE_PENDING] = milestone
+            }
+        }
+    }
+
+    suspend fun reviewMilestonePending(): Int? =
+        dataStore.data.first()[AnalyticsKeys.REVIEW_MILESTONE_PENDING]
+
+    suspend fun clearReviewMilestonePending() {
+        dataStore.edit { it.remove(AnalyticsKeys.REVIEW_MILESTONE_PENDING) }
+    }
+
     suspend fun hasReviewedSync(): Boolean =
         dataStore.data.first()[AnalyticsKeys.REVIEW_HAS_REVIEWED] ?: false
 
@@ -544,7 +574,7 @@ class UserPreferencesRepository(context: Context) {
         val last = pref[AnalyticsKeys.ENGAGEMENT_LAST_PROMPT_AT] ?: 0L
         if (last == 0L) return true
         val days = (System.currentTimeMillis() - last) / (1000 * 60 * 60 * 24)
-        return days >= EngagementPromptCoordinator.ENGAGEMENT_COOLDOWN_DAYS
+        return days >= EngagementPromptConstants.ENGAGEMENT_COOLDOWN_DAYS
     }
 
     suspend fun setNpsLastScore(score: Int) {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -140,6 +140,67 @@ object AnalyticsHelper {
         )
     }
 
+    // ── PostHog Surveys: NPS triggers ──────────────────────────────
+    // These events are display-condition triggers for the "Boxcast NPS +
+    // Feature Ideas" survey. The app only emits the trigger; PostHog owns the
+    // survey content, branching, and targeting.
+
+    /** Deferred automatic trigger, fired on app open once the user hits the eligibility milestone. */
+    fun trackSurveyNpsEligible(completedEpisodes: Int?, triggerContext: String) {
+        PostHog.capture(
+            event = "survey_nps_eligible",
+            properties = buildMap {
+                put("trigger_type", "automatic")
+                put("trigger_context", triggerContext)
+                completedEpisodes?.let { put("completed_episodes", it) }
+            }
+        )
+        deliverSurveyTriggerEvent()
+    }
+
+    /** Manual trigger from a long-press or a remote console feature flag. */
+    fun trackSurveyNpsManualTrigger(source: String) {
+        PostHog.capture(
+            event = "survey_nps_manual_trigger",
+            properties = mapOf(
+                "trigger_source" to source,
+                "trigger_type" to "manual",
+                "trigger_context" to if (source == "remote_flag") "console" else "manual"
+            )
+        )
+        deliverSurveyTriggerEvent()
+    }
+
+    /** Flush and refresh flags so the SDK evaluates survey display conditions immediately. */
+    private fun deliverSurveyTriggerEvent() {
+        try {
+            PostHog.flush()
+            PostHog.reloadFeatureFlags()
+        } catch (e: Exception) {
+            android.util.Log.e("AnalyticsHelper", "Failed to deliver survey trigger", e)
+        }
+    }
+
+    fun trackEngagementPromptShown(promptType: String, source: String, completedEpisodes: Int? = null) {
+        PostHog.capture(
+            event = "engagement_prompt_shown",
+            properties = buildMap {
+                put("prompt_type", promptType)
+                put("source", source)
+                completedEpisodes?.let { put("completed_episodes", it) }
+            },
+        )
+    }
+
+    fun trackPromoterReviewHandoff(npsScore: Int?) {
+        PostHog.capture(
+            event = "promoter_review_handoff",
+            properties = buildMap {
+                npsScore?.let { put("nps_score", it) }
+            },
+        )
+    }
+
     // ── Home Import Banner (Empty State) ───────────────────────────
 
     fun trackHomeImportBannerImpression() {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -181,6 +181,7 @@ object AnalyticsHelper {
         }
     }
 
+    /** Tracks when a proactive engagement modal (NPS, review, etc.) is shown. */
     fun trackEngagementPromptShown(promptType: String, source: String, completedEpisodes: Int? = null) {
         PostHog.capture(
             event = "engagement_prompt_shown",
@@ -192,6 +193,7 @@ object AnalyticsHelper {
         )
     }
 
+    /** Fired when a promoter (NPS 8+) is routed to the Play Store review sheet on a later open. */
     fun trackPromoterReviewHandoff(npsScore: Int?) {
         PostHog.capture(
             event = "promoter_review_handoff",

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/EngagementBottomSheetScaffold.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/EngagementBottomSheetScaffold.kt
@@ -1,0 +1,88 @@
+package cx.aswin.boxcast.core.designsystem.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared bottom-sheet chrome for engagement flows (NPS survey, review prompt, feedback).
+ * Matches the expressive M3 styling used by [cx.aswin.boxcast.feature.home.components.ReviewPromptSheet].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EngagementBottomSheetScaffold(
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    sheetState: SheetState =
+        rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+            confirmValueChange = { it != SheetValue.Hidden },
+        ),
+    properties: ModalBottomSheetProperties =
+        ModalBottomSheetProperties(shouldDismissOnBackPress = false),
+    showCloseButton: Boolean = true,
+    onCloseClick: () -> Unit = onDismissRequest,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
+        modifier = modifier,
+        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
+        containerColor = MaterialTheme.colorScheme.surface,
+        tonalElevation = 2.dp,
+        dragHandle = null,
+        contentWindowInsets = { WindowInsets.navigationBars },
+        properties = properties,
+    ) {
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = 24.dp,
+                            end = 24.dp,
+                            top = if (showCloseButton) 48.dp else 24.dp,
+                            bottom = 36.dp,
+                        ),
+                content = content,
+            )
+            if (showCloseButton) {
+                IconButton(
+                    onClick = onCloseClick,
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(top = 4.dp, end = 4.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Close,
+                        contentDescription = "Close",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/EngagementBottomSheetScaffold.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/EngagementBottomSheetScaffold.kt
@@ -29,6 +29,8 @@ import cx.aswin.boxcast.core.designsystem.R
 /**
  * Shared bottom-sheet chrome for engagement flows (NPS survey, review prompt, feedback).
  * Matches the expressive M3 styling used by review and survey sheets.
+ *
+ * @param showCloseButton When false, omits the top-right close icon (e.g. review prompt).
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/EngagementBottomSheetScaffold.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/EngagementBottomSheetScaffold.kt
@@ -22,11 +22,13 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import cx.aswin.boxcast.core.designsystem.R
 
 /**
  * Shared bottom-sheet chrome for engagement flows (NPS survey, review prompt, feedback).
- * Matches the expressive M3 styling used by [cx.aswin.boxcast.feature.home.components.ReviewPromptSheet].
+ * Matches the expressive M3 styling used by review and survey sheets.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,7 +80,7 @@ fun EngagementBottomSheetScaffold(
                 ) {
                     Icon(
                         imageVector = Icons.Rounded.Close,
-                        contentDescription = "Close",
+                        contentDescription = stringResource(R.string.engagement_sheet_close),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="engagement_sheet_close">Close</string>
+</resources>

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -144,6 +144,8 @@ data class HomePlaybackUi(
 @androidx.compose.runtime.Stable
 data class HomeSheetUi(
     val showReviewPrompt: Boolean = false,
+    val reviewPromptVariant: cx.aswin.boxcast.feature.home.components.ReviewPromptVariant =
+        cx.aswin.boxcast.feature.home.components.ReviewPromptVariant.Milestone,
     val showPostReview: Boolean = false,
     val showFeedback: Boolean = false,
     val candidatePodcasts: List<Podcast> = emptyList(),
@@ -181,6 +183,7 @@ data class HomeScreenCallbacks(
     val feed: HomeFeedCallbacks,
     val onNavigateToSettings: (() -> Unit)? = null,
     val onForceReviewPrompt: () -> Unit = {},
+    val onForceSurveyNps: () -> Unit = {},
     val onDismissReviewPrompt: () -> Unit = {},
     val onDismissPostReview: () -> Unit = {},
     val onDismissFeedback: () -> Unit = {},
@@ -196,6 +199,7 @@ fun HomeRoute(
     apiBaseUrl: String,
     publicKey: String,
     playbackRepository: cx.aswin.boxcast.core.data.PlaybackRepository,
+    engagementPromptCoordinator: cx.aswin.boxcast.core.data.EngagementPromptCoordinator,
     onPodcastClick: (Podcast, String, String?, Int?) -> Unit,
     onHeroArrowClick: (SmartHeroItem, Int) -> Unit,
     onEpisodeClick: ((Episode, Podcast, String?) -> Unit)? = null, // Navigate to EpisodeInfo
@@ -219,7 +223,13 @@ fun HomeRoute(
         factory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return HomeViewModel(application, apiBaseUrl, publicKey, playbackRepository) as T
+                return HomeViewModel(
+                    application,
+                    apiBaseUrl,
+                    publicKey,
+                    playbackRepository,
+                    engagementPromptCoordinator,
+                ) as T
             }
         }
     )
@@ -253,6 +263,7 @@ fun HomeRoute(
         viewModel.playerState.map { it.isLoading }.distinctUntilChanged()
     }.collectAsState(initial = false)
     val showReviewPrompt by viewModel.showReviewPrompt.collectAsState()
+    val reviewPromptVariant by viewModel.reviewPromptVariant.collectAsState()
     val showPostReview by viewModel.showPostReview.collectAsState()
     val showFeedback by viewModel.showFeedback.collectAsState()
     
@@ -314,6 +325,7 @@ fun HomeRoute(
             ),
             onNavigateToSettings = onNavigateToSettings,
             onForceReviewPrompt = viewModel::forceReviewPrompt,
+            onForceSurveyNps = viewModel::forceSurveyNps,
             onDismissReviewPrompt = {
                 viewModel.markReviewPromptShown()
                 viewModel.dismissReviewPrompt()
@@ -346,6 +358,7 @@ fun HomeRoute(
             ),
             sheets = HomeSheetUi(
                 showReviewPrompt = showReviewPrompt,
+                reviewPromptVariant = reviewPromptVariant,
                 showPostReview = showPostReview,
                 showFeedback = showFeedback,
                 candidatePodcasts = candidatePodcasts,
@@ -448,6 +461,7 @@ private fun HomeScreenBottomSheets(
     if (sheets.showReviewPrompt) {
         cx.aswin.boxcast.feature.home.components.ReviewPromptSheet(
             completedCount = uiState.completedEpisodeCount,
+            variant = sheets.reviewPromptVariant,
             onDismissRequest = callbacks.onDismissReviewPrompt,
             onNavigateToReview = callbacks.onNavigateToPlayStoreReview,
             onNavigateToFeedback = {
@@ -533,7 +547,7 @@ fun HomeScreen(
                 },
                 onFeedbackLongClick = {
                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackTopControlbarInteraction("feedback_long_clicked", "home")
-                    callbacks.onForceReviewPrompt()
+                    callbacks.onForceSurveyNps()
                 },
                 onAvatarClick = {
                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackTopControlbarInteraction("settings_clicked", "home")

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -162,7 +162,8 @@ class HomeViewModel(
     application: Application,
     apiBaseUrl: String,
     publicKey: String,
-    private val playbackRepository: cx.aswin.boxcast.core.data.PlaybackRepository
+    private val playbackRepository: cx.aswin.boxcast.core.data.PlaybackRepository,
+    private val engagementCoordinator: cx.aswin.boxcast.core.data.EngagementPromptCoordinator,
 ) : AndroidViewModel(application) {
     
     val podcastRepository = PodcastRepository(baseUrl = apiBaseUrl, publicKey = publicKey, context = application)
@@ -184,6 +185,10 @@ class HomeViewModel(
 
     private val _showReviewPrompt = MutableStateFlow(false)
     val showReviewPrompt = _showReviewPrompt.asStateFlow()
+
+    private val _reviewPromptVariant =
+        MutableStateFlow(cx.aswin.boxcast.feature.home.components.ReviewPromptVariant.Milestone)
+    val reviewPromptVariant = _reviewPromptVariant.asStateFlow()
 
     private val _showPostReview = MutableStateFlow(false)
     val showPostReview = _showPostReview.asStateFlow()
@@ -945,12 +950,45 @@ class HomeViewModel(
                     // Compute completed count for review prompt logic
                     val completedCount = allHistory.count { it.isCompleted }
                     
-                    // Check if review prompt should be shown (milestone-based)
+                    // Check if review prompt should be shown (promoter handoff or milestone-based)
                     if (!_showReviewPrompt.value && !_showFeedback.value && !_showPostReview.value) {
-                        val shouldPrompt = userPrefs.shouldShowReviewPrompt(completedCount, playerState.value.isPlaying)
-                        if (shouldPrompt) {
+                        val isPlayingNow = playerState.value.isPlaying
+                        if (engagementCoordinator.shouldShowPromoterReview(isPlayingNow)) {
+                            engagementCoordinator.recordProactivePromptShown()
+                            engagementCoordinator.clearPromoterReviewPending()
+                            val npsScore = userPrefs.npsLastScore()
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackPromoterReviewHandoff(
+                                npsScore,
+                            )
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackEngagementPromptShown(
+                                promptType = "promoter_review",
+                                source = "nps_handoff",
+                            )
+                            _reviewPromptVariant.value =
+                                cx.aswin.boxcast.feature.home.components.ReviewPromptVariant.PromoterHandoff
                             _showReviewPrompt.value = true
+                        } else if (engagementCoordinator.canShowProactivePrompt(isPlayingNow)) {
+                            val shouldPrompt =
+                                userPrefs.shouldShowReviewPrompt(completedCount, isPlayingNow)
+                            if (shouldPrompt) {
+                                engagementCoordinator.recordProactivePromptShown()
+                                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackEngagementPromptShown(
+                                    promptType = "milestone_review",
+                                    source = "episode_milestone",
+                                    completedEpisodes = completedCount,
+                                )
+                                _reviewPromptVariant.value =
+                                    cx.aswin.boxcast.feature.home.components.ReviewPromptVariant.Milestone
+                                _showReviewPrompt.value = true
+                            }
                         }
+                    }
+
+                    // NPS survey: mark eligible once the user reaches 3+ completed episodes.
+                    // The trigger event fires on the next app open (see MainActivity)
+                    // so it never interrupts background playback.
+                    if (completedCount >= 3) {
+                        userPrefs.markNpsSurveyPending(completedCount)
                     }
                     
                     // ... (Logic copied below) ...
@@ -1696,6 +1734,8 @@ mixtapePodcasts = cachedMix
 
     fun dismissReviewPrompt() {
         _showReviewPrompt.value = false
+        _reviewPromptVariant.value =
+            cx.aswin.boxcast.feature.home.components.ReviewPromptVariant.Milestone
     }
 
     fun dismissPostReview() {
@@ -1717,6 +1757,11 @@ mixtapePodcasts = cachedMix
         _showFeedback.value = false
         _showPostReview.value = false
         _showReviewPrompt.value = true
+    }
+
+    /** Manually trigger the NPS survey (long-press feedback icon). Bypasses the ep-3 milestone. */
+    fun forceSurveyNps() {
+        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSurveyNpsManualTrigger(source = "long_press")
     }
 
     fun triggerPostReview() {

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -968,8 +968,8 @@ class HomeViewModel(
                                 cx.aswin.boxcast.feature.home.components.ReviewPromptVariant.PromoterHandoff
                             _showReviewPrompt.value = true
                         } else if (engagementCoordinator.canShowProactivePrompt(isPlayingNow)) {
-                            val shouldPrompt =
-                                userPrefs.shouldShowReviewPrompt(completedCount, isPlayingNow)
+                            userPrefs.syncReviewMilestonePending(completedCount)
+                            val shouldPrompt = userPrefs.shouldShowReviewPrompt(isPlayingNow)
                             if (shouldPrompt) {
                                 engagementCoordinator.recordProactivePromptShown()
                                 cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackEngagementPromptShown(
@@ -987,7 +987,7 @@ class HomeViewModel(
                     // NPS survey: mark eligible once the user reaches 3+ completed episodes.
                     // The trigger event fires on the next app open (see MainActivity)
                     // so it never interrupts background playback.
-                    if (completedCount >= 3) {
+                    if (completedCount >= 3 && !userPrefs.hasNpsSurveyFired() && !userPrefs.isNpsSurveyPending()) {
                         userPrefs.markNpsSurveyPending(completedCount)
                     }
                     

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/ReviewSheet.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/ReviewSheet.kt
@@ -25,6 +25,9 @@ import kotlinx.coroutines.launch
 /**
  * Milestone review prompt — M3 Expressive bottom sheet.
  * Diverts happy users to Play Store, frustrated users to Feedback.
+ *
+ * @param variant Milestone uses episode-based copy; [ReviewPromptVariant.PromoterHandoff]
+ *   acknowledges the user already scored 8+ on NPS.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -32,19 +35,54 @@ fun ReviewPromptSheet(
     completedCount: Int,
     onDismissRequest: () -> Unit,
     onNavigateToReview: () -> Unit,
-    onNavigateToFeedback: () -> Unit
+    onNavigateToFeedback: () -> Unit,
+    variant: ReviewPromptVariant = ReviewPromptVariant.Milestone,
 ) {
-    val title = when {
-        completedCount >= 30 -> "You're a podcast pro"
-        completedCount >= 15 -> "You're a regular listener"
-        else -> "You're on a roll"
-    }
-    
-    val body = when {
-        completedCount >= 30 -> "$completedCount episodes and counting — your review would mean the world to us."
-        completedCount >= 15 -> "You've finished $completedCount episodes. Mind leaving a quick rating?"
-        else -> "You've completed $completedCount episodes. How's boxcast treating you?"
-    }
+    val title =
+        when (variant) {
+            ReviewPromptVariant.PromoterHandoff -> "Glad you're enjoying boxcast"
+            ReviewPromptVariant.Milestone ->
+                when {
+                    completedCount >= 30 -> "You're a podcast pro"
+                    completedCount >= 15 -> "You're a regular listener"
+                    else -> "You're on a roll"
+                }
+        }
+
+    val body =
+        when (variant) {
+            ReviewPromptVariant.PromoterHandoff ->
+                "Thanks for the great score — a quick Play Store rating helps other listeners discover boxcast."
+            ReviewPromptVariant.Milestone ->
+                when {
+                    completedCount >= 30 ->
+                        "$completedCount episodes and counting — your review would mean the world to us."
+                    completedCount >= 15 ->
+                        "You've finished $completedCount episodes. Mind leaving a quick rating?"
+                    else -> "You've completed $completedCount episodes. How's boxcast treating you?"
+                }
+        }
+
+    val primaryLabel =
+        when (variant) {
+            ReviewPromptVariant.PromoterHandoff -> "Rate on Play Store"
+            ReviewPromptVariant.Milestone ->
+                if (completedCount >= 15) "Rate boxcast" else "Loving it"
+        }
+
+    val secondaryLabel =
+        when (variant) {
+            ReviewPromptVariant.PromoterHandoff -> "Not right now"
+            ReviewPromptVariant.Milestone ->
+                if (completedCount >= 30) "Not right now" else "Could be better"
+        }
+
+    val onSecondaryClick =
+        when (variant) {
+            ReviewPromptVariant.PromoterHandoff -> onDismissRequest
+            ReviewPromptVariant.Milestone ->
+                if (completedCount >= 30) onDismissRequest else onNavigateToFeedback
+        }
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -118,7 +156,7 @@ fun ReviewPromptSheet(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = if (completedCount >= 15) "Rate boxcast" else "Loving it",
+                    text = primaryLabel,
                     style = MaterialTheme.typography.labelLarge
                 )
             }
@@ -127,19 +165,24 @@ fun ReviewPromptSheet(
             
             // Secondary — go to feedback or dismiss
             OutlinedButton(
-                onClick = if (completedCount >= 30) onDismissRequest else onNavigateToFeedback,
+                onClick = onSecondaryClick,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(52.dp),
                 shape = RoundedCornerShape(16.dp)
             ) {
                 Text(
-                    text = if (completedCount >= 30) "Not right now" else "Could be better",
+                    text = secondaryLabel,
                     style = MaterialTheme.typography.labelLarge
                 )
             }
         }
     }
+}
+
+enum class ReviewPromptVariant {
+    Milestone,
+    PromoterHandoff,
 }
 
 /**

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/ReviewSheet.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/ReviewSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import cx.aswin.boxcast.core.designsystem.components.EngagementBottomSheetScaffold
 import kotlinx.coroutines.launch
 
 /**
@@ -86,94 +87,90 @@ fun ReviewPromptSheet(
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    ModalBottomSheet(
+    EngagementBottomSheetScaffold(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-        containerColor = MaterialTheme.colorScheme.surface,
-        tonalElevation = 2.dp
+        showCloseButton = false,
+        properties = ModalBottomSheetProperties(),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 36.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            // Icon header
             Surface(
                 shape = RoundedCornerShape(16.dp),
                 color = MaterialTheme.colorScheme.primaryContainer,
-                modifier = Modifier.size(56.dp)
+                modifier = Modifier.size(56.dp),
             ) {
                 Box(contentAlignment = Alignment.Center) {
                     Icon(
                         imageVector = Icons.Rounded.Star,
                         contentDescription = null,
                         modifier = Modifier.size(28.dp),
-                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
                     )
                 }
             }
-            
+
             Spacer(modifier = Modifier.height(20.dp))
-            
+
             Text(
                 text = title,
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
             )
-            
+
             Spacer(modifier = Modifier.height(8.dp))
-            
+
             Text(
                 text = body,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
-                lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
+                lineHeight = MaterialTheme.typography.bodyMedium.lineHeight,
             )
-            
+
             Spacer(modifier = Modifier.height(28.dp))
-            
-            // Primary — rate on Play Store
+
             Button(
                 onClick = onNavigateToReview,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(52.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(52.dp),
                 shape = RoundedCornerShape(16.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary
-                )
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                    ),
             ) {
                 Icon(
                     imageVector = Icons.Rounded.ThumbUp,
                     contentDescription = null,
-                    modifier = Modifier.size(18.dp)
+                    modifier = Modifier.size(18.dp),
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
                     text = primaryLabel,
-                    style = MaterialTheme.typography.labelLarge
+                    style = MaterialTheme.typography.labelLarge,
                 )
             }
-            
+
             Spacer(modifier = Modifier.height(12.dp))
-            
-            // Secondary — go to feedback or dismiss
+
             OutlinedButton(
                 onClick = onSecondaryClick,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(52.dp),
-                shape = RoundedCornerShape(16.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(52.dp),
+                shape = RoundedCornerShape(16.dp),
             ) {
                 Text(
                     text = secondaryLabel,
-                    style = MaterialTheme.typography.labelLarge
+                    style = MaterialTheme.typography.labelLarge,
                 )
             }
         }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/ReviewSheet.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/ReviewSheet.kt
@@ -177,8 +177,12 @@ fun ReviewPromptSheet(
     }
 }
 
+/** Copy variant for [ReviewPromptSheet] — milestone-based or post-NPS promoter handoff. */
 enum class ReviewPromptVariant {
+    /** Episode-count milestone (5/15/30 completed). */
     Milestone,
+
+    /** Deferred Play review after the user scored 8+ on NPS. */
     PromoterHandoff,
 }
 


### PR DESCRIPTION
## Summary
- Replace `posthog-android-surveys-compose` (crashes on Material3 1.5) with a custom `BoxcastPostHogSurveysDelegate` and native Compose survey UI wrapped in `BoxCastTheme` and `EngagementBottomSheetScaffold`.
- Add `EngagementPromptCoordinator` so NPS and Play review share one proactive modal per session, a 14-day cooldown, and deferred promoter handoff (NPS 8+ → tailored review sheet on next open).
- Milestone Play review (ep 5/15/30) only runs after NPS has fired and skips detractors (score ≤ 7); promoter handoff uses distinct copy instead of repeating "How's boxcast treating you?"

## Test plan
- [ ] Long-press feedback → NPS sheet matches app theme (28dp sheet, connected 0–10 bar, 52dp submit)
- [ ] Submit NPS 8+ → force-close → reopen → promoter review sheet ("Glad you're enjoying boxcast") with Rate / Not right now
- [ ] Submit NPS ≤7 → reach ep 5 → milestone review suppressed
- [ ] Tap feedback anytime → FeedbackSheet opens without orchestrator blocking
- [ ] Same session: NPS shown → review does not also show on that open
- [ ] Remote flag `survey-nps-remote-trigger` still fires manual trigger when orchestrator allows


Made with [Cursor](https://cursor.com)