### PR TITLE
feat(queue): tiered auto-refill engine, Lore independence, and drag reorder

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -468,6 +468,53 @@ class MainActivity : ComponentActivity() {
                 cx.aswin.boxcast.core.data.QueueManager(queueRepository, playbackRepository)
             }
 
+            // Lore queue independence: queueing from the Lore card stack over an existing
+            // normal queue requires explicit confirmation (it clears the normal queue).
+            var loreQueueConflictEpisode by remember {
+                mutableStateOf<cx.aswin.boxcast.core.model.Episode?>(null)
+            }
+            val queueLoreEpisode: (cx.aswin.boxcast.core.model.Episode) -> Unit = { episode ->
+                val podcast = cx.aswin.boxcast.core.model.Podcast(
+                    id = episode.podcastId ?: "unknown",
+                    title = episode.podcastTitle ?: "Unknown Podcast",
+                    artist = episode.podcastTitle ?: "Unknown",
+                    imageUrl = episode.podcastImageUrl ?: episode.imageUrl ?: ""
+                )
+                queueManager.addToQueue(episode, podcast, cx.aswin.boxcast.core.model.PlaybackEntryPoint.LEARN)
+            }
+
+            loreQueueConflictEpisode?.let { pendingLoreEpisode ->
+                androidx.compose.material3.AlertDialog(
+                    onDismissRequest = {
+                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "cancelled")
+                        loreQueueConflictEpisode = null
+                    },
+                    title = { Text("Start a Lore queue?") },
+                    text = {
+                        Text(
+                            "Adding from Lore starts a fresh Lore queue and clears your current queue. " +
+                                "To keep your queue instead, tap the card to open the episode and use \"Add to Queue\" there."
+                        )
+                    },
+                    confirmButton = {
+                        androidx.compose.material3.TextButton(onClick = {
+                            loreQueueConflictEpisode = null
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "start_lore_queue")
+                            scope.launch {
+                                playbackRepository.stopAndClearQueue()
+                                queueLoreEpisode(pendingLoreEpisode)
+                            }
+                        }) { Text("Start Lore queue") }
+                    },
+                    dismissButton = {
+                        androidx.compose.material3.TextButton(onClick = {
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "cancelled")
+                            loreQueueConflictEpisode = null
+                        }) { Text("Cancel") }
+                    }
+                )
+            }
+
             val smartDownloadManager = remember {
                 cx.aswin.boxcast.core.data.SmartDownloadManager(
                     context = application,
@@ -1351,13 +1398,19 @@ class MainActivity : ComponentActivity() {
                                         navController.navigate(route)
                                     },
                                     onQueueEpisode = { episode ->
-                                        val podcast = cx.aswin.boxcast.core.model.Podcast(
-                                            id = episode.podcastId ?: "unknown",
-                                            title = episode.podcastTitle ?: "Unknown Podcast",
-                                            artist = episode.podcastTitle ?: "Unknown",
-                                            imageUrl = episode.podcastImageUrl ?: episode.imageUrl ?: ""
-                                        )
-                                         queueManager.addToQueue(episode, podcast, cx.aswin.boxcast.core.model.PlaybackEntryPoint.LEARN)
+                                        scope.launch {
+                                            // A normal queue exists: warn before clearing it for a
+                                            // Lore queue. Lore-only or empty queues append silently.
+                                            if (playbackRepository.hasNonLoreQueue()) {
+                                                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictShown(
+                                                    episodeId = episode.id,
+                                                    normalQueueSize = playbackRepository.playerState.value.queue.size
+                                                )
+                                                loreQueueConflictEpisode = episode
+                                            } else {
+                                                queueLoreEpisode(episode)
+                                            }
+                                        }
                                     },
                                     onPodcastClick = { feedId, itunesId, feedUrl, title ->
                                         val pId = feedId?.toString() ?: ""

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -501,8 +501,12 @@ class MainActivity : ComponentActivity() {
                             loreQueueConflictEpisode = null
                             cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "start_lore_queue")
                             scope.launch {
-                                playbackRepository.stopAndClearQueue()
-                                queueLoreEpisode(pendingLoreEpisode)
+                                try {
+                                    playbackRepository.stopAndClearQueue()
+                                    queueLoreEpisode(pendingLoreEpisode)
+                                } catch (e: Exception) {
+                                    android.util.Log.e("MainActivity", "Failed to start Lore queue", e)
+                                }
                             }
                         }) { Text("Start Lore queue") }
                     },
@@ -1399,16 +1403,20 @@ class MainActivity : ComponentActivity() {
                                     },
                                     onQueueEpisode = { episode ->
                                         scope.launch {
-                                            // A normal queue exists: warn before clearing it for a
-                                            // Lore queue. Lore-only or empty queues append silently.
-                                            if (playbackRepository.hasNonLoreQueue()) {
-                                                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictShown(
-                                                    episodeId = episode.id,
-                                                    normalQueueSize = playbackRepository.playerState.value.queue.size
-                                                )
-                                                loreQueueConflictEpisode = episode
-                                            } else {
-                                                queueLoreEpisode(episode)
+                                            try {
+                                                // A normal queue exists: warn before clearing it for a
+                                                // Lore queue. Lore-only or empty queues append silently.
+                                                if (playbackRepository.hasNonLoreQueue()) {
+                                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictShown(
+                                                        episodeId = episode.id,
+                                                        normalQueueSize = playbackRepository.playerState.value.queue.size
+                                                    )
+                                                    loreQueueConflictEpisode = episode
+                                                } else {
+                                                    queueLoreEpisode(episode)
+                                                }
+                                            } catch (e: Exception) {
+                                                android.util.Log.e("MainActivity", "Failed to queue Lore episode", e)
                                             }
                                         }
                                     },

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -461,12 +461,11 @@ class MainActivity : ComponentActivity() {
                 }
             }
             
-            // 5. Smart Queue Engine
-            val smartQueueEngine = remember { cx.aswin.boxcast.core.data.DefaultSmartQueueEngine(podcastRepository, database.listeningHistoryDao(), subscriptionRepository) }
-            
             // QueueManager (Singleton-ish) - Needs to be provided to ViewModels/Screens
+            // NOTE: auto-refill lives service-side (BoxLorePlaybackService owns the single
+            // SmartQueueEngine instance); the UI layer only performs explicit queue actions.
             val queueManager = remember { 
-                cx.aswin.boxcast.core.data.QueueManager(queueRepository, smartQueueEngine, playbackRepository, podcastRepository)
+                cx.aswin.boxcast.core.data.QueueManager(queueRepository, playbackRepository)
             }
 
             val smartDownloadManager = remember {

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -41,8 +41,7 @@ android {
     }
 
     testOptions {
-        // Let android.util.Log calls no-op in JVM unit tests instead of throwing.
-        unitTests.isReturnDefaultValues = true
+        unitTests.isIncludeAndroidResources = false
     }
 }
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -39,6 +39,11 @@ android {
         abortOnError = false
         checkReleaseBuilds = true
     }
+
+    testOptions {
+        // Let android.util.Log calls no-op in JVM unit tests instead of throwing.
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -81,4 +86,5 @@ dependencies {
 
     // Testing
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -874,7 +874,7 @@ class PlaybackRepository(
                             val historyItem = listeningHistoryDao.getHistoryItem(newEpisode.id)
                             if (historyItem != null && !historyItem.isCompleted && historyItem.progressMs > 2000) {
                                 android.util.Log.d("PlaybackRepo", "onMediaItemTransition: Restoring saved position ${historyItem.progressMs}ms for ${newEpisode.title}")
-                                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                                repositoryScope.launch {
                                     mediaController?.seekTo(historyItem.progressMs)
                                 }
                             }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -112,10 +112,10 @@ class PlaybackRepository(
     private var sleepTimerJob: Job? = null
     private var likeStateObserverJob: Job? = null
     
-    // Queue auto-refill callback - set by QueueManager
-    private val QUEUE_REFILL_THRESHOLD = 3
     private val QUEUE_MAX_SIZE = 50
-    var queueRefillCallback: ((currentEpisode: Episode, podcast: Podcast) -> Unit)? = null
+
+    // Local memory of rejected auto-fill suggestions (feeds the SmartQueueEngine).
+    private val queueSkipMemory = QueueSkipMemory.fromContext(context)
 
     init {
         getOrCreateDeviceUuid()
@@ -880,13 +880,18 @@ class PlaybackRepository(
                             }
                         }
 
-                        // 6. Auto-refill when queue is running low
-                        val currentQueueSize = _playerState.value.queue.size
-                        val isLearn = mediaItem.mediaId.startsWith(LEARN_PREFIX)
-                        if (currentQueueSize < QUEUE_REFILL_THRESHOLD && newPodcast != null && !isLearn) {
-                            android.util.Log.d("PlaybackRepo", "Queue running low ($currentQueueSize items). Triggering auto-refill.")
-                            queueRefillCallback?.invoke(newEpisode, newPodcast)
-                        }
+                        // NOTE: auto-refill is owned exclusively by BoxLorePlaybackService's
+                        // transition listener (single guarded path, works with UI closed).
+                        // Items it appends are picked up by onTimelineChanged below.
+                    }
+                }
+
+                override fun onTimelineChanged(timeline: androidx.media3.common.Timeline, reason: Int) {
+                    // The playback service (auto-refill, Android Auto) can append items
+                    // directly to the player. Reconcile the in-memory queue whenever the
+                    // playlist changes so the UI stays in sync.
+                    if (reason == androidx.media3.common.Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED) {
+                        reconcileQueueWithController()
                     }
                 }
             })
@@ -1061,6 +1066,76 @@ class PlaybackRepository(
         } catch (e: Exception) {
             android.util.Log.e("PlaybackRepo", "syncQueueToDb: Failed", e)
         }
+    }
+
+    /**
+     * Rebuilds PlayerState.queue from the controller's playlist when the two diverge —
+     * e.g. after the playback service auto-refilled the queue or Android Auto appended
+     * items directly to the player. Episode metadata is resolved from the in-memory
+     * queue first, then the persisted queue rows (which carry contextType/source for
+     * the queue-sheet labels), then the MediaItem itself as a last resort.
+     */
+    private fun reconcileQueueWithController() {
+        val controller = mediaController ?: return
+        if (controller.mediaItemCount == 0) return
+        val start = controller.currentMediaItemIndex.coerceAtLeast(0)
+        val orderedIds = (start until controller.mediaItemCount).map {
+            QueueMath.stripMediaIdPrefixes(controller.getMediaItemAt(it).mediaId)
+        }
+        if (orderedIds == _playerState.value.queue.map { it.id }) return
+
+        repositoryScope.launch {
+            var dbItems = try {
+                queueRepository.getQueueSnapshot().associateBy { it.id }
+            } catch (e: Exception) { emptyMap() }
+
+            // The service persists refill rows just before appending to the player; give
+            // a slow write one retry before falling back to bare MediaItem metadata.
+            val knownNow = _playerState.value.queue.associateBy { it.id }
+            if (orderedIds.any { it !in knownNow && it !in dbItems }) {
+                kotlinx.coroutines.delay(400)
+                dbItems = try {
+                    queueRepository.getQueueSnapshot().associateBy { it.id }
+                } catch (e: Exception) { dbItems }
+            }
+
+            // Re-read the controller: the playlist may have changed again meanwhile.
+            val controllerNow = mediaController ?: return@launch
+            if (controllerNow.mediaItemCount == 0) return@launch
+            val startNow = controllerNow.currentMediaItemIndex.coerceAtLeast(0)
+            val idsNow = (startNow until controllerNow.mediaItemCount).map {
+                QueueMath.stripMediaIdPrefixes(controllerNow.getMediaItemAt(it).mediaId)
+            }
+            val latestQueue = _playerState.value.queue
+            if (idsNow == latestQueue.map { it.id }) return@launch
+
+            val known = latestQueue.associateBy { it.id }
+            val newQueue = idsNow.mapIndexed { offset, id ->
+                known[id] ?: dbItems[id]
+                    ?: buildEpisodeFromMediaItem(controllerNow.getMediaItemAt(startNow + offset), id)
+            }
+            android.util.Log.d("PlaybackRepo", "reconcileQueueWithController: ${latestQueue.size} -> ${newQueue.size} items")
+            _playerState.value = _playerState.value.copy(queue = newQueue)
+        }
+    }
+
+    private fun buildEpisodeFromMediaItem(item: MediaItem, episodeId: String): Episode {
+        val metadata = item.mediaMetadata
+        return Episode(
+            id = episodeId,
+            title = metadata.title?.toString() ?: "Episode",
+            description = "",
+            audioUrl = item.localConfiguration?.uri?.toString() ?: "",
+            imageUrl = metadata.artworkUri?.toString(),
+            podcastImageUrl = metadata.artworkUri?.toString(),
+            podcastTitle = metadata.subtitle?.toString() ?: metadata.artist?.toString(),
+            podcastArtist = metadata.artist?.toString(),
+            podcastGenre = metadata.genre?.toString(),
+            duration = 0,
+            publishedDate = 0L,
+            // Items we didn't add locally were appended by the service refill path.
+            contextType = "AUTO_FILL"
+        )
     }
 
     private fun buildMediaItems(episodes: List<Episode>, podcast: Podcast, entryPointContext: android.os.Bundle?): List<MediaItem> {
@@ -1372,53 +1447,231 @@ class PlaybackRepository(
 
 
 
-    suspend fun removeFromQueue(episodeId: String) {
+    /**
+     * Snapshot of a removed queue item, returned so the UI can offer Undo and so the
+     * skip signal (analytics + skip memory) can be deferred until the undo window lapses.
+     */
+    data class RemovedQueueItem(
+        val episode: Episode,
+        val queueIndex: Int,
+        val mediaIndex: Int,
+        val contextType: String?,
+        val contextSourceId: String?
+    )
+
+    /**
+     * Removes an episode from the queue (Media3 + in-memory + DB).
+     *
+     * @param deferSkipSignal when true, the AUTO_FILL rejection signal is NOT recorded
+     *   here — the caller must invoke [confirmQueueRemoval] once the undo window lapses
+     *   (or [undoQueueRemoval] if the user undoes), so an undone remove doesn't count
+     *   as a rejection.
+     * @return removal info for undo, or null if the episode wasn't in the queue.
+     */
+    suspend fun removeFromQueue(episodeId: String, deferSkipSignal: Boolean = false): RemovedQueueItem? {
         if (mediaController == null) {
             mediaController = mediaControllerFuture?.await()
         }
-        
-        try {
-            val queueItem = queueRepository.getQueueItemByEpisodeId(episodeId)
-            if (queueItem != null && queueItem.contextType == "AUTO_FILL") {
-                var positionInQueue = -1
-                mediaController?.let { controller ->
-                    for (i in 0 until controller.mediaItemCount) {
-                        if (controller.getMediaItemAt(i).mediaId.removePrefix(LEARN_PREFIX) == episodeId) {
-                            positionInQueue = i
-                            break
-                        }
-                    }
-                }
-                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSmartQueueEpisodeSkipped(
-                    episodeId = episodeId,
-                    recommendationSource = queueItem.contextSourceId ?: "unknown",
-                    positionInQueue = positionInQueue
-                )
-            }
-        } catch (e: Exception) {
-            android.util.Log.e("PlaybackRepo", "Failed to track skip for $episodeId", e)
+
+        val queueItem = try {
+            queueRepository.getQueueItemByEpisodeId(episodeId)
+        } catch (e: Exception) { null }
+
+        val currentQueue = _playerState.value.queue
+        val queueIndex = currentQueue.indexOfFirst { it.id == episodeId }
+
+        var mediaIndex = -1
+        mediaController?.let { controller ->
+            val mediaIds = (0 until controller.mediaItemCount).map { controller.getMediaItemAt(it).mediaId }
+            mediaIndex = QueueMath.mediaIndexOfEpisode(mediaIds, episodeId)
+        }
+
+        val removedInfo = if (queueIndex != -1) {
+            val episode = currentQueue[queueIndex]
+            RemovedQueueItem(
+                episode = episode.copy(
+                    contextType = queueItem?.contextType ?: episode.contextType,
+                    contextSourceId = queueItem?.contextSourceId ?: episode.contextSourceId
+                ),
+                queueIndex = queueIndex,
+                mediaIndex = mediaIndex,
+                contextType = queueItem?.contextType ?: episode.contextType,
+                contextSourceId = queueItem?.contextSourceId ?: episode.contextSourceId
+            )
+        } else null
+
+        if (!deferSkipSignal && removedInfo != null) {
+            confirmQueueRemoval(removedInfo)
         }
 
         var removedFromController = false
         mediaController?.let { controller ->
-            for (i in 0 until controller.mediaItemCount) {
-                val item = controller.getMediaItemAt(i)
-                if (item.mediaId.removePrefix(LEARN_PREFIX) == episodeId) {
-                    controller.removeMediaItem(i)
-                    removedFromController = true
-                    break
-                }
+            if (mediaIndex != -1) {
+                controller.removeMediaItem(mediaIndex)
+                removedFromController = true
             }
         }
 
         // Always update local state and sync to DB, even if the item wasn't in Media3 playlist
-        val currentQueue = _playerState.value.queue
         val existsInLocalQueue = currentQueue.any { it.id == episodeId }
         
         if (existsInLocalQueue || !removedFromController) {
             val newQueue = currentQueue.filter { it.id != episodeId }
             _playerState.value = _playerState.value.copy(queue = newQueue)
             syncQueueToDb()
+        }
+        return removedInfo
+    }
+
+    /**
+     * Records the rejection signal for a removed AUTO_FILL item: PostHog analytics plus
+     * local skip memory (so the SmartQueueEngine stops re-suggesting it and can
+     * down-rank the podcast). Called immediately on remove, or after the undo window.
+     */
+    fun confirmQueueRemoval(removed: RemovedQueueItem) {
+        if (removed.contextType != "AUTO_FILL") return
+        try {
+            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSmartQueueEpisodeSkipped(
+                episodeId = removed.episode.id,
+                recommendationSource = removed.contextSourceId ?: "unknown",
+                positionInQueue = removed.mediaIndex
+            )
+            queueSkipMemory.recordSkip(
+                episodeId = removed.episode.id,
+                podcastId = removed.episode.podcastId,
+                source = removed.contextSourceId
+            )
+        } catch (e: Exception) {
+            android.util.Log.e("PlaybackRepo", "Failed to record queue removal signal for ${removed.episode.id}", e)
+        }
+    }
+
+    /** Re-inserts a removed episode at its original position (Media3 + state + DB). */
+    suspend fun undoQueueRemoval(removed: RemovedQueueItem) {
+        val episode = removed.episode
+        if (_playerState.value.queue.any { it.id == episode.id }) return
+        if (mediaController == null) {
+            mediaController = mediaControllerFuture?.await()
+        }
+        val controller = mediaController ?: return
+
+        val isLore = removed.contextType == QueueMath.CONTEXT_TYPE_LORE
+        val mediaId = if (isLore) "$LEARN_PREFIX${episode.id}" else episode.id
+        val resolvedUrl = episode.imageUrl?.takeIf { it.isNotBlank() }
+            ?: episode.podcastImageUrl?.takeIf { it.isNotBlank() } ?: ""
+        val metadata = androidx.media3.common.MediaMetadata.Builder()
+            .setTitle(episode.title)
+            .setArtist(episode.podcastTitle ?: "")
+            .setArtworkUri(android.net.Uri.parse(resolvedUrl))
+            .setDisplayTitle(episode.title)
+            .setSubtitle(episode.podcastTitle ?: "")
+            .setGenre(episode.podcastGenre ?: "Podcast")
+            .build()
+        val mediaItem = MediaItem.Builder()
+            .setUri(episode.audioUrl)
+            .setMediaMetadata(metadata)
+            .setMediaId(mediaId)
+            .setCustomCacheKey(episode.id)
+            .build()
+
+        val insertMediaIndex = removed.mediaIndex
+            .takeIf { it in 0..controller.mediaItemCount }
+            ?: controller.mediaItemCount
+        controller.addMediaItem(insertMediaIndex, mediaItem)
+
+        val currentQueue = _playerState.value.queue.toMutableList()
+        val insertQueueIndex = removed.queueIndex.coerceIn(0, currentQueue.size)
+        currentQueue.add(insertQueueIndex, episode)
+        _playerState.value = _playerState.value.copy(queue = currentQueue.toList())
+        syncQueueToDb()
+    }
+
+    /**
+     * Moves a queue item to a new position, updating all three layers in order:
+     * Media3 playlist (no playback interruption), in-memory PlayerState.queue, and —
+     * via [persistQueueOrder], typically debounced to drag end — the Room queue table.
+     *
+     * Indices are PlayerState.queue indices; index 0 (the playing item) is pinned.
+     */
+    fun moveQueueItem(fromQueueIndex: Int, toQueueIndex: Int) {
+        val queue = _playerState.value.queue
+        if (fromQueueIndex == toQueueIndex) return
+        if (fromQueueIndex !in queue.indices || toQueueIndex !in queue.indices) return
+        if (fromQueueIndex == 0 || toQueueIndex == 0) return
+
+        val controller = mediaController ?: return
+        val episode = queue[fromQueueIndex]
+
+        // Resolve Media3 indices by mediaId (with learn-prefix stripped), never by raw
+        // queue index: the playlist can retain already-played items before the current one.
+        val mediaIds = (0 until controller.mediaItemCount).map { controller.getMediaItemAt(it).mediaId }
+        val fromMedia = QueueMath.mediaIndexOfEpisode(mediaIds, episode.id)
+        if (fromMedia != -1) {
+            val base = QueueMath.mediaIndexOfEpisode(mediaIds, queue[0].id)
+                .takeIf { it != -1 } ?: controller.currentMediaItemIndex.coerceAtLeast(0)
+            val toMedia = (base + toQueueIndex).coerceIn(0, controller.mediaItemCount - 1)
+            controller.moveMediaItem(fromMedia, toMedia)
+        }
+
+        _playerState.value = _playerState.value.copy(
+            queue = QueueMath.moveItem(queue, fromQueueIndex, toQueueIndex)
+        )
+    }
+
+    /**
+     * Persists the current queue order to Room (called once on drag end so rapid moves
+     * don't thrash the DB) and emits the reorder analytics event.
+     */
+    suspend fun persistQueueOrder(movedEpisodeId: String? = null, fromQueueIndex: Int = -1, toQueueIndex: Int = -1) {
+        val queue = _playerState.value.queue
+        try {
+            queueRepository.reorderQueue(queue.map { it.id })
+        } catch (e: Exception) {
+            android.util.Log.e("PlaybackRepo", "persistQueueOrder: Failed", e)
+        }
+        if (movedEpisodeId != null && fromQueueIndex != toQueueIndex && fromQueueIndex >= 0 && toQueueIndex >= 0) {
+            val contextType = queue.firstOrNull { it.id == movedEpisodeId }?.contextType
+            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackQueueReordered(
+                episodeId = movedEpisodeId,
+                fromPosition = fromQueueIndex,
+                toPosition = toQueueIndex,
+                contextType = contextType
+            )
+        }
+    }
+
+    /**
+     * True when the current queue contains any normal (non-Lore) item. Checks the live
+     * player first, then the persisted queue rows (which survive process restarts).
+     */
+    suspend fun hasNonLoreQueue(): Boolean {
+        if (mediaController == null) {
+            mediaController = mediaControllerFuture?.await()
+        }
+        val controller = mediaController
+        if (controller != null && controller.mediaItemCount > 0) {
+            val mediaIds = (0 until controller.mediaItemCount).map { controller.getMediaItemAt(it).mediaId }
+            return QueueMath.hasNonLoreMediaIds(mediaIds)
+        }
+        val snapshot = try { queueRepository.getQueueSnapshot() } catch (e: Exception) { emptyList() }
+        return snapshot.isNotEmpty() && QueueMath.hasNonLoreContextTypes(snapshot.map { it.contextType })
+    }
+
+    /**
+     * Stops playback and clears the queue everywhere (player + state + DB). Used when
+     * the user confirms starting a fresh Lore queue over an existing normal queue.
+     */
+    suspend fun stopAndClearQueue() {
+        mediaController?.stop()
+        mediaController?.clearMediaItems()
+        stopProgressTicker()
+        _playerState.value = PlayerState()
+        // A new queue is about to start; don't block session restore on next launch.
+        prefs.edit().putBoolean(KEY_PLAYER_DISMISSED, false).apply()
+        try {
+            queueRepository.clearQueue()
+        } catch (e: Exception) {
+            android.util.Log.e("PlaybackRepo", "stopAndClearQueue: Failed to clear DB queue", e)
         }
     }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueManager.kt
@@ -11,73 +11,14 @@ import javax.inject.Singleton
 @Singleton
 class QueueManager @Inject constructor(
     private val queueRepository: QueueRepository,
-    private val smartQueueEngine: SmartQueueEngine,
-    private val playbackRepository: PlaybackRepository,
-    private val podcastRepository: PodcastRepository
+    private val playbackRepository: PlaybackRepository
 ) {
     private val TAG = "QueueManager"
     private val scope = CoroutineScope(Dispatchers.Main)
-    private var isRefilling = false
-    
-    init {
-        android.util.Log.d(TAG, "QueueManager initialized")
-        // Set up auto-refill callback
-        playbackRepository.queueRefillCallback = { currentEpisode, podcast ->
-            android.util.Log.d(TAG, "queueRefillCallback triggered for: ${currentEpisode.title}")
-            refillQueue(currentEpisode, podcast)
-        }
-    }
-    
-    /**
-     * Auto-refill queue when running low on episodes
-     */
-    private fun refillQueue(currentEpisode: cx.aswin.boxcast.core.model.Episode, podcast: cx.aswin.boxcast.core.model.Podcast) {
-        if (isRefilling) return
-        isRefilling = true
-        
-        scope.launch {
-            try {
-                android.util.Log.d(TAG, "Auto-refill triggered for: ${currentEpisode.title}")
-                
-                val currentItem = EpisodeItem(
-                    id = currentEpisode.id.toLongOrNull() ?: 0L,
-                    title = currentEpisode.title,
-                    description = currentEpisode.description,
-                    enclosureUrl = currentEpisode.audioUrl,
-                    duration = currentEpisode.duration,
-                    datePublished = currentEpisode.publishedDate,
-                    image = currentEpisode.imageUrl,
-                    feedImage = currentEpisode.podcastImageUrl
-                )
-                
-                val nextEntries = smartQueueEngine.getNextEpisodes(currentItem, podcast, null)
-                android.util.Log.d(TAG, "Auto-refill got ${nextEntries.size} more episodes")
-                
-                // Defensive dedup: skip any entry matching currently playing episode
-                val currentEpisodeId = currentEpisode.id
-                
-                nextEntries.forEach { entry ->
-                    val domainNext = entry.episode.toDomain(entry.podcast)
-                    
-                    // Skip if same ID as currently playing
-                    if (domainNext.id == currentEpisodeId) {
-                        android.util.Log.d(TAG, "Refill: Skipping duplicate '${domainNext.title}' (id=${domainNext.id})")
-                        return@forEach
-                    }
-                    
-                    // Add to Persistence
-                    queueRepository.addToQueue(entry.episode, entry.podcast)
-                    
-                    // Add to Active Player Queue
-                    playbackRepository.addToQueue(domainNext, entry.podcast)
-                }
-            } catch (e: Exception) {
-                android.util.Log.e(TAG, "Auto-refill failed", e)
-            } finally {
-                isRefilling = false
-            }
-        }
-    }
+
+    // NOTE: auto-refill is intentionally NOT handled here. BoxLorePlaybackService owns the
+    // single guarded refill path (it works with the UI closed and can't race a second
+    // trigger); this class only orchestrates explicit user actions.
 
     /**
      * Maps the rich "entry_point" string carried in the source bundle back to the coarse
@@ -105,7 +46,7 @@ class QueueManager @Inject constructor(
                 queueRepository.addToQueue(episode, podcast)
                 
                 // 3. Start playback IMMEDIATELY with just the current episode
-                // The queueRefillCallback will auto-fill more episodes when queue runs low
+                // The playback service auto-fills more episodes when the queue runs low
                 val domainEpisode = episode.toDomain(podcast)
                 val entryPoint = resolveEntryPoint(entryPointContext)
                 playbackRepository.playQueue(listOf(domainEpisode), podcast, 0, entryPoint, sourceContext = entryPointContext)
@@ -123,11 +64,15 @@ class QueueManager @Inject constructor(
         android.util.Log.d(TAG, "addToQueue called: episodeId=${episode.id}, title=${episode.title}, podcast=${podcast?.title}, entryPoint=$entryPoint")
         scope.launch {
             if (podcast != null) {
+                // Lore items carry their own contextType so queue-type detection is
+                // robust across restarts (see Lore queue independence).
+                val contextType = if (entryPoint == PlaybackEntryPoint.LEARN) QueueMath.CONTEXT_TYPE_LORE else "MANUAL"
+
                 // Persist
-                queueRepository.addToQueue(episode, podcast)
+                queueRepository.addToQueue(episode, podcast, contextType = contextType)
                 
-                // Add to Player
-                val domainEpisode = episode.toDomain(podcast)
+                // Add to Player (carry provenance so the queue sheet can label the row)
+                val domainEpisode = episode.toDomain(podcast).copy(contextType = contextType)
                 playbackRepository.addToQueue(domainEpisode, podcast, entryPoint)
                 android.util.Log.d(TAG, "addToQueue: Complete. Current queue size: ${playbackRepository.playerState.value.queue.size}")
             } else {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueMath.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueMath.kt
@@ -1,0 +1,51 @@
+package cx.aswin.boxcast.core.data
+
+/**
+ * Pure index-mapping and queue-type helpers shared by the player repository, the
+ * playback service, and the queue UI. Kept free of Android dependencies so the
+ * mapping rules (learn-prefix stripping, hidden-current offsets, Lore detection)
+ * are unit-testable.
+ */
+object QueueMath {
+    const val LEARN_PREFIX = "learn:"
+    const val EPISODE_PREFIX = "episode:"
+    const val QUEUE_PREFIX = "queue:"
+    const val CONTEXT_TYPE_LORE = "LORE"
+
+    /** Strips any media-id prefix so ids can be compared against raw episode ids. */
+    fun stripMediaIdPrefixes(mediaId: String): String =
+        mediaId.removePrefix(LEARN_PREFIX).removePrefix(EPISODE_PREFIX).removePrefix(QUEUE_PREFIX)
+
+    /** Finds the media-item index of an episode, matching by id with prefixes stripped. */
+    fun mediaIndexOfEpisode(mediaIds: List<String>, episodeId: String): Int =
+        mediaIds.indexOfFirst { stripMediaIdPrefixes(it) == episodeId }
+
+    /**
+     * The queue sheet hides the currently playing item (queue index 0), so UI list
+     * indices are offset by one from PlayerState.queue indices.
+     */
+    fun uiIndexToQueueIndex(uiIndex: Int): Int = uiIndex + 1
+
+    fun queueIndexToUiIndex(queueIndex: Int): Int = queueIndex - 1
+
+    /**
+     * A queue is a "normal" queue (as opposed to a Lore-only queue) when any media id
+     * is not learn-prefixed.
+     */
+    fun hasNonLoreMediaIds(mediaIds: List<String>): Boolean =
+        mediaIds.any { !it.startsWith(LEARN_PREFIX) }
+
+    /** Same detection, from persisted queue rows (survives process restarts). */
+    fun hasNonLoreContextTypes(contextTypes: List<String?>): Boolean =
+        contextTypes.any { it != CONTEXT_TYPE_LORE }
+
+    /** Moves an element within a list, returning a new list. */
+    fun <T> moveItem(list: List<T>, fromIndex: Int, toIndex: Int): List<T> {
+        if (fromIndex == toIndex) return list
+        if (fromIndex !in list.indices || toIndex !in list.indices) return list
+        val mutable = list.toMutableList()
+        val item = mutable.removeAt(fromIndex)
+        mutable.add(toIndex, item)
+        return mutable
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueRepository.kt
@@ -228,7 +228,27 @@ class QueueRepository @Inject constructor(
         return queueDao.getQueueItemByEpisodeId(episodeId)
     }
 
-    suspend fun reorderQueue(items: List<EpisodeItem>) {
-        // Deferred
+    /**
+     * Rewrites row positions to match the given episode-id order (a Room transaction via
+     * the DAO), preserving each row's contextType/contextSourceId provenance.
+     * Ids not present in the DB are ignored; rows not present in the list keep their
+     * position but are pushed after the reordered block.
+     */
+    suspend fun reorderQueue(orderedEpisodeIds: List<String>) {
+        val items = queueDao.getAllQueueItemsSync()
+        if (items.isEmpty() || orderedEpisodeIds.isEmpty()) return
+
+        val byEpisodeId = items.associateBy { it.episodeId }
+        val reordered = mutableListOf<QueueItem>()
+        orderedEpisodeIds.forEach { episodeId ->
+            byEpisodeId[episodeId]?.let { reordered.add(it) }
+        }
+        // Keep any rows that weren't part of the provided order (defensive) at the tail.
+        val coveredIds = reordered.map { it.episodeId }.toSet()
+        items.filter { it.episodeId !in coveredIds }.forEach { reordered.add(it) }
+
+        val updated = reordered.mapIndexed { index, item -> item.copy(position = index) }
+        android.util.Log.d(TAG, "reorderQueue: Rewriting positions for ${updated.size} items")
+        queueDao.updateQueuePositions(updated)
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueSkipMemory.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueSkipMemory.kt
@@ -1,6 +1,7 @@
 package cx.aswin.boxcast.core.data
 
 import android.content.Context
+import android.util.Log
 
 /**
  * Lightweight local memory of auto-filled episodes the user rejected — either removed
@@ -36,6 +37,7 @@ class QueueSkipMemory(
         private const val ENTRY_SEPARATOR = "\n"
         private const val PREFS_NAME = "queue_skip_memory"
         private const val KEY_ENTRIES = "entries"
+        private const val TAG = "QueueSkipMemory"
 
         fun fromContext(context: Context): QueueSkipMemory {
             val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -94,7 +96,12 @@ class QueueSkipMemory(
     }
 
     private fun load(): List<SkipEntry> {
-        val raw = try { readRaw() } catch (e: Exception) { null } ?: return emptyList()
+        val raw = try {
+            readRaw()
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to read skip memory", e)
+            null
+        } ?: return emptyList()
         return raw.split(ENTRY_SEPARATOR).mapNotNull { line ->
             val parts = line.split(FIELD_SEPARATOR)
             if (parts.size < 4) return@mapNotNull null
@@ -113,6 +120,10 @@ class QueueSkipMemory(
             listOf(entry.episodeId, entry.podcastId, entry.source, entry.timestampMs.toString())
                 .joinToString(FIELD_SEPARATOR) { it.replace(FIELD_SEPARATOR, "_").replace(ENTRY_SEPARATOR, " ") }
         }
-        try { writeRaw(sanitized) } catch (_: Exception) { }
+        try {
+            writeRaw(sanitized)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to persist skip memory", e)
+        }
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueSkipMemory.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueSkipMemory.kt
@@ -1,0 +1,118 @@
+package cx.aswin.boxcast.core.data
+
+import android.content.Context
+
+/**
+ * Lightweight local memory of auto-filled episodes the user rejected — either removed
+ * from the queue sheet or skipped within the first 30 seconds of playback.
+ *
+ * The SmartQueueEngine uses this to:
+ *  - never re-suggest a skipped episode, and
+ *  - down-rank podcasts that accumulated 2+ recent skips in fallback tiers.
+ *
+ * Entries expire after 7 days and the store is capped at 200 entries.
+ *
+ * Persistence is injected as read/write lambdas so the class is a pure JVM type
+ * (unit-testable without Android). Use [fromContext] in production code.
+ */
+class QueueSkipMemory(
+    private val readRaw: () -> String?,
+    private val writeRaw: (String) -> Unit,
+    private val nowMs: () -> Long = { System.currentTimeMillis() }
+) {
+
+    data class SkipEntry(
+        val episodeId: String,
+        val podcastId: String,
+        val source: String,
+        val timestampMs: Long
+    )
+
+    companion object {
+        const val MAX_ENTRIES = 200
+        const val EXPIRY_MS = 7L * 24 * 60 * 60 * 1000
+        const val DOWN_RANK_MIN_SKIPS = 2
+        private const val FIELD_SEPARATOR = "|"
+        private const val ENTRY_SEPARATOR = "\n"
+        private const val PREFS_NAME = "queue_skip_memory"
+        private const val KEY_ENTRIES = "entries"
+
+        fun fromContext(context: Context): QueueSkipMemory {
+            val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            return QueueSkipMemory(
+                readRaw = { prefs.getString(KEY_ENTRIES, null) },
+                writeRaw = { prefs.edit().putString(KEY_ENTRIES, it).apply() }
+            )
+        }
+    }
+
+    @Synchronized
+    fun recordSkip(episodeId: String, podcastId: String?, source: String?) {
+        if (episodeId.isBlank()) return
+        val entries = load().toMutableList()
+        entries.removeAll { it.episodeId == episodeId }
+        entries.add(
+            SkipEntry(
+                episodeId = episodeId,
+                podcastId = podcastId.orEmpty(),
+                source = source.orEmpty(),
+                timestampMs = nowMs()
+            )
+        )
+        save(pruneList(entries))
+    }
+
+    /** Episode IDs the user recently rejected — never re-suggest these. */
+    @Synchronized
+    fun skippedEpisodeIds(): Set<String> = pruneList(load()).map { it.episodeId }.toSet()
+
+    /** Podcasts with [DOWN_RANK_MIN_SKIPS]+ recent skips — de-prioritized in fallback tiers. */
+    @Synchronized
+    fun downRankedPodcastIds(): Set<String> {
+        return pruneList(load())
+            .filter { it.podcastId.isNotBlank() }
+            .groupingBy { it.podcastId }
+            .eachCount()
+            .filterValues { it >= DOWN_RANK_MIN_SKIPS }
+            .keys
+    }
+
+    /** Removes expired entries from the persisted store. */
+    @Synchronized
+    fun prune() {
+        val entries = load()
+        val pruned = pruneList(entries)
+        if (pruned.size != entries.size) save(pruned)
+    }
+
+    private fun pruneList(entries: List<SkipEntry>): List<SkipEntry> {
+        val cutoff = nowMs() - EXPIRY_MS
+        return entries
+            .filter { it.timestampMs >= cutoff }
+            .sortedBy { it.timestampMs }
+            .takeLast(MAX_ENTRIES)
+    }
+
+    private fun load(): List<SkipEntry> {
+        val raw = try { readRaw() } catch (e: Exception) { null } ?: return emptyList()
+        return raw.split(ENTRY_SEPARATOR).mapNotNull { line ->
+            val parts = line.split(FIELD_SEPARATOR)
+            if (parts.size < 4) return@mapNotNull null
+            val ts = parts[3].toLongOrNull() ?: return@mapNotNull null
+            SkipEntry(
+                episodeId = parts[0],
+                podcastId = parts[1],
+                source = parts[2],
+                timestampMs = ts
+            )
+        }
+    }
+
+    private fun save(entries: List<SkipEntry>) {
+        val sanitized = entries.joinToString(ENTRY_SEPARATOR) { entry ->
+            listOf(entry.episodeId, entry.podcastId, entry.source, entry.timestampMs.toString())
+                .joinToString(FIELD_SEPARATOR) { it.replace(FIELD_SEPARATOR, "_").replace(ENTRY_SEPARATOR, " ") }
+        }
+        try { writeRaw(sanitized) } catch (_: Exception) { }
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
@@ -3,6 +3,7 @@ package cx.aswin.boxcast.core.data
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.network.model.EpisodeItem
+import cx.aswin.boxcast.core.network.model.HistoryItem
 
 /**
  * Represents an episode in the queue along with its podcast context.
@@ -20,8 +21,33 @@ interface SmartQueueEngine {
         const val SOURCE_SAME_PODCAST = "same_podcast"
         const val SOURCE_RESUME = "resume"
         const val SOURCE_SUBSCRIPTION = "subscription"
+        /** Legacy persisted rows; new refills use [SOURCE_PERSONALIZED_REC] or [SOURCE_SIMILAR_EPISODE]. */
         const val SOURCE_SERVER_REC = "server_rec"
+        const val SOURCE_PERSONALIZED_REC = "personalized_rec"
+        const val SOURCE_SIMILAR_EPISODE = "similar_episode"
+        /** Tier 3.5: similar to a recently liked episode (distinct label from [SOURCE_SIMILAR_EPISODE]). */
+        const val SOURCE_SIMILAR_LIKED = "similar_liked"
         const val SOURCE_TRENDING = "trending"
+
+        /**
+         * AUTO_FILL sources where the user got a single cross-show suggestion, not an
+         * intentional binge. Refills anchored on these skip Tier 0 deep continuation.
+         */
+        val DISCOVERY_REFILL_SOURCES: Set<String> = setOf(
+            SOURCE_RESUME,
+            SOURCE_SUBSCRIPTION,
+            SOURCE_SERVER_REC,
+            SOURCE_PERSONALIZED_REC,
+            SOURCE_SIMILAR_EPISODE,
+            SOURCE_SIMILAR_LIKED,
+            SOURCE_TRENDING
+        )
+
+        /** True when Tier 0 may queue a deep run of same-show episodes after [contextSourceId]. */
+        fun allowsSamePodcastContinuation(contextSourceId: String?): Boolean =
+            contextSourceId == null ||
+                contextSourceId == SOURCE_SAME_PODCAST ||
+                contextSourceId !in DISCOVERY_REFILL_SOURCES
     }
 
     /**
@@ -29,12 +55,17 @@ interface SmartQueueEngine {
      *
      * @param excludeEpisodeIds episode IDs already in the live player queue — the engine
      *   never suggests these (on top of completed episodes and skip-memory rejections).
+     * @param currentContextSourceId provenance of the episode currently playing (from the
+     *   queue row's contextSourceId). When the user landed via a discovery refill
+     *   (resume, rec, similar, trending, etc.), Tier 0 same-show continuation is skipped
+     *   so the queue does not backfill an entire archive after one suggested episode.
      */
     suspend fun getNextEpisodes(
         currentEpisode: EpisodeItem,
         podcast: Podcast?,
         preferredSort: String? = null,
-        excludeEpisodeIds: Set<String> = emptySet()
+        excludeEpisodeIds: Set<String> = emptySet(),
+        currentContextSourceId: String? = null
     ): List<QueueEntry>
 }
 
@@ -42,12 +73,16 @@ interface SmartQueueEngine {
  * Tiered, offline-first queue refill engine.
  *
  * Tier 0 — same-podcast continuation (respects preferredSort + serial/episodic type,
- *          skips completed episodes and trailers).
+ *          skips completed episodes and trailers). Skipped when the currently playing
+ *          episode arrived via a discovery refill (resume/rec/similar/trending/etc.).
  * Tier 1 — resume one in-progress episode (10-90% progress, played in the last 30 days).
  * Tier 2 — subscriptions ranked by [PodcastScoring] (newest unplayed, round-robin).
- * Tier 3 — server /recommendations (history + interests + region), only when local
- *          tiers are thin; failures degrade silently.
- * Tier 3.5 — one episode similar to the most recent liked episode (same online rules).
+ * Tier 3 — signal-aware network pick, only when local tiers are thin:
+ *          warm users (meaningful listen history) → /recommendations;
+ *          cold users with episode metadata → /episodes/similar on the current episode;
+ *          otherwise skip straight to Tier 4. Failures degrade silently.
+ * Tier 3.5 — one episode similar to the most recent liked episode, only when Tier 3
+ *          did not already use episode-similar on the current show.
  * Tier 4 — trending in the user's region + current genre, as a last resort.
  *
  * All tiers filter against the live queue, completed episodes, and [QueueSkipMemory];
@@ -85,9 +120,10 @@ class DefaultSmartQueueEngine(
         currentEpisode: EpisodeItem,
         podcast: Podcast?,
         preferredSort: String?,
-        excludeEpisodeIds: Set<String>
+        excludeEpisodeIds: Set<String>,
+        currentContextSourceId: String?
     ): List<QueueEntry> {
-        android.util.Log.d("SmartQueue", "getNextEpisodes: epId=${currentEpisode.id}, podcast=${podcast?.title}, sort=$preferredSort, exclude=${excludeEpisodeIds.size}")
+        android.util.Log.d("SmartQueue", "getNextEpisodes: epId=${currentEpisode.id}, podcast=${podcast?.title}, sort=$preferredSort, contextSource=$currentContextSourceId, exclude=${excludeEpisodeIds.size}")
         if (podcast == null) return emptyList()
 
         skipMemory?.prune()
@@ -111,7 +147,7 @@ class DefaultSmartQueueEngine(
         val batch = mutableListOf<QueueEntry>()
 
         // ── Tier 0: same-podcast continuation ─────────────────────────────
-        if (!isBriefing) {
+        if (!isBriefing && SmartQueueEngine.allowsSamePodcastContinuation(currentContextSourceId)) {
             val sameShow = sameShowContinuation(currentEpisode, effectivePodcast, preferredSort, exclude)
             batch += sameShow
             sameShow.forEach { exclude.add(it.episode.id.toString()) }
@@ -120,6 +156,8 @@ class DefaultSmartQueueEngine(
                 android.util.Log.d("SmartQueue", "Tier 0 satisfied batch with ${batch.size} same-show episodes")
                 return batch
             }
+        } else if (!isBriefing) {
+            android.util.Log.d("SmartQueue", "Tier 0 skipped — discovery landing (source=$currentContextSourceId)")
         }
 
         // ── Fallback assembly (Tiers 1-4) ──────────────────────────────────
@@ -147,15 +185,17 @@ class DefaultSmartQueueEngine(
         if (batch.size + fallback.size < MIN_ITEMS_BEFORE_NETWORK) {
             val region = sources.getRegion()
 
-            fallback += serverRecommendations(
+            val tier3 = networkTier3(
+                currentEpisode = currentEpisode,
                 currentPodcast = effectivePodcast,
                 exclude = exclude,
                 downRankedPodcasts = downRankedPodcasts,
                 region = region,
                 needed = FALLBACK_BATCH_TARGET - batch.size - fallback.size
             )
+            fallback += tier3.entries
 
-            if (batch.size + fallback.size < FALLBACK_BATCH_TARGET) {
+            if (batch.size + fallback.size < FALLBACK_BATCH_TARGET && !tier3.usedEpisodeSimilar) {
                 fallback += likedSimilarBoost(exclude, region)
             }
 
@@ -199,28 +239,56 @@ class DefaultSmartQueueEngine(
         if (allEpisodes.isEmpty()) return emptyList()
 
         val currentId = currentEpisode.id.toString()
+        // Match subscription defaults: serial → oldest, episodic → newest.
         val sort = preferredSort ?: podcast.preferredSort
+            ?: if (podcast.type == "serial") "oldest" else "newest"
         val isSerialListening = podcast.type == "serial" || sort == "oldest"
-        // News-style episodic shows jump to the freshest unplayed episode; everything
-        // else continues chronologically from the current episode.
+        // Episodic / news listening jumps forward to fresher episodes only — never
+        // rewinds into the archive when the user is already on (or past) the latest.
         val newestFirst = !isSerialListening &&
             (sort == "newest" || podcast.genre.equals("News", ignoreCase = true))
 
+        val currentPublished = allEpisodes.firstOrNull { it.id == currentId }?.publishedDate
+            ?: currentEpisode.datePublished
+            ?: 0L
+
         val candidates: List<Episode> = if (newestFirst) {
-            allEpisodes.sortedByDescending { it.publishedDate }
+            allEpisodes
+                .filter { it.publishedDate > currentPublished }
+                .sortedByDescending { it.publishedDate }
         } else {
             val chronological = allEpisodes.sortedBy { it.publishedDate }
             val idx = chronological.indexOfFirst { it.id == currentId }
             if (idx == -1) emptyList() else chronological.drop(idx + 1)
         }
 
-        return candidates.asSequence()
+        android.util.Log.d(
+            "SmartQueue",
+            "Tier0 ${podcast.title}: type=${podcast.type}, sort=$sort, " +
+                "mode=${if (newestFirst) "newest-forward" else "serial-chrono"}, " +
+                "currentId=$currentId, currentPub=$currentPublished, " +
+                "feedSize=${allEpisodes.size}, rawCandidates=${candidates.size}"
+        )
+
+        val picks = candidates.asSequence()
             .filter { it.id != currentId && it.id !in exclude }
             .filter { it.episodeType != "trailer" }
             .filter { it.audioUrl.isNotBlank() }
             .take(SAME_PODCAST_BATCH_LIMIT)
             .map { it.toQueueEntry(podcast, SmartQueueEngine.SOURCE_SAME_PODCAST) }
             .toList()
+
+        if (picks.isNotEmpty()) {
+            android.util.Log.d(
+                "SmartQueue",
+                "Tier0 picks: ${picks.take(5).joinToString { "${it.episode.id}(pub=${allEpisodes.firstOrNull { e -> e.id == it.episode.id.toString() }?.publishedDate})" }}" +
+                    if (picks.size > 5) " +${picks.size - 5} more" else ""
+            )
+        } else {
+            android.util.Log.d("SmartQueue", "Tier0 empty — ${if (newestFirst) "no newer episodes after current" else "show exhausted or all filtered"}")
+        }
+
+        return picks
     }
 
     // ── Tier 1 ─────────────────────────────────────────────────────────────
@@ -328,16 +396,59 @@ class DefaultSmartQueueEngine(
 
     // ── Tier 3 ─────────────────────────────────────────────────────────────
 
-    private suspend fun serverRecommendations(
+    private data class Tier3Result(
+        val entries: List<QueueEntry>,
+        val usedEpisodeSimilar: Boolean
+    )
+
+    private suspend fun networkTier3(
+        currentEpisode: EpisodeItem,
         currentPodcast: Podcast,
         exclude: MutableSet<String>,
         downRankedPodcasts: Set<String>,
         region: String,
         needed: Int
+    ): Tier3Result {
+        if (needed <= 0) return Tier3Result(emptyList(), usedEpisodeSimilar = false)
+
+        val history = runCatching { sources.getHistoryForRecommendations(15) }.getOrDefault(emptyList())
+        val picks = if (history.isNotEmpty()) {
+            personalizedRecommendations(
+                currentPodcast = currentPodcast,
+                exclude = exclude,
+                downRankedPodcasts = downRankedPodcasts,
+                region = region,
+                history = history,
+                needed = needed
+            )
+        } else if (hasSimilarMetadata(currentEpisode, currentPodcast)) {
+            similarToEpisode(
+                currentEpisode = currentEpisode,
+                currentPodcast = currentPodcast,
+                exclude = exclude,
+                downRankedPodcasts = downRankedPodcasts,
+                region = region,
+                needed = needed
+            )
+        } else {
+            emptyList()
+        }
+
+        return Tier3Result(
+            entries = picks,
+            usedEpisodeSimilar = history.isEmpty() && picks.isNotEmpty()
+        )
+    }
+
+    private suspend fun personalizedRecommendations(
+        currentPodcast: Podcast,
+        exclude: MutableSet<String>,
+        downRankedPodcasts: Set<String>,
+        region: String,
+        history: List<HistoryItem>,
+        needed: Int
     ): List<QueueEntry> {
-        if (needed <= 0) return emptyList()
         val recs = runCatching {
-            val history = sources.getHistoryForRecommendations(15)
             val interests = sources.getInterests()
             val subs = sources.getSubscribedPodcasts()
             sources.getPersonalizedRecommendations(
@@ -351,17 +462,69 @@ class DefaultSmartQueueEngine(
             )
         }.getOrDefault(emptyList())
 
-        val picks = recs.asSequence()
+        return networkEpisodePicks(
+            episodes = recs,
+            currentPodcast = currentPodcast,
+            exclude = exclude,
+            downRankedPodcasts = downRankedPodcasts,
+            needed = needed,
+            source = SmartQueueEngine.SOURCE_PERSONALIZED_REC
+        )
+    }
+
+    private suspend fun similarToEpisode(
+        currentEpisode: EpisodeItem,
+        currentPodcast: Podcast,
+        exclude: MutableSet<String>,
+        downRankedPodcasts: Set<String>,
+        region: String,
+        needed: Int
+    ): List<QueueEntry> {
+        val similar = runCatching {
+            sources.getSimilarEpisodes(
+                episodeId = currentEpisode.id.toString(),
+                podcastId = currentPodcast.id,
+                title = currentEpisode.title.orEmpty(),
+                description = currentEpisode.description.orEmpty(),
+                podcastTitle = currentPodcast.title,
+                country = region
+            )
+        }.getOrDefault(emptyList())
+
+        return networkEpisodePicks(
+            episodes = similar,
+            currentPodcast = currentPodcast,
+            exclude = exclude,
+            downRankedPodcasts = downRankedPodcasts,
+            needed = needed,
+            source = SmartQueueEngine.SOURCE_SIMILAR_EPISODE
+        )
+    }
+
+    private fun networkEpisodePicks(
+        episodes: List<Episode>,
+        currentPodcast: Podcast,
+        exclude: MutableSet<String>,
+        downRankedPodcasts: Set<String>,
+        needed: Int,
+        source: String
+    ): List<QueueEntry> {
+        val picks = episodes.asSequence()
             .filter { it.id !in exclude && it.id.toLongOrNull() != null }
             .filter { it.episodeType != "trailer" && it.audioUrl.isNotBlank() }
             .filter { it.podcastId != currentPodcast.id }
             .sortedBy { (it.podcastId ?: "") in downRankedPodcasts }
             .take(needed)
-            .map { it.toQueueEntry(podcastFromEpisode(it), SmartQueueEngine.SOURCE_SERVER_REC) }
+            .map { it.toQueueEntry(podcastFromEpisode(it), source) }
             .toList()
         picks.forEach { exclude.add(it.episode.id.toString()) }
         return picks
     }
+
+    private fun hasSimilarMetadata(episode: EpisodeItem, podcast: Podcast): Boolean =
+        episode.id != 0L &&
+            podcast.id.isNotBlank() &&
+            !episode.title.isNullOrBlank()
 
     // ── Tier 3.5: liked-episode similarity boost ───────────────────────────
 
@@ -390,7 +553,7 @@ class DefaultSmartQueueEngine(
                 it.episodeType != "trailer" && it.audioUrl.isNotBlank()
         } ?: return emptyList()
         exclude.add(pick.id)
-        return listOf(pick.toQueueEntry(podcastFromEpisode(pick), SmartQueueEngine.SOURCE_SERVER_REC))
+        return listOf(pick.toQueueEntry(podcastFromEpisode(pick), SmartQueueEngine.SOURCE_SIMILAR_LIKED))
     }
 
     // ── Tier 4 ─────────────────────────────────────────────────────────────

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
@@ -114,6 +114,8 @@ class DefaultSmartQueueEngine(
         /** Bound network cost: max feed fetches while hunting for fallback episodes. */
         const val MAX_SUBSCRIPTION_FEED_FETCHES = 6
         const val MAX_TRENDING_FEED_FETCHES = 5
+
+        private const val LOG_TAG = "SmartQueue"
     }
 
     override suspend fun getNextEpisodes(
@@ -123,109 +125,120 @@ class DefaultSmartQueueEngine(
         excludeEpisodeIds: Set<String>,
         currentContextSourceId: String?
     ): List<QueueEntry> {
-        android.util.Log.d("SmartQueue", "getNextEpisodes: epId=${currentEpisode.id}, podcast=${podcast?.title}, sort=$preferredSort, contextSource=$currentContextSourceId, exclude=${excludeEpisodeIds.size}")
+        android.util.Log.d(
+            LOG_TAG,
+            "getNextEpisodes: epId=${currentEpisode.id}, podcast=${podcast?.title}, " +
+                "sort=$preferredSort, contextSource=$currentContextSourceId, exclude=${excludeEpisodeIds.size}"
+        )
         if (podcast == null) return emptyList()
 
         skipMemory?.prune()
-        val skippedEpisodes = skipMemory?.skippedEpisodeIds() ?: emptySet()
-        val downRankedPodcasts = skipMemory?.downRankedPodcastIds() ?: emptySet()
-        val completed = runCatching { sources.getCompletedEpisodeIds() }.getOrDefault(emptySet())
+        val exclude = buildExcludeSet(currentEpisode, excludeEpisodeIds)
+        val isBriefing = podcast.id.startsWith("briefing_")
+        val effectivePodcast = if (isBriefing) podcast.copy(genre = "News") else podcast
 
+        val tier0 = if (!isBriefing && SmartQueueEngine.allowsSamePodcastContinuation(currentContextSourceId)) {
+            sameShowContinuation(currentEpisode, effectivePodcast, preferredSort, exclude)
+        } else {
+            if (!isBriefing) {
+                android.util.Log.d(LOG_TAG, "Tier 0 skipped — discovery landing (source=$currentContextSourceId)")
+            }
+            emptyList()
+        }
+        tier0.forEach { exclude.add(it.episode.id.toString()) }
+        if (tier0.size >= MIN_ITEMS_BEFORE_NETWORK) {
+            android.util.Log.d(LOG_TAG, "Tier 0 satisfied batch with ${tier0.size} same-show episodes")
+            return tier0
+        }
+
+        val batch = mutableListOf<QueueEntry>()
+        batch += tier0
+        val fallback = assembleFallbackTiers(
+            currentEpisode = currentEpisode,
+            effectivePodcast = effectivePodcast,
+            exclude = exclude,
+            downRankedPodcasts = skipMemory?.downRankedPodcastIds() ?: emptySet(),
+            existingBatchSize = batch.size
+        )
+        batch += if (isBriefing) sortBriefingFallback(fallback) else fallback
+        android.util.Log.d(LOG_TAG, "Returning batch of ${batch.size}: ${batch.groupingBy { it.source }.eachCount()}")
+        return batch.distinctBy { it.episode.id }
+    }
+
+    private suspend fun buildExcludeSet(
+        currentEpisode: EpisodeItem,
+        excludeEpisodeIds: Set<String>
+    ): MutableSet<String> {
+        val skippedEpisodes = skipMemory?.skippedEpisodeIds() ?: emptySet()
+        val completed = runCatching { sources.getCompletedEpisodeIds() }.getOrDefault(emptySet())
         val currentId = currentEpisode.id.toString()
-        val exclude = HashSet<String>(excludeEpisodeIds.size + completed.size + skippedEpisodes.size + 1).apply {
+        return HashSet<String>(excludeEpisodeIds.size + completed.size + skippedEpisodes.size + 1).apply {
             addAll(excludeEpisodeIds)
             addAll(completed)
             addAll(skippedEpisodes)
             add(currentId)
         }
+    }
 
-        // Daily briefings are standalone (no feed in the podcast index): skip straight to
-        // the fallback tiers using the News genre, preferring short follow-ups.
-        val isBriefing = podcast.id.startsWith("briefing_")
-        val effectivePodcast = if (isBriefing) podcast.copy(genre = "News") else podcast
-
-        val batch = mutableListOf<QueueEntry>()
-
-        // ── Tier 0: same-podcast continuation ─────────────────────────────
-        if (!isBriefing && SmartQueueEngine.allowsSamePodcastContinuation(currentContextSourceId)) {
-            val sameShow = sameShowContinuation(currentEpisode, effectivePodcast, preferredSort, exclude)
-            batch += sameShow
-            sameShow.forEach { exclude.add(it.episode.id.toString()) }
-            if (batch.size >= MIN_ITEMS_BEFORE_NETWORK) {
-                // Binge fast path: plenty of the same show left, no fallback needed.
-                android.util.Log.d("SmartQueue", "Tier 0 satisfied batch with ${batch.size} same-show episodes")
-                return batch
-            }
-        } else if (!isBriefing) {
-            android.util.Log.d("SmartQueue", "Tier 0 skipped — discovery landing (source=$currentContextSourceId)")
-        }
-
-        // ── Fallback assembly (Tiers 1-4) ──────────────────────────────────
+    private suspend fun assembleFallbackTiers(
+        currentEpisode: EpisodeItem,
+        effectivePodcast: Podcast,
+        exclude: MutableSet<String>,
+        downRankedPodcasts: Set<String>,
+        existingBatchSize: Int
+    ): List<QueueEntry> {
         val recentPodcasts = runCatching {
             sources.getRecentlyPlayedPodcastIds(nowMs() - RECENT_PODCAST_WINDOW_MS)
         }.getOrDefault(emptySet())
 
         val fallback = mutableListOf<QueueEntry>()
-
-        // Tier 1: resume nudge
         fallback += resumeCandidates(effectivePodcast, exclude)
 
-        // Tier 2: scored subscriptions
-        if (batch.size + fallback.size < FALLBACK_BATCH_TARGET) {
+        if (existingBatchSize + fallback.size < FALLBACK_BATCH_TARGET) {
             fallback += scoredSubscriptionEpisodes(
                 currentPodcast = effectivePodcast,
                 exclude = exclude,
                 recentPodcasts = recentPodcasts,
                 downRankedPodcasts = downRankedPodcasts,
-                needed = FALLBACK_BATCH_TARGET - batch.size - fallback.size
+                needed = FALLBACK_BATCH_TARGET - existingBatchSize - fallback.size
             )
         }
 
-        // Tiers 3/3.5/4: network, only when local tiers came up thin
-        if (batch.size + fallback.size < MIN_ITEMS_BEFORE_NETWORK) {
-            val region = sources.getRegion()
+        if (existingBatchSize + fallback.size >= MIN_ITEMS_BEFORE_NETWORK) return fallback
 
-            val tier3 = networkTier3(
-                currentEpisode = currentEpisode,
+        val region = sources.getRegion()
+        val tier3 = networkTier3(
+            currentEpisode = currentEpisode,
+            currentPodcast = effectivePodcast,
+            exclude = exclude,
+            downRankedPodcasts = downRankedPodcasts,
+            region = region,
+            needed = FALLBACK_BATCH_TARGET - existingBatchSize - fallback.size
+        )
+        fallback += tier3.entries
+
+        if (existingBatchSize + fallback.size < FALLBACK_BATCH_TARGET && !tier3.usedEpisodeSimilar) {
+            fallback += likedSimilarBoost(exclude, region)
+        }
+
+        if (existingBatchSize + fallback.size < MIN_ITEMS_BEFORE_NETWORK) {
+            fallback += trendingEpisodes(
                 currentPodcast = effectivePodcast,
                 exclude = exclude,
+                recentPodcasts = recentPodcasts,
                 downRankedPodcasts = downRankedPodcasts,
                 region = region,
-                needed = FALLBACK_BATCH_TARGET - batch.size - fallback.size
+                needed = FALLBACK_BATCH_TARGET - existingBatchSize - fallback.size
             )
-            fallback += tier3.entries
-
-            if (batch.size + fallback.size < FALLBACK_BATCH_TARGET && !tier3.usedEpisodeSimilar) {
-                fallback += likedSimilarBoost(exclude, region)
-            }
-
-            if (batch.size + fallback.size < MIN_ITEMS_BEFORE_NETWORK) {
-                fallback += trendingEpisodes(
-                    currentPodcast = effectivePodcast,
-                    exclude = exclude,
-                    recentPodcasts = recentPodcasts,
-                    downRankedPodcasts = downRankedPodcasts,
-                    region = region,
-                    needed = FALLBACK_BATCH_TARGET - batch.size - fallback.size
-                )
-            }
         }
-
-        // Briefing follow-ups: soft preference for short episodes (stable sort keeps
-        // relative tier ordering within each duration bucket).
-        val orderedFallback = if (isBriefing) {
-            fallback.sortedBy { entry ->
-                val duration = entry.episode.duration ?: 0
-                if (duration in 1..SHORT_EPISODE_MAX_SECONDS) 0 else 1
-            }
-        } else {
-            fallback
-        }
-
-        batch += orderedFallback
-        android.util.Log.d("SmartQueue", "Returning batch of ${batch.size}: ${batch.groupingBy { it.source }.eachCount()}")
-        return batch.distinctBy { it.episode.id }
+        return fallback
     }
+
+    private fun sortBriefingFallback(fallback: List<QueueEntry>): List<QueueEntry> =
+        fallback.sortedBy { entry ->
+            val duration = entry.episode.duration ?: 0
+            if (duration in 1..SHORT_EPISODE_MAX_SECONDS) 0 else 1
+        }
 
     // ── Tier 0 ─────────────────────────────────────────────────────────────
 
@@ -239,35 +252,21 @@ class DefaultSmartQueueEngine(
         if (allEpisodes.isEmpty()) return emptyList()
 
         val currentId = currentEpisode.id.toString()
-        // Match subscription defaults: serial → oldest, episodic → newest.
-        val sort = preferredSort ?: podcast.preferredSort
-            ?: if (podcast.type == "serial") "oldest" else "newest"
+        val sort = effectiveContinuationSort(preferredSort, podcast)
         val isSerialListening = podcast.type == "serial" || sort == "oldest"
-        // Episodic / news listening jumps forward to fresher episodes only — never
-        // rewinds into the archive when the user is already on (or past) the latest.
         val newestFirst = !isSerialListening &&
             (sort == "newest" || podcast.genre.equals("News", ignoreCase = true))
+        val currentPublished = continuationAnchorDate(allEpisodes, currentId, currentEpisode)
+        val candidates = continuationCandidates(allEpisodes, currentId, currentPublished, newestFirst)
 
-        val currentPublished = allEpisodes.firstOrNull { it.id == currentId }?.publishedDate
-            ?: currentEpisode.datePublished
-            ?: 0L
-
-        val candidates: List<Episode> = if (newestFirst) {
-            allEpisodes
-                .filter { it.publishedDate > currentPublished }
-                .sortedByDescending { it.publishedDate }
-        } else {
-            val chronological = allEpisodes.sortedBy { it.publishedDate }
-            val idx = chronological.indexOfFirst { it.id == currentId }
-            if (idx == -1) emptyList() else chronological.drop(idx + 1)
-        }
-
-        android.util.Log.d(
-            "SmartQueue",
-            "Tier0 ${podcast.title}: type=${podcast.type}, sort=$sort, " +
-                "mode=${if (newestFirst) "newest-forward" else "serial-chrono"}, " +
-                "currentId=$currentId, currentPub=$currentPublished, " +
-                "feedSize=${allEpisodes.size}, rawCandidates=${candidates.size}"
+        logTier0Summary(
+            podcast = podcast,
+            sort = sort,
+            newestFirst = newestFirst,
+            currentId = currentId,
+            currentPublished = currentPublished,
+            feedSize = allEpisodes.size,
+            candidateCount = candidates.size
         )
 
         val picks = candidates.asSequence()
@@ -278,17 +277,72 @@ class DefaultSmartQueueEngine(
             .map { it.toQueueEntry(podcast, SmartQueueEngine.SOURCE_SAME_PODCAST) }
             .toList()
 
+        logTier0Picks(picks, newestFirst)
+        return picks
+    }
+
+    private fun effectiveContinuationSort(preferredSort: String?, podcast: Podcast): String {
+        preferredSort?.takeIf { it.isNotBlank() }?.let { return it }
+        podcast.preferredSort?.takeIf { it.isNotBlank() }?.let { return it }
+        return if (podcast.type == "serial") "oldest" else "newest"
+    }
+
+    private fun continuationAnchorDate(
+        allEpisodes: List<Episode>,
+        currentId: String,
+        currentEpisode: EpisodeItem
+    ): Long = allEpisodes.firstOrNull { it.id == currentId }?.publishedDate
+        ?: currentEpisode.datePublished
+        ?: 0L
+
+    private fun continuationCandidates(
+        allEpisodes: List<Episode>,
+        currentId: String,
+        currentPublished: Long,
+        newestFirst: Boolean
+    ): List<Episode> = if (newestFirst) {
+        allEpisodes
+            .filter { it.publishedDate > currentPublished }
+            .sortedByDescending { it.publishedDate }
+    } else {
+        val chronological = allEpisodes.sortedBy { it.publishedDate }
+        val idx = chronological.indexOfFirst { it.id == currentId }
+        if (idx == -1) emptyList() else chronological.drop(idx + 1)
+    }
+
+    private fun logTier0Summary(
+        podcast: Podcast,
+        sort: String,
+        newestFirst: Boolean,
+        currentId: String,
+        currentPublished: Long,
+        feedSize: Int,
+        candidateCount: Int
+    ) {
+        if (!android.util.Log.isLoggable(LOG_TAG, android.util.Log.DEBUG)) return
+        android.util.Log.d(
+            LOG_TAG,
+            "Tier0 ${podcast.title}: type=${podcast.type}, sort=$sort, " +
+                "mode=${if (newestFirst) "newest-forward" else "serial-chrono"}, " +
+                "currentId=$currentId, currentPub=$currentPublished, " +
+                "feedSize=$feedSize, rawCandidates=$candidateCount"
+        )
+    }
+
+    private fun logTier0Picks(picks: List<QueueEntry>, newestFirst: Boolean) {
+        if (!android.util.Log.isLoggable(LOG_TAG, android.util.Log.DEBUG)) return
         if (picks.isNotEmpty()) {
             android.util.Log.d(
-                "SmartQueue",
-                "Tier0 picks: ${picks.take(5).joinToString { "${it.episode.id}(pub=${allEpisodes.firstOrNull { e -> e.id == it.episode.id.toString() }?.publishedDate})" }}" +
+                LOG_TAG,
+                "Tier0 picks: ${picks.take(5).joinToString { it.episode.id.toString() }}" +
                     if (picks.size > 5) " +${picks.size - 5} more" else ""
             )
         } else {
-            android.util.Log.d("SmartQueue", "Tier0 empty — ${if (newestFirst) "no newer episodes after current" else "show exhausted or all filtered"}")
+            android.util.Log.d(
+                LOG_TAG,
+                "Tier0 empty — ${if (newestFirst) "no newer episodes after current" else "show exhausted or all filtered"}"
+            )
         }
-
-        return picks
     }
 
     // ── Tier 1 ─────────────────────────────────────────────────────────────

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
@@ -4,6 +4,16 @@ import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.network.model.EpisodeItem
 import cx.aswin.boxcast.core.network.model.HistoryItem
+import kotlinx.coroutines.CancellationException
+
+private suspend inline fun <T> runSuspendCatching(crossinline block: suspend () -> T): Result<T> =
+    try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.failure(e)
+    }
 
 /**
  * Represents an episode in the queue along with its podcast context.
@@ -170,7 +180,7 @@ class DefaultSmartQueueEngine(
         excludeEpisodeIds: Set<String>
     ): MutableSet<String> {
         val skippedEpisodes = skipMemory?.skippedEpisodeIds() ?: emptySet()
-        val completed = runCatching { sources.getCompletedEpisodeIds() }.getOrDefault(emptySet())
+        val completed = runSuspendCatching { sources.getCompletedEpisodeIds() }.getOrDefault(emptySet())
         val currentId = currentEpisode.id.toString()
         return HashSet<String>(excludeEpisodeIds.size + completed.size + skippedEpisodes.size + 1).apply {
             addAll(excludeEpisodeIds)
@@ -187,7 +197,7 @@ class DefaultSmartQueueEngine(
         downRankedPodcasts: Set<String>,
         existingBatchSize: Int
     ): List<QueueEntry> {
-        val recentPodcasts = runCatching {
+        val recentPodcasts = runSuspendCatching {
             sources.getRecentlyPlayedPodcastIds(nowMs() - RECENT_PODCAST_WINDOW_MS)
         }.getOrDefault(emptySet())
 
@@ -248,7 +258,7 @@ class DefaultSmartQueueEngine(
         preferredSort: String?,
         exclude: Set<String>
     ): List<QueueEntry> {
-        val allEpisodes = runCatching { sources.getEpisodes(podcast.id) }.getOrDefault(emptyList())
+        val allEpisodes = runSuspendCatching { sources.getEpisodes(podcast.id) }.getOrDefault(emptyList())
         if (allEpisodes.isEmpty()) return emptyList()
 
         val currentId = currentEpisode.id.toString()
@@ -352,7 +362,7 @@ class DefaultSmartQueueEngine(
         exclude: MutableSet<String>
     ): List<QueueEntry> {
         val cutoff = nowMs() - RESUME_WINDOW_MS
-        val picks = runCatching { sources.getResumeCandidates() }.getOrDefault(emptyList())
+        val picks = runSuspendCatching { sources.getResumeCandidates() }.getOrDefault(emptyList())
             .asSequence()
             .filter { it.episodeId !in exclude }
             .filter { it.podcastId != currentPodcast.id }
@@ -398,10 +408,10 @@ class DefaultSmartQueueEngine(
         needed: Int
     ): List<QueueEntry> {
         if (needed <= 0) return emptyList()
-        val subs = runCatching { sources.getSubscribedPodcasts() }.getOrDefault(emptyList())
+        val subs = runSuspendCatching { sources.getSubscribedPodcasts() }.getOrDefault(emptyList())
         if (subs.isEmpty()) return emptyList()
 
-        val history = runCatching { sources.getRecentHistory(300) }.getOrDefault(emptyList())
+        val history = runSuspendCatching { sources.getRecentHistory(300) }.getOrDefault(emptyList())
         val scores = PodcastScoring.calculateScores(subs.map { it.toScorable() }, history)
 
         val ranked = subs.asSequence()
@@ -434,7 +444,7 @@ class DefaultSmartQueueEngine(
 
             if (feedFetches >= MAX_SUBSCRIPTION_FEED_FETCHES) continue
             feedFetches++
-            val next = runCatching { sources.getEpisodes(sub.id) }.getOrDefault(emptyList())
+            val next = runSuspendCatching { sources.getEpisodes(sub.id) }.getOrDefault(emptyList())
                 .sortedByDescending { it.publishedDate }
                 .firstOrNull {
                     it.id !in exclude && it.episodeType != "trailer" &&
@@ -465,7 +475,7 @@ class DefaultSmartQueueEngine(
     ): Tier3Result {
         if (needed <= 0) return Tier3Result(emptyList(), usedEpisodeSimilar = false)
 
-        val history = runCatching { sources.getHistoryForRecommendations(15) }.getOrDefault(emptyList())
+        val history = runSuspendCatching { sources.getHistoryForRecommendations(15) }.getOrDefault(emptyList())
         val picks = if (history.isNotEmpty()) {
             personalizedRecommendations(
                 currentPodcast = currentPodcast,
@@ -502,7 +512,7 @@ class DefaultSmartQueueEngine(
         history: List<HistoryItem>,
         needed: Int
     ): List<QueueEntry> {
-        val recs = runCatching {
+        val recs = runSuspendCatching {
             val interests = sources.getInterests()
             val subs = sources.getSubscribedPodcasts()
             sources.getPersonalizedRecommendations(
@@ -534,7 +544,7 @@ class DefaultSmartQueueEngine(
         region: String,
         needed: Int
     ): List<QueueEntry> {
-        val similar = runCatching {
+        val similar = runSuspendCatching {
             sources.getSimilarEpisodes(
                 episodeId = currentEpisode.id.toString(),
                 podcastId = currentPodcast.id,
@@ -586,12 +596,12 @@ class DefaultSmartQueueEngine(
         exclude: MutableSet<String>,
         region: String
     ): List<QueueEntry> {
-        val recentLike = runCatching { sources.getRecentHistory(100) }.getOrDefault(emptyList())
+        val recentLike = runSuspendCatching { sources.getRecentHistory(100) }.getOrDefault(emptyList())
             .filter { it.isLiked }
             .maxByOrNull { it.lastPlayedAt }
             ?: return emptyList()
 
-        val similar = runCatching {
+        val similar = runSuspendCatching {
             sources.getSimilarEpisodes(
                 episodeId = recentLike.episodeId,
                 podcastId = recentLike.podcastId,
@@ -623,7 +633,7 @@ class DefaultSmartQueueEngine(
         if (needed <= 0) return emptyList()
 
         val genre = resolveGenre(currentPodcast)
-        val trending = runCatching { sources.getTrendingPodcasts(region, genre) }.getOrDefault(emptyList())
+        val trending = runSuspendCatching { sources.getTrendingPodcasts(region, genre) }.getOrDefault(emptyList())
         if (trending.isEmpty()) return emptyList()
 
         val recentTrimmed = recentPodcasts.map { it.trim() }.toSet()
@@ -638,7 +648,7 @@ class DefaultSmartQueueEngine(
             if (pod.id.trim() in recentTrimmed) continue
 
             feedFetches++
-            val next = runCatching { sources.getEpisodes(pod.id) }.getOrDefault(emptyList())
+            val next = runSuspendCatching { sources.getEpisodes(pod.id) }.getOrDefault(emptyList())
                 .sortedByDescending { it.publishedDate }
                 .firstOrNull {
                     it.id !in exclude && it.episodeType != "trailer" &&
@@ -657,7 +667,7 @@ class DefaultSmartQueueEngine(
     private suspend fun resolveGenre(currentPodcast: Podcast): String? {
         val genre = currentPodcast.genre
         if (genre.isNotBlank() && genre != "Podcast") return genre
-        return runCatching { sources.getPodcastDetails(currentPodcast.id)?.genre }.getOrNull()
+        return runSuspendCatching { sources.getPodcastDetails(currentPodcast.id)?.genre }.getOrNull()
             ?.takeIf { it.isNotBlank() && it != "Podcast" }
     }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
@@ -1,12 +1,8 @@
 package cx.aswin.boxcast.core.data
 
-import cx.aswin.boxcast.core.data.database.ListeningHistoryDao
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.network.model.EpisodeItem
-import javax.inject.Inject
-import javax.inject.Singleton
-import kotlinx.coroutines.flow.first
 
 /**
  * Represents an episode in the queue along with its podcast context.
@@ -19,194 +15,457 @@ data class QueueEntry(
 )
 
 interface SmartQueueEngine {
-    suspend fun getNextEpisodes(currentEpisode: EpisodeItem, podcast: Podcast?, preferredSort: String? = null): List<QueueEntry>
+
+    companion object {
+        const val SOURCE_SAME_PODCAST = "same_podcast"
+        const val SOURCE_RESUME = "resume"
+        const val SOURCE_SUBSCRIPTION = "subscription"
+        const val SOURCE_SERVER_REC = "server_rec"
+        const val SOURCE_TRENDING = "trending"
+    }
+
+    /**
+     * Builds a batch of queue entries to append after [currentEpisode].
+     *
+     * @param excludeEpisodeIds episode IDs already in the live player queue — the engine
+     *   never suggests these (on top of completed episodes and skip-memory rejections).
+     */
+    suspend fun getNextEpisodes(
+        currentEpisode: EpisodeItem,
+        podcast: Podcast?,
+        preferredSort: String? = null,
+        excludeEpisodeIds: Set<String> = emptySet()
+    ): List<QueueEntry>
 }
 
-@Singleton
-class DefaultSmartQueueEngine @Inject constructor(
-    private val podcastRepository: PodcastRepository,
-    private val listeningHistoryDao: ListeningHistoryDao,
-    private val subscriptionRepository: SubscriptionRepository
+/**
+ * Tiered, offline-first queue refill engine.
+ *
+ * Tier 0 — same-podcast continuation (respects preferredSort + serial/episodic type,
+ *          skips completed episodes and trailers).
+ * Tier 1 — resume one in-progress episode (10-90% progress, played in the last 30 days).
+ * Tier 2 — subscriptions ranked by [PodcastScoring] (newest unplayed, round-robin).
+ * Tier 3 — server /recommendations (history + interests + region), only when local
+ *          tiers are thin; failures degrade silently.
+ * Tier 3.5 — one episode similar to the most recent liked episode (same online rules).
+ * Tier 4 — trending in the user's region + current genre, as a last resort.
+ *
+ * All tiers filter against the live queue, completed episodes, and [QueueSkipMemory];
+ * podcasts with repeated skips are down-ranked in the fallback tiers.
+ */
+class DefaultSmartQueueEngine(
+    private val sources: SmartQueueSources,
+    private val skipMemory: QueueSkipMemory? = null,
+    private val nowMs: () -> Long = { System.currentTimeMillis() }
 ) : SmartQueueEngine {
 
-    override suspend fun getNextEpisodes(currentEpisode: EpisodeItem, podcast: Podcast?, preferredSort: String?): List<QueueEntry> {
-        android.util.Log.d("SmartQueue", "getNextEpisodes called for epId=${currentEpisode.id}, podcast=${podcast?.title}, sort=$preferredSort")
-        
-        if (podcast == null) {
-            android.util.Log.e("SmartQueue", "Podcast is null, returning empty")
-            return emptyList()
-        }
+    companion object {
+        /** Deep continuation cap when bingeing within a show. */
+        const val SAME_PODCAST_BATCH_LIMIT = 20
 
-        // Daily briefings are standalone — they have no feed in the podcast index.
-        // Skip straight to subscriptions/trending fallback, using News genre for trending.
-        if (podcast.id.startsWith("briefing_")) {
-            android.util.Log.d("SmartQueue", "Briefing detected, skipping to Smart Fallback (genre=News)")
-            return getSmartFallbackEpisodes(podcast.copy(genre = "News"))
-        }
+        /** Mixed fallback batches aim for this many items... */
+        const val FALLBACK_BATCH_TARGET = 5
 
-        // 1. Fetch all episodes for context
-        val rawEpisodes = podcastRepository.getEpisodes(podcast.id)
-        android.util.Log.d("SmartQueue", "Fetched ${rawEpisodes.size} episodes from repo")
-        
-        if (rawEpisodes.isEmpty()) {
-             android.util.Log.w("SmartQueue", "Repo returned NO episodes")
-             return emptyList()
-        }
+        /** ...and network tiers only fire when local tiers produced fewer than this. */
+        const val MIN_ITEMS_BEFORE_NETWORK = 3
 
-        // Sort Chronologically (Oldest -> Newest)
-        val allEpisodes = rawEpisodes.sortedBy { it.publishedDate }
+        /** A resume nudge, not a rerun: at most one resume item per batch. */
+        const val MAX_RESUME_PER_BATCH = 1
 
-        // 2. Find current episode index
-        val searchId = currentEpisode.id.toString()
-        val currentIndex = allEpisodes.indexOfFirst { it.id == searchId }
-        
-        android.util.Log.d("SmartQueue", "Searching for ID $searchId. Found at index: $currentIndex")
+        const val RESUME_WINDOW_MS = 30L * 24 * 60 * 60 * 1000
+        const val RECENT_PODCAST_WINDOW_MS = 12L * 60 * 60 * 1000
+        const val SHORT_EPISODE_MAX_SECONDS = 20 * 60
 
-        if (currentIndex == -1) {
-            android.util.Log.e("SmartQueue", "Current episode NOT found in list of ${allEpisodes.size}. IDs: ${allEpisodes.take(5).map { it.id }}")
-            return emptyList()
-        }
-
-        // 3. Take next episodes from the same podcast (excluding current)
-        val currentIdStr = searchId
-        val candidates = mutableListOf<Episode>()
-        val remainingCount = allEpisodes.size - (currentIndex + 1)
-        
-        android.util.Log.d("SmartQueue", "Current=$currentIndex, Total=${allEpisodes.size}, Remaining=$remainingCount")
-
-        if (remainingCount > 0) {
-            val limit = minOf(remainingCount, 20)
-            for (i in 1..limit) {
-                val candidate = allEpisodes[currentIndex + i]
-                // Skip duplicates (by ID only — title dedup is too fragile)
-                if (candidate.id == currentIdStr) {
-                    android.util.Log.d("SmartQueue", "Skipping duplicate: '${candidate.title}' (id=${candidate.id})")
-                    continue
-                }
-                // Skip trailers — don't auto-suggest promotional content
-                if (candidate.episodeType == "trailer") {
-                    android.util.Log.d("SmartQueue", "Skipping trailer: '${candidate.title}' (id=${candidate.id})")
-                    continue
-                }
-                candidates.add(candidate)
-            }
-        }
-        
-        // If no valid candidates remain (all were trailers or end of podcast), use fallback
-        if (candidates.isEmpty()) {
-            android.util.Log.d("SmartQueue", "No non-trailer candidates remain. Triggering Smart Fallback")
-            val fallbackEpisodes = getSmartFallbackEpisodes(podcast)
-            android.util.Log.d("SmartQueue", "Fallback returned ${fallbackEpisodes.size} episodes")
-            return fallbackEpisodes
-        }
-        
-        android.util.Log.d("SmartQueue", "Returning ${candidates.size} candidates from same podcast (trailers excluded)")
-
-        return candidates.map { domainEp ->
-            val episodeItem = EpisodeItem(
-                id = domainEp.id.toLongOrNull() ?: 0L,
-                title = domainEp.title,
-                description = domainEp.description,
-                enclosureUrl = domainEp.audioUrl,
-                duration = domainEp.duration.toInt(),
-                datePublished = domainEp.publishedDate,
-                image = domainEp.imageUrl,
-                feedImage = domainEp.podcastImageUrl,
-                episodeType = domainEp.episodeType
-            )
-            QueueEntry(episode = episodeItem, podcast = podcast, source = "same_podcast")
-        }
+        /** Bound network cost: max feed fetches while hunting for fallback episodes. */
+        const val MAX_SUBSCRIPTION_FEED_FETCHES = 6
+        const val MAX_TRENDING_FEED_FETCHES = 5
     }
 
-    /**
-     * Smart Fallback: When the current podcast has no more episodes.
-     * Priority:
-     * 1. User's subscriptions (ANY sub with unplayed episodes, no genre matching)
-     * 2. Trending podcasts in the same genre -> latest episode
-     * Returns QueueEntry with the CORRECT podcast for each episode.
-     */
-    private suspend fun getSmartFallbackEpisodes(currentPodcast: Podcast): List<QueueEntry> {
-        val completedEpisodeIds = listeningHistoryDao.getCompletedEpisodeIds().toSet()
-        
-        // Loop prevention: exclude recently played podcasts (12h)
-        val limitTimestamp = System.currentTimeMillis() - (12 * 60 * 60 * 1000)
-        val recentPodcasts = listeningHistoryDao.getRecentlyPlayedPodcasts(limitTimestamp).toSet()
-        
-        android.util.Log.d("SmartQueue", "Fallback: ${completedEpisodeIds.size} completed, ${recentPodcasts.size} recently played")
+    override suspend fun getNextEpisodes(
+        currentEpisode: EpisodeItem,
+        podcast: Podcast?,
+        preferredSort: String?,
+        excludeEpisodeIds: Set<String>
+    ): List<QueueEntry> {
+        android.util.Log.d("SmartQueue", "getNextEpisodes: epId=${currentEpisode.id}, podcast=${podcast?.title}, sort=$preferredSort, exclude=${excludeEpisodeIds.size}")
+        if (podcast == null) return emptyList()
 
-        // --- Priority 1: Any subscription with unplayed episodes (NO genre matching) ---
-        val subscribedPodcasts = subscriptionRepository.subscribedPodcasts.first()
-        
-        val eligibleSubs = subscribedPodcasts.filter { sub ->
-            sub.id != currentPodcast.id && 
-            !sub.title.equals(currentPodcast.title, ignoreCase = true) &&
-            !recentPodcasts.contains(sub.id)
-        }.shuffled() // Rotate which subscription gets priority
-        android.util.Log.d("SmartQueue", "Fallback: ${eligibleSubs.size} eligible subscriptions (shuffled, no genre filter)")
+        skipMemory?.prune()
+        val skippedEpisodes = skipMemory?.skippedEpisodeIds() ?: emptySet()
+        val downRankedPodcasts = skipMemory?.downRankedPodcastIds() ?: emptySet()
+        val completed = runCatching { sources.getCompletedEpisodeIds() }.getOrDefault(emptySet())
 
-        for (sub in eligibleSubs) {
-            val subEpisodes = podcastRepository.getEpisodes(sub.id)
-                .sortedByDescending { it.publishedDate }
-                .filter { it.id !in completedEpisodeIds && it.episodeType != "trailer" }
-            
-            if (subEpisodes.isNotEmpty()) {
-                android.util.Log.d("SmartQueue", "Fallback: Found unplayed episode in '${sub.title}'")
-                val nextEp = subEpisodes.first()
-                return listOf(nextEp.toQueueEntry(sub, "subscription"))
+        val currentId = currentEpisode.id.toString()
+        val exclude = HashSet<String>(excludeEpisodeIds.size + completed.size + skippedEpisodes.size + 1).apply {
+            addAll(excludeEpisodeIds)
+            addAll(completed)
+            addAll(skippedEpisodes)
+            add(currentId)
+        }
+
+        // Daily briefings are standalone (no feed in the podcast index): skip straight to
+        // the fallback tiers using the News genre, preferring short follow-ups.
+        val isBriefing = podcast.id.startsWith("briefing_")
+        val effectivePodcast = if (isBriefing) podcast.copy(genre = "News") else podcast
+
+        val batch = mutableListOf<QueueEntry>()
+
+        // ── Tier 0: same-podcast continuation ─────────────────────────────
+        if (!isBriefing) {
+            val sameShow = sameShowContinuation(currentEpisode, effectivePodcast, preferredSort, exclude)
+            batch += sameShow
+            sameShow.forEach { exclude.add(it.episode.id.toString()) }
+            if (batch.size >= MIN_ITEMS_BEFORE_NETWORK) {
+                // Binge fast path: plenty of the same show left, no fallback needed.
+                android.util.Log.d("SmartQueue", "Tier 0 satisfied batch with ${batch.size} same-show episodes")
+                return batch
             }
         }
 
-        // --- Priority 2: Trending (genre-matched, last resort) ---
-        // Fetch full podcast for accurate genre
-        val fullPodcast = try {
-            val cached = subscribedPodcasts.find { it.id == currentPodcast.id }
-            if (cached != null && !cached.genre.isNullOrEmpty()) cached
-            else podcastRepository.getPodcastDetails(currentPodcast.id) ?: currentPodcast
-        } catch (e: Exception) { currentPodcast }
-        
-        val currentGenre = fullPodcast.genre
-        android.util.Log.d("SmartQueue", "Fallback: Trying Trending for genre='$currentGenre'")
-        
-        val trendingPodcasts = podcastRepository.getTrendingPodcasts(category = currentGenre)
+        // ── Fallback assembly (Tiers 1-4) ──────────────────────────────────
+        val recentPodcasts = runCatching {
+            sources.getRecentlyPlayedPodcastIds(nowMs() - RECENT_PODCAST_WINDOW_MS)
+        }.getOrDefault(emptySet())
 
-        for (trendingPod in trendingPodcasts) {
-            if (trendingPod.id == currentPodcast.id) continue
-            if (trendingPod.title.equals(currentPodcast.title, ignoreCase = true)) continue
-            
-            val cleanId = trendingPod.id.trim()
-            if (recentPodcasts.any { it.trim() == cleanId }) {
-                android.util.Log.d("SmartQueue", "Fallback: Skipping trending '${trendingPod.title}' (recently played)")
+        val fallback = mutableListOf<QueueEntry>()
+
+        // Tier 1: resume nudge
+        fallback += resumeCandidates(effectivePodcast, exclude)
+
+        // Tier 2: scored subscriptions
+        if (batch.size + fallback.size < FALLBACK_BATCH_TARGET) {
+            fallback += scoredSubscriptionEpisodes(
+                currentPodcast = effectivePodcast,
+                exclude = exclude,
+                recentPodcasts = recentPodcasts,
+                downRankedPodcasts = downRankedPodcasts,
+                needed = FALLBACK_BATCH_TARGET - batch.size - fallback.size
+            )
+        }
+
+        // Tiers 3/3.5/4: network, only when local tiers came up thin
+        if (batch.size + fallback.size < MIN_ITEMS_BEFORE_NETWORK) {
+            val region = sources.getRegion()
+
+            fallback += serverRecommendations(
+                currentPodcast = effectivePodcast,
+                exclude = exclude,
+                downRankedPodcasts = downRankedPodcasts,
+                region = region,
+                needed = FALLBACK_BATCH_TARGET - batch.size - fallback.size
+            )
+
+            if (batch.size + fallback.size < FALLBACK_BATCH_TARGET) {
+                fallback += likedSimilarBoost(exclude, region)
+            }
+
+            if (batch.size + fallback.size < MIN_ITEMS_BEFORE_NETWORK) {
+                fallback += trendingEpisodes(
+                    currentPodcast = effectivePodcast,
+                    exclude = exclude,
+                    recentPodcasts = recentPodcasts,
+                    downRankedPodcasts = downRankedPodcasts,
+                    region = region,
+                    needed = FALLBACK_BATCH_TARGET - batch.size - fallback.size
+                )
+            }
+        }
+
+        // Briefing follow-ups: soft preference for short episodes (stable sort keeps
+        // relative tier ordering within each duration bucket).
+        val orderedFallback = if (isBriefing) {
+            fallback.sortedBy { entry ->
+                val duration = entry.episode.duration ?: 0
+                if (duration in 1..SHORT_EPISODE_MAX_SECONDS) 0 else 1
+            }
+        } else {
+            fallback
+        }
+
+        batch += orderedFallback
+        android.util.Log.d("SmartQueue", "Returning batch of ${batch.size}: ${batch.groupingBy { it.source }.eachCount()}")
+        return batch.distinctBy { it.episode.id }
+    }
+
+    // ── Tier 0 ─────────────────────────────────────────────────────────────
+
+    private suspend fun sameShowContinuation(
+        currentEpisode: EpisodeItem,
+        podcast: Podcast,
+        preferredSort: String?,
+        exclude: Set<String>
+    ): List<QueueEntry> {
+        val allEpisodes = runCatching { sources.getEpisodes(podcast.id) }.getOrDefault(emptyList())
+        if (allEpisodes.isEmpty()) return emptyList()
+
+        val currentId = currentEpisode.id.toString()
+        val sort = preferredSort ?: podcast.preferredSort
+        val isSerialListening = podcast.type == "serial" || sort == "oldest"
+        // News-style episodic shows jump to the freshest unplayed episode; everything
+        // else continues chronologically from the current episode.
+        val newestFirst = !isSerialListening &&
+            (sort == "newest" || podcast.genre.equals("News", ignoreCase = true))
+
+        val candidates: List<Episode> = if (newestFirst) {
+            allEpisodes.sortedByDescending { it.publishedDate }
+        } else {
+            val chronological = allEpisodes.sortedBy { it.publishedDate }
+            val idx = chronological.indexOfFirst { it.id == currentId }
+            if (idx == -1) emptyList() else chronological.drop(idx + 1)
+        }
+
+        return candidates.asSequence()
+            .filter { it.id != currentId && it.id !in exclude }
+            .filter { it.episodeType != "trailer" }
+            .filter { it.audioUrl.isNotBlank() }
+            .take(SAME_PODCAST_BATCH_LIMIT)
+            .map { it.toQueueEntry(podcast, SmartQueueEngine.SOURCE_SAME_PODCAST) }
+            .toList()
+    }
+
+    // ── Tier 1 ─────────────────────────────────────────────────────────────
+
+    private suspend fun resumeCandidates(
+        currentPodcast: Podcast,
+        exclude: MutableSet<String>
+    ): List<QueueEntry> {
+        val cutoff = nowMs() - RESUME_WINDOW_MS
+        val picks = runCatching { sources.getResumeCandidates() }.getOrDefault(emptyList())
+            .asSequence()
+            .filter { it.episodeId !in exclude }
+            .filter { it.podcastId != currentPodcast.id }
+            .filter { it.lastPlayedAt >= cutoff }
+            .filter { !it.episodeAudioUrl.isNullOrBlank() }
+            .filter {
+                val ratio = if (it.durationMs > 0) it.progressMs.toDouble() / it.durationMs else 0.0
+                ratio in 0.10..0.90
+            }
+            .take(MAX_RESUME_PER_BATCH)
+            .map { entity ->
+                val episodeItem = EpisodeItem(
+                    id = entity.episodeId.toLongOrNull() ?: 0L,
+                    title = entity.episodeTitle,
+                    description = entity.episodeDescription,
+                    enclosureUrl = entity.episodeAudioUrl,
+                    duration = (entity.durationMs / 1000L).toInt(),
+                    image = entity.episodeImageUrl,
+                    feedImage = entity.podcastImageUrl,
+                    enclosureType = entity.enclosureType
+                )
+                val pod = Podcast(
+                    id = entity.podcastId,
+                    title = entity.podcastName,
+                    artist = "",
+                    imageUrl = entity.podcastImageUrl ?: entity.episodeImageUrl ?: ""
+                )
+                QueueEntry(episodeItem, pod, SmartQueueEngine.SOURCE_RESUME)
+            }
+            .filter { it.episode.id != 0L }
+            .toList()
+        picks.forEach { exclude.add(it.episode.id.toString()) }
+        return picks
+    }
+
+    // ── Tier 2 ─────────────────────────────────────────────────────────────
+
+    private suspend fun scoredSubscriptionEpisodes(
+        currentPodcast: Podcast,
+        exclude: MutableSet<String>,
+        recentPodcasts: Set<String>,
+        downRankedPodcasts: Set<String>,
+        needed: Int
+    ): List<QueueEntry> {
+        if (needed <= 0) return emptyList()
+        val subs = runCatching { sources.getSubscribedPodcasts() }.getOrDefault(emptyList())
+        if (subs.isEmpty()) return emptyList()
+
+        val history = runCatching { sources.getRecentHistory(300) }.getOrDefault(emptyList())
+        val scores = PodcastScoring.calculateScores(subs.map { it.toScorable() }, history)
+
+        val ranked = subs.asSequence()
+            .filter { it.id != currentPodcast.id }
+            .filter { !it.title.equals(currentPodcast.title, ignoreCase = true) }
+            .filter { it.id !in recentPodcasts }
+            .sortedWith(
+                compareBy(
+                    { it.id in downRankedPodcasts }, // down-ranked shows go last
+                    { -(scores[it.id] ?: 0.0) }
+                )
+            )
+            .toList()
+
+        val results = mutableListOf<QueueEntry>()
+        var feedFetches = 0
+        // Round-robin: one episode per top-scored show for variety.
+        for (sub in ranked) {
+            if (results.size >= needed) break
+
+            // Cheap path: the cached latest episode avoids a feed fetch entirely.
+            val cached = sub.latestEpisode
+            if (cached != null && cached.id !in exclude && cached.episodeType != "trailer" &&
+                cached.audioUrl.isNotBlank() && cached.id.toLongOrNull() != null
+            ) {
+                results += cached.toQueueEntry(sub, SmartQueueEngine.SOURCE_SUBSCRIPTION)
+                exclude.add(cached.id)
                 continue
             }
-            
-            val trendingEpisodes = podcastRepository.getEpisodes(trendingPod.id)
-                .sortedByDescending { it.publishedDate }
-                .filter { it.id !in completedEpisodeIds && it.episodeType != "trailer" }
 
-            if (trendingEpisodes.isNotEmpty()) {
-                android.util.Log.d("SmartQueue", "Fallback: Found trending '${trendingPod.title}' with unplayed")
-                val nextEp = trendingEpisodes.first()
-                return listOf(nextEp.toQueueEntry(trendingPod, "trending"))
+            if (feedFetches >= MAX_SUBSCRIPTION_FEED_FETCHES) continue
+            feedFetches++
+            val next = runCatching { sources.getEpisodes(sub.id) }.getOrDefault(emptyList())
+                .sortedByDescending { it.publishedDate }
+                .firstOrNull {
+                    it.id !in exclude && it.episodeType != "trailer" &&
+                        it.audioUrl.isNotBlank() && it.id.toLongOrNull() != null
+                }
+            if (next != null) {
+                results += next.toQueueEntry(sub, SmartQueueEngine.SOURCE_SUBSCRIPTION)
+                exclude.add(next.id)
             }
         }
-
-        android.util.Log.w("SmartQueue", "Fallback: No suitable episodes found. Queue will end.")
-        return emptyList()
+        return results
     }
 
-    /**
-     * Convert Episode to QueueEntry with its associated podcast.
-     */
+    // ── Tier 3 ─────────────────────────────────────────────────────────────
+
+    private suspend fun serverRecommendations(
+        currentPodcast: Podcast,
+        exclude: MutableSet<String>,
+        downRankedPodcasts: Set<String>,
+        region: String,
+        needed: Int
+    ): List<QueueEntry> {
+        if (needed <= 0) return emptyList()
+        val recs = runCatching {
+            val history = sources.getHistoryForRecommendations(15)
+            val interests = sources.getInterests()
+            val subs = sources.getSubscribedPodcasts()
+            sources.getPersonalizedRecommendations(
+                history = history,
+                interests = interests,
+                country = region,
+                subscribedPodcastIds = subs.map { it.id },
+                subscribedGenres = subs.map { it.genre }
+                    .filter { it.isNotBlank() && it != "Podcast" }
+                    .distinct()
+            )
+        }.getOrDefault(emptyList())
+
+        val picks = recs.asSequence()
+            .filter { it.id !in exclude && it.id.toLongOrNull() != null }
+            .filter { it.episodeType != "trailer" && it.audioUrl.isNotBlank() }
+            .filter { it.podcastId != currentPodcast.id }
+            .sortedBy { (it.podcastId ?: "") in downRankedPodcasts }
+            .take(needed)
+            .map { it.toQueueEntry(podcastFromEpisode(it), SmartQueueEngine.SOURCE_SERVER_REC) }
+            .toList()
+        picks.forEach { exclude.add(it.episode.id.toString()) }
+        return picks
+    }
+
+    // ── Tier 3.5: liked-episode similarity boost ───────────────────────────
+
+    private suspend fun likedSimilarBoost(
+        exclude: MutableSet<String>,
+        region: String
+    ): List<QueueEntry> {
+        val recentLike = runCatching { sources.getRecentHistory(100) }.getOrDefault(emptyList())
+            .filter { it.isLiked }
+            .maxByOrNull { it.lastPlayedAt }
+            ?: return emptyList()
+
+        val similar = runCatching {
+            sources.getSimilarEpisodes(
+                episodeId = recentLike.episodeId,
+                podcastId = recentLike.podcastId,
+                title = recentLike.episodeTitle,
+                description = recentLike.episodeDescription ?: "",
+                podcastTitle = recentLike.podcastName,
+                country = region
+            )
+        }.getOrDefault(emptyList())
+
+        val pick = similar.firstOrNull {
+            it.id !in exclude && it.id.toLongOrNull() != null &&
+                it.episodeType != "trailer" && it.audioUrl.isNotBlank()
+        } ?: return emptyList()
+        exclude.add(pick.id)
+        return listOf(pick.toQueueEntry(podcastFromEpisode(pick), SmartQueueEngine.SOURCE_SERVER_REC))
+    }
+
+    // ── Tier 4 ─────────────────────────────────────────────────────────────
+
+    private suspend fun trendingEpisodes(
+        currentPodcast: Podcast,
+        exclude: MutableSet<String>,
+        recentPodcasts: Set<String>,
+        downRankedPodcasts: Set<String>,
+        region: String,
+        needed: Int
+    ): List<QueueEntry> {
+        if (needed <= 0) return emptyList()
+
+        val genre = resolveGenre(currentPodcast)
+        val trending = runCatching { sources.getTrendingPodcasts(region, genre) }.getOrDefault(emptyList())
+        if (trending.isEmpty()) return emptyList()
+
+        val recentTrimmed = recentPodcasts.map { it.trim() }.toSet()
+        val ordered = trending.sortedBy { it.id in downRankedPodcasts }
+
+        val results = mutableListOf<QueueEntry>()
+        var feedFetches = 0
+        for (pod in ordered) {
+            if (results.size >= needed || feedFetches >= MAX_TRENDING_FEED_FETCHES) break
+            if (pod.id == currentPodcast.id) continue
+            if (pod.title.equals(currentPodcast.title, ignoreCase = true)) continue
+            if (pod.id.trim() in recentTrimmed) continue
+
+            feedFetches++
+            val next = runCatching { sources.getEpisodes(pod.id) }.getOrDefault(emptyList())
+                .sortedByDescending { it.publishedDate }
+                .firstOrNull {
+                    it.id !in exclude && it.episodeType != "trailer" &&
+                        it.audioUrl.isNotBlank() && it.id.toLongOrNull() != null
+                }
+            if (next != null) {
+                results += next.toQueueEntry(pod, SmartQueueEngine.SOURCE_TRENDING)
+                exclude.add(next.id)
+            }
+        }
+        return results
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private suspend fun resolveGenre(currentPodcast: Podcast): String? {
+        val genre = currentPodcast.genre
+        if (genre.isNotBlank() && genre != "Podcast") return genre
+        return runCatching { sources.getPodcastDetails(currentPodcast.id)?.genre }.getOrNull()
+            ?.takeIf { it.isNotBlank() && it != "Podcast" }
+    }
+
+    private fun podcastFromEpisode(episode: Episode): Podcast = Podcast(
+        id = episode.podcastId ?: "",
+        title = episode.podcastTitle ?: "Podcast",
+        artist = episode.podcastArtist ?: "",
+        imageUrl = episode.podcastImageUrl ?: episode.imageUrl ?: "",
+        genre = episode.podcastGenre ?: "Podcast"
+    )
+
     private fun Episode.toQueueEntry(podcast: Podcast, source: String): QueueEntry {
         val episodeItem = EpisodeItem(
             id = this.id.toLongOrNull() ?: 0L,
             title = this.title,
             description = this.description,
             enclosureUrl = this.audioUrl,
-            duration = this.duration.toInt(),
+            duration = this.duration,
             datePublished = this.publishedDate,
             image = this.imageUrl,
-            feedImage = this.podcastImageUrl ?: podcast.imageUrl
+            feedImage = this.podcastImageUrl ?: podcast.imageUrl,
+            episodeType = this.episodeType,
+            enclosureType = this.enclosureType,
+            chaptersUrl = this.chaptersUrl,
+            transcriptUrl = this.transcriptUrl
         )
         return QueueEntry(episode = episodeItem, podcast = podcast, source = source)
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueSources.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueSources.kt
@@ -6,6 +6,7 @@ import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.network.model.HistoryItem
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 
 /**
@@ -83,6 +84,8 @@ class DefaultSmartQueueSources(
 
     override suspend fun getRegion(): String = try {
         userPreferencesRepository.regionStream.first()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         "us"
     }
@@ -90,6 +93,8 @@ class DefaultSmartQueueSources(
     override suspend fun getInterests(): List<String> = try {
         context.getSharedPreferences("boxcast_prefs", Context.MODE_PRIVATE)
             .getStringSet("user_genres", emptySet())?.toList() ?: emptyList()
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: Exception) {
         emptyList()
     }
@@ -101,27 +106,32 @@ class DefaultSmartQueueSources(
     override suspend fun getHistoryForRecommendations(limit: Int): List<HistoryItem> {
         val podcastDao = database.podcastDao()
         val rawHistory = database.listeningHistoryDao().getRecentHistoryList(limit * 3)
-        return rawHistory
+        val filtered = rawHistory
             .filter { entity ->
                 !entity.isManualCompletion && !entity.isBulkCompletion &&
                     (entity.progressMs >= 60_000L || entity.isCompleted)
             }
             .take(limit)
-            .map { entity ->
-                val podcast = podcastDao.getPodcast(entity.podcastId)
-                HistoryItem(
-                    podcastTitle = entity.podcastName,
-                    episodeTitle = entity.episodeTitle,
-                    podcastId = entity.podcastId,
-                    episodeId = entity.episodeId,
-                    genre = podcast?.genre,
-                    durationMs = entity.durationMs,
-                    progressMs = entity.progressMs,
-                    isCompleted = entity.isCompleted,
-                    isLiked = entity.isLiked,
-                    episodeDescription = entity.episodeDescription
-                )
-            }
+        val genreByPodcastId = if (filtered.isEmpty()) {
+            emptyMap()
+        } else {
+            podcastDao.getPodcastsByIds(filtered.map { it.podcastId }.distinct())
+                .associate { it.podcastId to it.genre }
+        }
+        return filtered.map { entity ->
+            HistoryItem(
+                podcastTitle = entity.podcastName,
+                episodeTitle = entity.episodeTitle,
+                podcastId = entity.podcastId,
+                episodeId = entity.episodeId,
+                genre = genreByPodcastId[entity.podcastId],
+                durationMs = entity.durationMs,
+                progressMs = entity.progressMs,
+                isCompleted = entity.isCompleted,
+                isLiked = entity.isLiked,
+                episodeDescription = entity.episodeDescription
+            )
+        }
     }
 
     override suspend fun getPersonalizedRecommendations(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueSources.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueSources.kt
@@ -1,0 +1,159 @@
+package cx.aswin.boxcast.core.data
+
+import android.content.Context
+import cx.aswin.boxcast.core.data.database.BoxLoreDatabase
+import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
+import cx.aswin.boxcast.core.model.Episode
+import cx.aswin.boxcast.core.model.Podcast
+import cx.aswin.boxcast.core.network.model.HistoryItem
+import kotlinx.coroutines.flow.first
+
+/**
+ * Data-access seam for [DefaultSmartQueueEngine].
+ *
+ * The engine only talks to this interface so the tier/ranking logic stays a pure
+ * JVM component that can be unit-tested with hand-rolled fakes. Production code
+ * uses [DefaultSmartQueueSources], which wraps the real repositories and DAOs.
+ */
+interface SmartQueueSources {
+    suspend fun getEpisodes(podcastId: String): List<Episode>
+    suspend fun getPodcastDetails(podcastId: String): Podcast?
+    suspend fun getSubscribedPodcasts(): List<Podcast>
+    suspend fun getCompletedEpisodeIds(): Set<String>
+    suspend fun getRecentlyPlayedPodcastIds(sinceMs: Long): Set<String>
+    suspend fun getResumeCandidates(): List<ListeningHistoryEntity>
+    suspend fun getRecentHistory(limit: Int): List<ListeningHistoryEntity>
+
+    /** Normalized user region code (e.g. "us", "in"), used for trending + recommendations. */
+    suspend fun getRegion(): String
+
+    /** Genres the user picked during onboarding. */
+    suspend fun getInterests(): List<String>
+
+    suspend fun getHistoryForRecommendations(limit: Int): List<HistoryItem>
+
+    suspend fun getPersonalizedRecommendations(
+        history: List<HistoryItem>,
+        interests: List<String>,
+        country: String?,
+        subscribedPodcastIds: List<String>,
+        subscribedGenres: List<String>
+    ): List<Episode>
+
+    suspend fun getSimilarEpisodes(
+        episodeId: String,
+        podcastId: String,
+        title: String,
+        description: String,
+        podcastTitle: String,
+        country: String?
+    ): List<Episode>
+
+    suspend fun getTrendingPodcasts(country: String, category: String?): List<Podcast>
+}
+
+class DefaultSmartQueueSources(
+    private val context: Context,
+    private val database: BoxLoreDatabase,
+    private val podcastRepository: PodcastRepository,
+    private val subscriptionRepository: SubscriptionRepository,
+    private val userPreferencesRepository: UserPreferencesRepository
+) : SmartQueueSources {
+
+    override suspend fun getEpisodes(podcastId: String): List<Episode> =
+        podcastRepository.getEpisodes(podcastId)
+
+    override suspend fun getPodcastDetails(podcastId: String): Podcast? =
+        podcastRepository.getPodcastDetails(podcastId)
+
+    override suspend fun getSubscribedPodcasts(): List<Podcast> =
+        subscriptionRepository.subscribedPodcasts.first()
+
+    override suspend fun getCompletedEpisodeIds(): Set<String> =
+        database.listeningHistoryDao().getCompletedEpisodeIds().toSet()
+
+    override suspend fun getRecentlyPlayedPodcastIds(sinceMs: Long): Set<String> =
+        database.listeningHistoryDao().getRecentlyPlayedPodcasts(sinceMs).toSet()
+
+    override suspend fun getResumeCandidates(): List<ListeningHistoryEntity> =
+        database.listeningHistoryDao().getResumeItemsList()
+
+    override suspend fun getRecentHistory(limit: Int): List<ListeningHistoryEntity> =
+        database.listeningHistoryDao().getRecentHistoryList(limit)
+
+    override suspend fun getRegion(): String = try {
+        userPreferencesRepository.regionStream.first()
+    } catch (e: Exception) {
+        "us"
+    }
+
+    override suspend fun getInterests(): List<String> = try {
+        context.getSharedPreferences("boxcast_prefs", Context.MODE_PRIVATE)
+            .getStringSet("user_genres", emptySet())?.toList() ?: emptyList()
+    } catch (e: Exception) {
+        emptyList()
+    }
+
+    /**
+     * Same shaping as PlaybackRepository.getHistoryForRecommendations: recent meaningful
+     * listens (>= 60s progress or naturally completed), excluding manual/bulk completions.
+     */
+    override suspend fun getHistoryForRecommendations(limit: Int): List<HistoryItem> {
+        val podcastDao = database.podcastDao()
+        val rawHistory = database.listeningHistoryDao().getRecentHistoryList(limit * 3)
+        return rawHistory
+            .filter { entity ->
+                !entity.isManualCompletion && !entity.isBulkCompletion &&
+                    (entity.progressMs >= 60_000L || entity.isCompleted)
+            }
+            .take(limit)
+            .map { entity ->
+                val podcast = podcastDao.getPodcast(entity.podcastId)
+                HistoryItem(
+                    podcastTitle = entity.podcastName,
+                    episodeTitle = entity.episodeTitle,
+                    podcastId = entity.podcastId,
+                    episodeId = entity.episodeId,
+                    genre = podcast?.genre,
+                    durationMs = entity.durationMs,
+                    progressMs = entity.progressMs,
+                    isCompleted = entity.isCompleted,
+                    isLiked = entity.isLiked,
+                    episodeDescription = entity.episodeDescription
+                )
+            }
+    }
+
+    override suspend fun getPersonalizedRecommendations(
+        history: List<HistoryItem>,
+        interests: List<String>,
+        country: String?,
+        subscribedPodcastIds: List<String>,
+        subscribedGenres: List<String>
+    ): List<Episode> = podcastRepository.getPersonalizedRecommendations(
+        history = history,
+        interests = interests,
+        country = country,
+        subscribedPodcastIds = subscribedPodcastIds,
+        subscribedGenres = subscribedGenres
+    )
+
+    override suspend fun getSimilarEpisodes(
+        episodeId: String,
+        podcastId: String,
+        title: String,
+        description: String,
+        podcastTitle: String,
+        country: String?
+    ): List<Episode> = podcastRepository.getSimilarEpisodes(
+        episodeId = episodeId,
+        podcastId = podcastId,
+        title = title,
+        description = description,
+        podcastTitle = podcastTitle,
+        country = country
+    )
+
+    override suspend fun getTrendingPodcasts(country: String, category: String?): List<Podcast> =
+        podcastRepository.getTrendingPodcasts(country = country, category = category)
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -1151,26 +1151,28 @@ object AnalyticsHelper {
         )
     }
 
-    fun trackSmartQueueRefilled(
-        triggeringEpisodeId: String,
-        triggeringPodcastGenre: String,
-        refilledCount: Int,
-        recommendationSources: List<String>,
-        refilledEpisodeIds: List<String>,
-        region: String? = null,
-        sourceCounts: Map<String, Int> = emptyMap(),
-        usedServerRecommendations: Boolean = false
-    ) {
+    data class SmartQueueRefillEvent(
+        val triggeringEpisodeId: String,
+        val triggeringPodcastGenre: String,
+        val refilledCount: Int,
+        val recommendationSources: List<String>,
+        val refilledEpisodeIds: List<String>,
+        val region: String? = null,
+        val sourceCounts: Map<String, Int> = emptyMap(),
+        val usedServerRecommendations: Boolean = false
+    )
+
+    fun trackSmartQueueRefilled(event: SmartQueueRefillEvent) {
         val props = mutableMapOf<String, Any>(
-            "triggering_episode_id" to triggeringEpisodeId,
-            "triggering_podcast_genre" to triggeringPodcastGenre,
-            "refilled_count" to refilledCount,
-            "recommendation_sources" to recommendationSources,
-            "refilled_episode_ids" to refilledEpisodeIds,
-            "used_server_recommendations" to usedServerRecommendations
+            "triggering_episode_id" to event.triggeringEpisodeId,
+            "triggering_podcast_genre" to event.triggeringPodcastGenre,
+            "refilled_count" to event.refilledCount,
+            "recommendation_sources" to event.recommendationSources,
+            "refilled_episode_ids" to event.refilledEpisodeIds,
+            "used_server_recommendations" to event.usedServerRecommendations
         )
-        region?.let { props["region"] = it }
-        sourceCounts.forEach { (source, count) -> props["source_count_$source"] = count }
+        event.region?.let { props["region"] = it }
+        event.sourceCounts.forEach { (source, count) -> props["source_count_$source"] = count }
         PostHog.capture(
             event = "smart_queue_refilled",
             properties = props

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -1156,16 +1156,61 @@ object AnalyticsHelper {
         triggeringPodcastGenre: String,
         refilledCount: Int,
         recommendationSources: List<String>,
-        refilledEpisodeIds: List<String>
+        refilledEpisodeIds: List<String>,
+        region: String? = null,
+        sourceCounts: Map<String, Int> = emptyMap(),
+        usedServerRecommendations: Boolean = false
     ) {
+        val props = mutableMapOf<String, Any>(
+            "triggering_episode_id" to triggeringEpisodeId,
+            "triggering_podcast_genre" to triggeringPodcastGenre,
+            "refilled_count" to refilledCount,
+            "recommendation_sources" to recommendationSources,
+            "refilled_episode_ids" to refilledEpisodeIds,
+            "used_server_recommendations" to usedServerRecommendations
+        )
+        region?.let { props["region"] = it }
+        sourceCounts.forEach { (source, count) -> props["source_count_$source"] = count }
         PostHog.capture(
             event = "smart_queue_refilled",
+            properties = props
+        )
+    }
+
+    fun trackQueueReordered(
+        episodeId: String,
+        fromPosition: Int,
+        toPosition: Int,
+        contextType: String?
+    ) {
+        PostHog.capture(
+            event = "queue_reordered",
             properties = mapOf(
-                "triggering_episode_id" to triggeringEpisodeId,
-                "triggering_podcast_genre" to triggeringPodcastGenre,
-                "refilled_count" to refilledCount,
-                "recommendation_sources" to recommendationSources,
-                "refilled_episode_ids" to refilledEpisodeIds
+                "episode_id" to episodeId,
+                "from_position" to fromPosition,
+                "to_position" to toPosition,
+                "context_type" to (contextType ?: "unknown")
+            )
+        )
+    }
+
+    fun trackLoreQueueConflictShown(episodeId: String, normalQueueSize: Int) {
+        PostHog.capture(
+            event = "lore_queue_conflict_shown",
+            properties = mapOf(
+                "episode_id" to episodeId,
+                "normal_queue_size" to normalQueueSize
+            )
+        )
+    }
+
+    /** @param result "start_lore_queue" or "cancelled" */
+    fun trackLoreQueueConflictResult(episodeId: String, result: String) {
+        PostHog.capture(
+            event = "lore_queue_conflict_result",
+            properties = mapOf(
+                "episode_id" to episodeId,
+                "result" to result
             )
         )
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/database/PodcastDao.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/database/PodcastDao.kt
@@ -21,6 +21,9 @@ interface PodcastDao {
     
     @Query("SELECT * FROM podcasts WHERE podcastId = :id")
     suspend fun getPodcast(id: String): PodcastEntity?
+
+    @Query("SELECT * FROM podcasts WHERE podcastId IN (:ids)")
+    suspend fun getPodcastsByIds(ids: List<String>): List<PodcastEntity>
     
     @Query("UPDATE podcasts SET isSubscribed = :isSubscribed WHERE podcastId = :id")
     suspend fun setSubscribed(id: String, isSubscribed: Boolean)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -847,13 +847,23 @@ class BoxLorePlaybackService : MediaLibraryService() {
             }.toSet()
         }
 
+        android.util.Log.d(
+            "AutoQueue",
+            "Refill context: podcastId=${podcast.id}, type=${podcast.type}, " +
+                "preferredSort=${podcastEntity?.preferredSort ?: podcast.preferredSort}, genre=${podcast.genre}"
+        )
+        val currentContextSourceId = database.queueDao().getQueueItemByEpisodeId(episodeId)?.contextSourceId
         val nextEntries = smartQueueEngine.getNextEpisodes(
             currentEpisode = currentEpisodeItem,
             podcast = podcast,
             preferredSort = podcastEntity?.preferredSort,
-            excludeEpisodeIds = existingIds
+            excludeEpisodeIds = existingIds,
+            currentContextSourceId = currentContextSourceId
         )
-        android.util.Log.d("AutoQueue", "SmartQueue returned ${nextEntries.size} episodes")
+        android.util.Log.d(
+            "AutoQueue",
+            "SmartQueue returned ${nextEntries.size} episodes: ${nextEntries.groupingBy { it.source }.eachCount()}"
+        )
         if (nextEntries.isEmpty()) return
 
         // Respect the queue cap when appending the batch.
@@ -930,7 +940,8 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 refilledEpisodeIds = refilledEpisodeIds,
                 region = region,
                 sourceCounts = sourceCounts,
-                usedServerRecommendations = cx.aswin.boxcast.core.data.SmartQueueEngine.SOURCE_SERVER_REC in sourceCounts
+                usedServerRecommendations = cx.aswin.boxcast.core.data.SmartQueueEngine.SOURCE_PERSONALIZED_REC in sourceCounts ||
+                    cx.aswin.boxcast.core.data.SmartQueueEngine.SOURCE_SERVER_REC in sourceCounts
             )
         }
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -933,15 +933,17 @@ class BoxLorePlaybackService : MediaLibraryService() {
             } catch (e: Exception) { null }
             val sourceCounts = recommendationSources.groupingBy { it }.eachCount()
             cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSmartQueueRefilled(
-                triggeringEpisodeId = episodeId,
-                triggeringPodcastGenre = podcast.genre ?: "Podcast",
-                refilledCount = refilledEpisodeIds.size,
-                recommendationSources = recommendationSources.distinct(),
-                refilledEpisodeIds = refilledEpisodeIds,
-                region = region,
-                sourceCounts = sourceCounts,
-                usedServerRecommendations = cx.aswin.boxcast.core.data.SmartQueueEngine.SOURCE_PERSONALIZED_REC in sourceCounts ||
-                    cx.aswin.boxcast.core.data.SmartQueueEngine.SOURCE_SERVER_REC in sourceCounts
+                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.SmartQueueRefillEvent(
+                    triggeringEpisodeId = episodeId,
+                    triggeringPodcastGenre = podcast.genre ?: "Podcast",
+                    refilledCount = refilledEpisodeIds.size,
+                    recommendationSources = recommendationSources.distinct(),
+                    refilledEpisodeIds = refilledEpisodeIds,
+                    region = region,
+                    sourceCounts = sourceCounts,
+                    usedServerRecommendations = cx.aswin.boxcast.core.data.SmartQueueEngine.SOURCE_PERSONALIZED_REC in sourceCounts ||
+                        cx.aswin.boxcast.core.data.SmartQueueEngine.SOURCE_SERVER_REC in sourceCounts
+                )
             )
         }
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -54,11 +54,19 @@ class BoxLorePlaybackService : MediaLibraryService() {
     private val subscriptionRepository by lazy {
         cx.aswin.boxcast.core.data.SubscriptionRepository(database.podcastDao())
     }
+    private val queueSkipMemory by lazy {
+        cx.aswin.boxcast.core.data.QueueSkipMemory.fromContext(this)
+    }
     private val smartQueueEngine by lazy {
         cx.aswin.boxcast.core.data.DefaultSmartQueueEngine(
-            podcastRepository = podcastRepository,
-            listeningHistoryDao = database.listeningHistoryDao(),
-            subscriptionRepository = subscriptionRepository
+            sources = cx.aswin.boxcast.core.data.DefaultSmartQueueSources(
+                context = this,
+                database = database,
+                podcastRepository = podcastRepository,
+                subscriptionRepository = subscriptionRepository,
+                userPreferencesRepository = userPreferencesRepository
+            ),
+            skipMemory = queueSkipMemory
         )
     }
     private val queueRepository by lazy {
@@ -239,7 +247,11 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 val currentItem = player.currentMediaItem
                 val isLearn = currentItem?.mediaId?.startsWith(LEARN_PREFIX) == true
 
-                if (remaining <= 2 && !isRefilling && player.mediaItemCount > 0 && !isLearn) {
+                // Sleep-timer guard: when playback will stop at the end of this episode,
+                // refilling would fetch episodes the player is about to abandon.
+                val sleepingAtEndOfEpisode = cx.aswin.boxcast.core.data.SleepTimerHolder.sleepAtEndOfEpisode
+
+                if (remaining <= 2 && !isRefilling && player.mediaItemCount > 0 && !isLearn && !sleepingAtEndOfEpisode) {
                     isRefilling = true
                     serviceScope.launch {
                         try {
@@ -699,13 +711,24 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     pauseReason = pauseReason
                 )
 
-                // Track skip if it's a transition skip within 30 seconds for an AUTO_FILL episode
+                // Track skip if it's a transition skip within 30 seconds for an AUTO_FILL episode.
+                // Also feed local skip memory so the SmartQueueEngine never re-suggests it
+                // and can down-rank the podcast after repeated rejections.
                 if (isTransition && durationPlayedSeconds <= 30f && playbackSessionContextType == "AUTO_FILL") {
                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSmartQueueEpisodeSkipped(
                         episodeId = currentEpisodeId,
                         recommendationSource = playbackSessionContextSourceId ?: "unknown",
                         positionInQueue = 0
                     )
+                    try {
+                        queueSkipMemory.recordSkip(
+                            episodeId = currentEpisodeId,
+                            podcastId = currentPodcastId,
+                            source = playbackSessionContextSourceId
+                        )
+                    } catch (e: Exception) {
+                        android.util.Log.e("AutoQueue", "Failed to record skip memory", e)
+                    }
                 }
             }
             
@@ -759,8 +782,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
     }
 
     /**
-     * SmartQueue refill: called when the player queue is running low.
-     * Uses SmartQueueEngine to find next episodes (same podcast → subscriptions → trending).
+     * SmartQueue refill: the single auto-refill path in the app (the UI-side triggers
+     * were removed). Uses the tiered SmartQueueEngine to build a batch of episodes
+     * (same podcast → resume → scored subscriptions → server recs → region trending).
      * Works independently of the app UI being open.
      */
     private suspend fun refillQueue(player: ExoPlayer) {
@@ -777,22 +801,33 @@ class BoxLorePlaybackService : MediaLibraryService() {
             return
         }
         
-        // Get podcast context (check DB first, then fallback to API)
-        val podcastId = findPodcastIdForEpisode(episodeId) ?: return
+        // Get podcast context (check DB first, then fallback to API).
+        // Briefings have no feed entry; synthesize a minimal podcast so the engine can
+        // run its fallback tiers (it detects the briefing_ prefix itself).
+        val isBriefing = episodeId.startsWith("briefing_")
+        val podcastId = if (isBriefing) episodeId else findPodcastIdForEpisode(episodeId) ?: return
         
-        val podcastEntity = database.podcastDao().getPodcast(podcastId)
-        val podcast = if (podcastEntity != null) {
-            cx.aswin.boxcast.core.model.Podcast(
+        val podcastEntity = if (isBriefing) null else database.podcastDao().getPodcast(podcastId)
+        val podcast = when {
+            podcastEntity != null -> cx.aswin.boxcast.core.model.Podcast(
                 id = podcastEntity.podcastId,
                 title = podcastEntity.title,
                 artist = podcastEntity.author,
                 imageUrl = podcastEntity.imageUrl,
                 description = podcastEntity.description,
-                genre = podcastEntity.genre ?: "Podcast"
+                genre = podcastEntity.genre ?: "Podcast",
+                type = podcastEntity.type,
+                preferredSort = podcastEntity.preferredSort
             )
-        } else {
+            isBriefing -> cx.aswin.boxcast.core.model.Podcast(
+                id = "briefing_daily",
+                title = metadata.subtitle?.toString() ?: "Daily Briefing",
+                artist = "",
+                imageUrl = metadata.artworkUri?.toString() ?: "",
+                genre = "News"
+            )
             // Fallback to API if not in local DB (e.g. unsubscribed podcast from history)
-            podcastRepository.getPodcastDetails(podcastId) ?: return
+            else -> podcastRepository.getPodcastDetails(podcastId) ?: return
         }
         
         // Build the EpisodeItem for SmartQueueEngine
@@ -805,92 +840,98 @@ class BoxLorePlaybackService : MediaLibraryService() {
             feedImage = podcast.imageUrl
         )
         
-        val nextEntries = smartQueueEngine.getNextEpisodes(currentEpisodeItem, podcast)
-        android.util.Log.d("AutoQueue", "SmartQueue returned ${nextEntries.size} episodes")
-        
-        if (nextEntries.isNotEmpty()) {
-            val refilledEpisodeIds = mutableListOf<String>()
-            val recommendationSources = mutableListOf<String>()
- 
-            // Collect existing mediaIds to avoid duplicates
-            val existingIds = kotlinx.coroutines.withContext(mainDispatcher) {
-                (0 until player.mediaItemCount).map { 
-                    player.getMediaItemAt(it).mediaId.removePrefix(LEARN_PREFIX).removePrefix(EPISODE_PREFIX).removePrefix(QUEUE_PREFIX)
-                }.toSet()
-            }
-            
-            // Add to player queue on main thread
-            kotlinx.coroutines.withContext(mainDispatcher) {
-                nextEntries.forEach { entry ->
-                    val ep = entry.episode
-                    val pod = entry.podcast
-                    val epIdStr = ep.id.toString()
-                    
-                    // Skip duplicates
-                    if (epIdStr in existingIds) {
-                        android.util.Log.d("AutoQueue", "Skipping duplicate: ${ep.title} ($epIdStr)")
-                        return@forEach
-                    }
-                    
-                    val epImageUrl = ep.image
-                    val podImageUrl = ep.feedImage ?: pod.imageUrl
-                    val finalImageUrl = epImageUrl ?: podImageUrl
-                    android.util.Log.d("BoxCastPlayer", "refillQueue: epId=${ep.id}, ep.image='$epImageUrl', pod.imageUrl='$podImageUrl', finalImageUrl='$finalImageUrl'")
-                    val artworkUri = finalImageUrl.let { android.net.Uri.parse(it) }
-                    
-                    // Use raw ID — same format as PlaybackRepository (L1 fix)
-                    val mediaItem = MediaItem.Builder()
-                        .setMediaId(epIdStr)
-                        .setUri(ep.enclosureUrl ?: "")
-                        .setMediaMetadata(
-                            MediaMetadata.Builder()
-                                .setTitle(ep.title)
-                                .setSubtitle(pod.title)
-                                .setArtist(pod.artist)
-                                .setArtworkUri(artworkUri)
-                                .setDisplayTitle(ep.title)
-                                .setGenre(pod.genre)
-                                .setIsPlayable(true)
-                                .setIsBrowsable(false)
-                                .setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE)
-                                .build()
-                        )
-                        .build()
-                    
-                    player.addMediaItem(mediaItem)
-                    refilledEpisodeIds.add(epIdStr)
-                    recommendationSources.add(entry.source)
-                }
-                android.util.Log.d("AutoQueue", "Added ${refilledEpisodeIds.size} items. Queue now: ${player.mediaItemCount}")
-            }
-            
-            // Persist to QueueRepository so PlaybackRepository and UI stay in sync (C2 fix)
-            nextEntries.forEach { entry ->
-                val epIdStr = entry.episode.id.toString()
-                if (epIdStr in refilledEpisodeIds) {
-                    try {
-                        queueRepository.addToQueue(
-                            episode = entry.episode,
-                            podcast = entry.podcast,
-                            contextType = "AUTO_FILL",
-                            contextSourceId = entry.source
-                        )
-                    } catch (e: Exception) {
-                        android.util.Log.e("AutoQueue", "Failed to persist queue item: ${entry.episode.title}", e)
-                    }
-                }
-            }
+        // Everything already in the player is off-limits for the engine.
+        val existingIds = kotlinx.coroutines.withContext(mainDispatcher) {
+            (0 until player.mediaItemCount).map {
+                player.getMediaItemAt(it).mediaId.removePrefix(LEARN_PREFIX).removePrefix(EPISODE_PREFIX).removePrefix(QUEUE_PREFIX)
+            }.toSet()
+        }
 
-            if (refilledEpisodeIds.isNotEmpty()) {
-                val uniqueSources = recommendationSources.distinct()
-                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSmartQueueRefilled(
-                    triggeringEpisodeId = episodeId,
-                    triggeringPodcastGenre = podcast.genre ?: "Podcast",
-                    refilledCount = refilledEpisodeIds.size,
-                    recommendationSources = uniqueSources,
-                    refilledEpisodeIds = refilledEpisodeIds
+        val nextEntries = smartQueueEngine.getNextEpisodes(
+            currentEpisode = currentEpisodeItem,
+            podcast = podcast,
+            preferredSort = podcastEntity?.preferredSort,
+            excludeEpisodeIds = existingIds
+        )
+        android.util.Log.d("AutoQueue", "SmartQueue returned ${nextEntries.size} episodes")
+        if (nextEntries.isEmpty()) return
+
+        // Respect the queue cap when appending the batch.
+        val room = (QUEUE_MAX_SIZE - player.mediaItemCount).coerceAtLeast(0)
+        val entriesToAdd = nextEntries
+            .filter { it.episode.id.toString() !in existingIds }
+            .take(room)
+        if (entriesToAdd.isEmpty()) return
+
+        // Persist FIRST so PlaybackRepository's timeline reconciliation finds the rows
+        // (with contextType/source for queue-sheet labels) when the player callback fires.
+        entriesToAdd.forEach { entry ->
+            try {
+                queueRepository.addToQueue(
+                    episode = entry.episode,
+                    podcast = entry.podcast,
+                    contextType = "AUTO_FILL",
+                    contextSourceId = entry.source
                 )
+            } catch (e: Exception) {
+                android.util.Log.e("AutoQueue", "Failed to persist queue item: ${entry.episode.title}", e)
             }
+        }
+
+        val refilledEpisodeIds = mutableListOf<String>()
+        val recommendationSources = mutableListOf<String>()
+
+        // Add to player queue on main thread
+        kotlinx.coroutines.withContext(mainDispatcher) {
+            entriesToAdd.forEach { entry ->
+                val ep = entry.episode
+                val pod = entry.podcast
+                val epIdStr = ep.id.toString()
+                
+                val finalImageUrl = ep.image ?: ep.feedImage ?: pod.imageUrl
+                val artworkUri = finalImageUrl.let { android.net.Uri.parse(it) }
+                
+                // Use raw ID — same format as PlaybackRepository (L1 fix)
+                val mediaItem = MediaItem.Builder()
+                    .setMediaId(epIdStr)
+                    .setUri(ep.enclosureUrl ?: "")
+                    .setMediaMetadata(
+                        MediaMetadata.Builder()
+                            .setTitle(ep.title)
+                            .setSubtitle(pod.title)
+                            .setArtist(pod.artist)
+                            .setArtworkUri(artworkUri)
+                            .setDisplayTitle(ep.title)
+                            .setGenre(pod.genre)
+                            .setIsPlayable(true)
+                            .setIsBrowsable(false)
+                            .setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE)
+                            .build()
+                    )
+                    .build()
+                
+                player.addMediaItem(mediaItem)
+                refilledEpisodeIds.add(epIdStr)
+                recommendationSources.add(entry.source)
+            }
+            android.util.Log.d("AutoQueue", "Added ${refilledEpisodeIds.size} items. Queue now: ${player.mediaItemCount}")
+        }
+
+        if (refilledEpisodeIds.isNotEmpty()) {
+            val region = try {
+                userPreferencesRepository.regionStream.first()
+            } catch (e: Exception) { null }
+            val sourceCounts = recommendationSources.groupingBy { it }.eachCount()
+            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSmartQueueRefilled(
+                triggeringEpisodeId = episodeId,
+                triggeringPodcastGenre = podcast.genre ?: "Podcast",
+                refilledCount = refilledEpisodeIds.size,
+                recommendationSources = recommendationSources.distinct(),
+                refilledEpisodeIds = refilledEpisodeIds,
+                region = region,
+                sourceCounts = sourceCounts,
+                usedServerRecommendations = cx.aswin.boxcast.core.data.SmartQueueEngine.SOURCE_SERVER_REC in sourceCounts
+            )
         }
     }
 
@@ -1620,53 +1661,35 @@ class BoxLorePlaybackService : MediaLibraryService() {
             }.toMutableList()
         }
 
+        /**
+         * Android Auto browse plays a single episode; this routes the follow-up queue
+         * build through the same guarded SmartQueueEngine refill path as the transition
+         * listener (shared isRefilling flag), so Auto no longer bypasses dedup/ranking
+         * or persists rows without provenance.
+         */
         private fun buildAndAppendQueueAsync(episodeId: String, mediaSession: MediaSession) {
             serviceScope.launch {
                 try {
-                    val podcastId = findPodcastIdForEpisode(episodeId)
-                    if (podcastId != null) {
-                        android.util.Log.d("AutoBrowse", "Async queue build: fetching episodes for $podcastId")
-                        val allEpisodes = podcastRepository.getEpisodes(podcastId)
-                        val podcastEntity = database.podcastDao().getPodcast(podcastId)
-                        
-                        val podcastApi = if (podcastEntity == null) podcastRepository.getPodcastDetails(podcastId) else null
-                        val podcastImageUrl = podcastEntity?.imageUrl ?: podcastApi?.imageUrl
-                        val podcastTitle = podcastEntity?.title ?: podcastApi?.title
-                        val podcastAuthor = podcastEntity?.author ?: podcastApi?.artist
-                        
-                        if (allEpisodes.isNotEmpty()) {
-                            val sorted = allEpisodes.sortedBy { it.publishedDate }
-                            val selectedIndex = sorted.indexOfFirst { it.id == episodeId }
-                            
-                            if (selectedIndex >= 0 && selectedIndex < sorted.size - 1) {
-                                val remainingQueue = sorted.subList(selectedIndex + 1, sorted.size)
-                                
-                                val mediaItemsToAdd = remainingQueue.map { episode ->
-                                    val artworkUri = (episode.imageUrl ?: podcastImageUrl)?.let { android.net.Uri.parse(it) }
-                                    
-                                    MediaItem.Builder()
-                                        .setMediaId("episode:${episode.id}")
-                                        .setUri(episode.audioUrl)
-                                        .setMediaMetadata(
-                                            MediaMetadata.Builder()
-                                                .setTitle(episode.title)
-                                                .setSubtitle(podcastTitle ?: episode.podcastTitle ?: "")
-                                                .setArtist(podcastAuthor ?: episode.podcastArtist ?: "")
-                                                .setArtworkUri(artworkUri)
-                                                .setIsPlayable(true)
-                                                .setIsBrowsable(false)
-                                                .setMediaType(MediaMetadata.MEDIA_TYPE_PODCAST_EPISODE)
-                                                .build()
-                                        )
-                                        .build()
-                                }
-                                
-                                kotlinx.coroutines.withContext(mainDispatcher) {
-                                    mediaSession.player.addMediaItems(mediaItemsToAdd)
-                                    android.util.Log.d("AutoBrowse", "Async queue built: appended ${mediaItemsToAdd.size} items")
-                                }
-                            }
-                        }
+                    val player = mediaSession.player as? ExoPlayer ?: return@launch
+                    // Wait briefly for the selected episode to become the current item so
+                    // the engine refills relative to it (playback start is asynchronous).
+                    var attempts = 0
+                    while (attempts < 20) {
+                        val currentId = player.currentMediaItem?.mediaId
+                            ?.removePrefix(LEARN_PREFIX)?.removePrefix(EPISODE_PREFIX)?.removePrefix(QUEUE_PREFIX)
+                        if (currentId == episodeId) break
+                        kotlinx.coroutines.delay(250)
+                        attempts++
+                    }
+                    if (isRefilling) {
+                        android.util.Log.d("AutoBrowse", "Refill already in flight; skipping Auto queue build")
+                        return@launch
+                    }
+                    isRefilling = true
+                    try {
+                        refillQueue(player)
+                    } finally {
+                        isRefilling = false
                     }
                 } catch (e: Exception) {
                     android.util.Log.e("AutoBrowse", "Async queue build failed", e)

--- a/core/data/src/test/java/android/util/Log.kt
+++ b/core/data/src/test/java/android/util/Log.kt
@@ -1,0 +1,20 @@
+package android.util
+
+/** JVM unit-test stub so production [Log] calls compile and no-op without Robolectric. */
+object Log {
+    @JvmStatic fun v(tag: String, msg: String): Int = 0
+
+    @JvmStatic fun d(tag: String, msg: String): Int = 0
+
+    @JvmStatic fun i(tag: String, msg: String): Int = 0
+
+    @JvmStatic fun w(tag: String, msg: String): Int = 0
+
+    @JvmStatic fun w(tag: String, msg: String, tr: Throwable): Int = 0
+
+    @JvmStatic fun e(tag: String, msg: String): Int = 0
+
+    @JvmStatic fun e(tag: String, msg: String, tr: Throwable): Int = 0
+
+    @JvmStatic fun isLoggable(tag: String, level: Int): Boolean = false
+}

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/QueueMathTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/QueueMathTest.kt
@@ -1,0 +1,90 @@
+package cx.aswin.boxcast.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Index-mapping and queue-type detection rules shared by the queue sheet, the player
+ * repository, and the playback service. These mappings are where the reorder feature
+ * can silently corrupt the queue, so they're pinned down here.
+ */
+class QueueMathTest {
+
+    // ── media-id prefix handling ────────────────────────────────────────────
+
+    @Test
+    fun `strips learn, episode and queue prefixes`() {
+        assertEquals("123", QueueMath.stripMediaIdPrefixes("learn:123"))
+        assertEquals("123", QueueMath.stripMediaIdPrefixes("episode:123"))
+        assertEquals("123", QueueMath.stripMediaIdPrefixes("queue:123"))
+        assertEquals("123", QueueMath.stripMediaIdPrefixes("123"))
+    }
+
+    @Test
+    fun `finds media index regardless of prefix`() {
+        val mediaIds = listOf("episode:1", "learn:2", "3")
+        assertEquals(0, QueueMath.mediaIndexOfEpisode(mediaIds, "1"))
+        assertEquals(1, QueueMath.mediaIndexOfEpisode(mediaIds, "2"))
+        assertEquals(2, QueueMath.mediaIndexOfEpisode(mediaIds, "3"))
+        assertEquals(-1, QueueMath.mediaIndexOfEpisode(mediaIds, "4"))
+    }
+
+    // ── UI index <-> queue index (sheet hides the playing item) ─────────────
+
+    @Test
+    fun `ui index maps to queue index with hidden-current offset`() {
+        assertEquals(1, QueueMath.uiIndexToQueueIndex(0))
+        assertEquals(5, QueueMath.uiIndexToQueueIndex(4))
+        assertEquals(0, QueueMath.queueIndexToUiIndex(1))
+        assertEquals(4, QueueMath.queueIndexToUiIndex(5))
+    }
+
+    @Test
+    fun `ui and queue index mappings are inverses`() {
+        for (ui in 0..10) {
+            assertEquals(ui, QueueMath.queueIndexToUiIndex(QueueMath.uiIndexToQueueIndex(ui)))
+        }
+    }
+
+    // ── Lore queue detection ────────────────────────────────────────────────
+
+    @Test
+    fun `queue with any non-learn media id is a normal queue`() {
+        assertTrue(QueueMath.hasNonLoreMediaIds(listOf("learn:1", "42")))
+        assertTrue(QueueMath.hasNonLoreMediaIds(listOf("episode:9")))
+    }
+
+    @Test
+    fun `lore-only or empty media ids are not a normal queue`() {
+        assertFalse(QueueMath.hasNonLoreMediaIds(listOf("learn:1", "learn:2")))
+        assertFalse(QueueMath.hasNonLoreMediaIds(emptyList()))
+    }
+
+    @Test
+    fun `persisted context types detect normal queues across restarts`() {
+        assertTrue(QueueMath.hasNonLoreContextTypes(listOf("LORE", "MANUAL")))
+        assertTrue(QueueMath.hasNonLoreContextTypes(listOf(null)))       // legacy rows
+        assertTrue(QueueMath.hasNonLoreContextTypes(listOf("AUTO_FILL")))
+        assertFalse(QueueMath.hasNonLoreContextTypes(listOf("LORE", "LORE")))
+        assertFalse(QueueMath.hasNonLoreContextTypes(emptyList()))
+    }
+
+    // ── list reordering ─────────────────────────────────────────────────────
+
+    @Test
+    fun `moveItem moves forward and backward`() {
+        val list = listOf("a", "b", "c", "d")
+        assertEquals(listOf("b", "c", "a", "d"), QueueMath.moveItem(list, 0, 2))
+        assertEquals(listOf("c", "a", "b", "d"), QueueMath.moveItem(list, 2, 0))
+    }
+
+    @Test
+    fun `moveItem with same or invalid indices returns the list unchanged`() {
+        val list = listOf("a", "b", "c")
+        assertEquals(list, QueueMath.moveItem(list, 1, 1))
+        assertEquals(list, QueueMath.moveItem(list, -1, 2))
+        assertEquals(list, QueueMath.moveItem(list, 0, 3))
+    }
+}

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/QueueSkipMemoryTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/QueueSkipMemoryTest.kt
@@ -1,0 +1,95 @@
+package cx.aswin.boxcast.core.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure JVM tests for the skip-memory store. Persistence is injected as lambdas, so
+ * these run without Android (no SharedPreferences involved).
+ */
+class QueueSkipMemoryTest {
+
+    private var store: String? = null
+    private var now: Long = 1_000_000_000_000L
+
+    private fun newMemory() = QueueSkipMemory(
+        readRaw = { store },
+        writeRaw = { store = it },
+        nowMs = { now }
+    )
+
+    @Test
+    fun `recorded skips are returned and never re-suggested`() {
+        val memory = newMemory()
+        memory.recordSkip("ep1", "podA", "trending")
+        memory.recordSkip("ep2", "podB", "subscription")
+
+        assertEquals(setOf("ep1", "ep2"), memory.skippedEpisodeIds())
+    }
+
+    @Test
+    fun `entries survive a reload through the persisted format`() {
+        newMemory().recordSkip("ep1", "podA", "trending")
+        // A brand-new instance reading the same raw store sees the entry.
+        assertEquals(setOf("ep1"), newMemory().skippedEpisodeIds())
+    }
+
+    @Test
+    fun `entries expire after seven days`() {
+        val memory = newMemory()
+        memory.recordSkip("old", "podA", "trending")
+
+        now += QueueSkipMemory.EXPIRY_MS + 1
+        memory.recordSkip("fresh", "podA", "trending")
+
+        assertEquals(setOf("fresh"), memory.skippedEpisodeIds())
+    }
+
+    @Test
+    fun `store is capped at the max entry count keeping newest`() {
+        val memory = newMemory()
+        repeat(QueueSkipMemory.MAX_ENTRIES + 50) { i ->
+            now += 1
+            memory.recordSkip("ep$i", "pod$i", "trending")
+        }
+        val ids = memory.skippedEpisodeIds()
+        assertEquals(QueueSkipMemory.MAX_ENTRIES, ids.size)
+        assertTrue("newest entry kept", "ep${QueueSkipMemory.MAX_ENTRIES + 49}" in ids)
+        assertFalse("oldest entry dropped", "ep0" in ids)
+    }
+
+    @Test
+    fun `podcasts with two or more skips are down-ranked`() {
+        val memory = newMemory()
+        memory.recordSkip("ep1", "podA", "trending")
+        memory.recordSkip("ep2", "podA", "subscription")
+        memory.recordSkip("ep3", "podB", "trending")
+
+        assertEquals(setOf("podA"), memory.downRankedPodcastIds())
+    }
+
+    @Test
+    fun `re-recording the same episode does not double count its podcast`() {
+        val memory = newMemory()
+        memory.recordSkip("ep1", "podA", "trending")
+        memory.recordSkip("ep1", "podA", "trending")
+
+        assertTrue(memory.downRankedPodcastIds().isEmpty())
+    }
+
+    @Test
+    fun `blank episode ids are ignored`() {
+        val memory = newMemory()
+        memory.recordSkip("", "podA", "trending")
+        assertTrue(memory.skippedEpisodeIds().isEmpty())
+    }
+
+    @Test
+    fun `corrupt raw data degrades to empty instead of throwing`() {
+        store = "garbage-without-separators\nanother|line"
+        val memory = newMemory()
+        assertTrue(memory.skippedEpisodeIds().isEmpty())
+    }
+}

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/SmartQueueEngineTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/SmartQueueEngineTest.kt
@@ -33,6 +33,7 @@ class SmartQueueEngineTest {
         var recentHistory: List<ListeningHistoryEntity> = emptyList()
         var region: String = "us"
         var interests: List<String> = emptyList()
+        var recommendationHistory: List<HistoryItem> = emptyList()
         var recommendations: List<Episode> = emptyList()
         var similarEpisodes: List<Episode> = emptyList()
         var trendingPodcasts: List<Podcast> = emptyList()
@@ -62,9 +63,7 @@ class SmartQueueEngineTest {
         override suspend fun getInterests(): List<String> = interests
 
         override suspend fun getHistoryForRecommendations(limit: Int): List<HistoryItem> =
-            recentHistory.take(limit).map {
-                HistoryItem(podcastTitle = it.podcastName, episodeTitle = it.episodeTitle)
-            }
+            recommendationHistory.take(limit)
 
         override suspend fun getPersonalizedRecommendations(
             history: List<HistoryItem>,
@@ -200,7 +199,7 @@ class SmartQueueEngineTest {
     }
 
     @Test
-    fun `news-style episodic show jumps to freshest unplayed episodes`() = runTest {
+    fun `news-style episodic show queues only newer episodes than current`() = runTest {
         val sources = FakeSources()
         sources.episodesByPodcast["pod1"] = (1L..5L).map { episode(it, podcastGenre = "News") }
 
@@ -208,8 +207,22 @@ class SmartQueueEngineTest {
             currentItem(2), podcast("pod1", type = "episodic", genre = "News")
         )
 
-        // Newest first, current excluded.
-        assertEquals(listOf("5", "4", "3", "1"), batch.map { it.episode.id.toString() })
+        // Playing ep 2 → only fresher eps 3, 4, 5 (newest first), never rewind to ep 1.
+        assertEquals(listOf("5", "4", "3"), batch.map { it.episode.id.toString() })
+    }
+
+    @Test
+    fun `newest sort on latest episode does not rewind into older episodes`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..5L).map { episode(it) }
+        sources.subscriptions = listOf(podcast("sub1"))
+        sources.episodesByPodcast["sub1"] = listOf(episode(901, "sub1"))
+
+        val batch = engine(sources).getNextEpisodes(
+            currentItem(5), podcast("pod1", type = "episodic", preferredSort = "newest")
+        )
+
+        assertTrue(batch.none { it.source == SmartQueueEngine.SOURCE_SAME_PODCAST })
     }
 
     @Test
@@ -248,6 +261,46 @@ class SmartQueueEngineTest {
         val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
 
         assertEquals(batch.size, batch.map { it.episode.id }.distinct().size)
+    }
+
+    @Test
+    fun `discovery landing skips tier 0 so one suggested episode does not backfill the whole show`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..10L).map { episode(it) }
+        sources.subscriptions = listOf(podcast("sub1"))
+        sources.episodesByPodcast["sub1"] = listOf(episode(901, "sub1"))
+
+        SmartQueueEngine.DISCOVERY_REFILL_SOURCES.forEach { discoverySource ->
+            val batch = engine(sources).getNextEpisodes(
+                currentItem(1),
+                podcast("pod1", type = "serial"),
+                currentContextSourceId = discoverySource
+            )
+            assertTrue(
+                "Tier 0 must not run for discovery source $discoverySource",
+                batch.none { it.source == SmartQueueEngine.SOURCE_SAME_PODCAST }
+            )
+        }
+    }
+
+    @Test
+    fun `same-podcast auto-fill and manual play still allow tier 0 continuation`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..6L).map { episode(it) }
+
+        val bingeBatch = engine(sources).getNextEpisodes(
+            currentItem(3),
+            podcast("pod1", type = "serial"),
+            currentContextSourceId = SmartQueueEngine.SOURCE_SAME_PODCAST
+        )
+        assertTrue(bingeBatch.all { it.source == SmartQueueEngine.SOURCE_SAME_PODCAST })
+
+        val manualBatch = engine(sources).getNextEpisodes(
+            currentItem(3),
+            podcast("pod1", type = "serial"),
+            currentContextSourceId = null
+        )
+        assertTrue(manualBatch.all { it.source == SmartQueueEngine.SOURCE_SAME_PODCAST })
     }
 
     // ── Tier 1: resume ──────────────────────────────────────────────────────
@@ -354,17 +407,56 @@ class SmartQueueEngineTest {
     // ── Tier 3 + 4: network tiers ───────────────────────────────────────────
 
     @Test
-    fun `network tiers fire only when local tiers are thin and receive the region`() = runTest {
+    fun `warm users get personalized recommendations when local tiers are thin`() = runTest {
         val sources = FakeSources()
         sources.region = "in"
+        sources.recommendationHistory = listOf(
+            HistoryItem(podcastTitle = "Past Pod", episodeTitle = "Past Ep")
+        )
         sources.episodesByPodcast["pod1"] = listOf(episode(1)) // exhausted
         sources.recommendations = listOf(episode(701, "recPod"), episode(702, "recPod2"))
 
         val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
 
         assertEquals(1, sources.recommendationsCalls)
+        assertEquals(0, sources.similarCalls)
         assertEquals("in", sources.lastRecommendationCountry)
-        assertTrue(batch.any { it.source == SmartQueueEngine.SOURCE_SERVER_REC })
+        assertTrue(batch.any { it.source == SmartQueueEngine.SOURCE_PERSONALIZED_REC })
+    }
+
+    @Test
+    fun `cold users with episode metadata get similar episodes instead of recommendations`() = runTest {
+        val sources = FakeSources()
+        sources.region = "us"
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.similarEpisodes = listOf(episode(801, "simPod"))
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertEquals(0, sources.recommendationsCalls)
+        assertEquals(1, sources.similarCalls)
+        assertEquals("us", sources.lastSimilarCountry)
+        assertTrue(batch.any { it.source == SmartQueueEngine.SOURCE_SIMILAR_EPISODE })
+    }
+
+    @Test
+    fun `cold users without metadata skip tier 3 and fall through to trending`() = runTest {
+        val sources = FakeSources()
+        sources.region = "de"
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.recommendations = listOf(episode(701, "recPod"))
+        sources.trendingPodcasts = listOf(podcast("trend1"))
+        sources.episodesByPodcast["trend1"] = listOf(episode(901, "trend1"))
+
+        val batch = engine(sources).getNextEpisodes(
+            EpisodeItem(id = 0L, title = ""),
+            podcast("pod1", genre = "Comedy", type = "serial")
+        )
+
+        assertEquals(0, sources.recommendationsCalls)
+        assertEquals(0, sources.similarCalls)
+        assertEquals(1, sources.trendingCalls)
+        assertTrue(batch.any { it.source == SmartQueueEngine.SOURCE_TRENDING })
     }
 
     @Test
@@ -427,6 +519,9 @@ class SmartQueueEngineTest {
     fun `recent like triggers a region-aware similar-episode boost when tiers are thin`() = runTest {
         val sources = FakeSources()
         sources.region = "gb"
+        sources.recommendationHistory = listOf(
+            HistoryItem(podcastTitle = "Past Pod", episodeTitle = "Past Ep")
+        )
         sources.episodesByPodcast["pod1"] = listOf(episode(1))
         sources.recentHistory = listOf(
             resumeEntry("111", "pod9", progressMs = 60_000, isLiked = true)
@@ -435,9 +530,28 @@ class SmartQueueEngineTest {
 
         val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
 
+        assertEquals(1, sources.recommendationsCalls)
         assertEquals(1, sources.similarCalls)
         assertEquals("gb", sources.lastSimilarCountry)
-        assertTrue(batch.any { it.episode.id == 951L && it.source == SmartQueueEngine.SOURCE_SERVER_REC })
+        assertTrue(batch.any { it.episode.id == 951L && it.source == SmartQueueEngine.SOURCE_SIMILAR_LIKED })
+    }
+
+    @Test
+    fun `liked similar boost is skipped when tier 3 already used episode similar`() = runTest {
+        val sources = FakeSources()
+        sources.region = "gb"
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.recentHistory = listOf(
+            resumeEntry("111", "pod9", progressMs = 60_000, isLiked = true)
+        )
+        sources.similarEpisodes = listOf(episode(801, "simPod"))
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertEquals(0, sources.recommendationsCalls)
+        assertEquals(1, sources.similarCalls)
+        assertTrue(batch.any { it.source == SmartQueueEngine.SOURCE_SIMILAR_EPISODE })
+        assertEquals(1, batch.count { it.source == SmartQueueEngine.SOURCE_SIMILAR_EPISODE })
     }
 
     // ── Briefing handling ───────────────────────────────────────────────────

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/SmartQueueEngineTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/SmartQueueEngineTest.kt
@@ -1,0 +1,506 @@
+package cx.aswin.boxcast.core.data
+
+import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
+import cx.aswin.boxcast.core.model.Episode
+import cx.aswin.boxcast.core.model.Podcast
+import cx.aswin.boxcast.core.network.model.EpisodeItem
+import cx.aswin.boxcast.core.network.model.HistoryItem
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * JVM tests for the tiered refill engine, driven through a hand-rolled fake of
+ * [SmartQueueSources]. No Android framework, no network: each test shapes the fake's
+ * canned data to force the engine down a specific tier path, then asserts on the
+ * returned batch (sources, ordering, exclusions, and network usage).
+ */
+class SmartQueueEngineTest {
+
+    private val now = 1_700_000_000_000L
+
+    // ── fakes ───────────────────────────────────────────────────────────────
+
+    private open class FakeSources : SmartQueueSources {
+        val episodesByPodcast = mutableMapOf<String, List<Episode>>()
+        val podcastDetails = mutableMapOf<String, Podcast>()
+        var subscriptions: List<Podcast> = emptyList()
+        var completedIds: Set<String> = emptySet()
+        var recentlyPlayedPodcastIds: Set<String> = emptySet()
+        var resumeCandidates: List<ListeningHistoryEntity> = emptyList()
+        var recentHistory: List<ListeningHistoryEntity> = emptyList()
+        var region: String = "us"
+        var interests: List<String> = emptyList()
+        var recommendations: List<Episode> = emptyList()
+        var similarEpisodes: List<Episode> = emptyList()
+        var trendingPodcasts: List<Podcast> = emptyList()
+
+        // Spies
+        var recommendationsCalls = 0
+        var lastRecommendationCountry: String? = null
+        var trendingCalls = 0
+        var lastTrendingCountry: String? = null
+        var lastTrendingCategory: String? = null
+        var similarCalls = 0
+        var lastSimilarCountry: String? = null
+        var feedFetches = mutableListOf<String>()
+
+        override suspend fun getEpisodes(podcastId: String): List<Episode> {
+            feedFetches.add(podcastId)
+            return episodesByPodcast[podcastId] ?: emptyList()
+        }
+
+        override suspend fun getPodcastDetails(podcastId: String): Podcast? = podcastDetails[podcastId]
+        override suspend fun getSubscribedPodcasts(): List<Podcast> = subscriptions
+        override suspend fun getCompletedEpisodeIds(): Set<String> = completedIds
+        override suspend fun getRecentlyPlayedPodcastIds(sinceMs: Long): Set<String> = recentlyPlayedPodcastIds
+        override suspend fun getResumeCandidates(): List<ListeningHistoryEntity> = resumeCandidates
+        override suspend fun getRecentHistory(limit: Int): List<ListeningHistoryEntity> = recentHistory.take(limit)
+        override suspend fun getRegion(): String = region
+        override suspend fun getInterests(): List<String> = interests
+
+        override suspend fun getHistoryForRecommendations(limit: Int): List<HistoryItem> =
+            recentHistory.take(limit).map {
+                HistoryItem(podcastTitle = it.podcastName, episodeTitle = it.episodeTitle)
+            }
+
+        override suspend fun getPersonalizedRecommendations(
+            history: List<HistoryItem>,
+            interests: List<String>,
+            country: String?,
+            subscribedPodcastIds: List<String>,
+            subscribedGenres: List<String>
+        ): List<Episode> {
+            recommendationsCalls++
+            lastRecommendationCountry = country
+            return recommendations
+        }
+
+        override suspend fun getSimilarEpisodes(
+            episodeId: String,
+            podcastId: String,
+            title: String,
+            description: String,
+            podcastTitle: String,
+            country: String?
+        ): List<Episode> {
+            similarCalls++
+            lastSimilarCountry = country
+            return similarEpisodes
+        }
+
+        override suspend fun getTrendingPodcasts(country: String, category: String?): List<Podcast> {
+            trendingCalls++
+            lastTrendingCountry = country
+            lastTrendingCategory = category
+            return trendingPodcasts
+        }
+    }
+
+    private fun episode(
+        id: Long,
+        podcastId: String = "pod1",
+        publishedDate: Long = id, // monotonic by default
+        episodeType: String? = "full",
+        duration: Int = 1800,
+        podcastTitle: String = "Podcast $podcastId",
+        podcastGenre: String? = "Comedy"
+    ) = Episode(
+        id = id.toString(),
+        title = "Episode $id",
+        description = "",
+        audioUrl = "https://audio/$id.mp3",
+        imageUrl = "https://img/$id.png",
+        podcastImageUrl = "https://img/$podcastId.png",
+        podcastTitle = podcastTitle,
+        podcastId = podcastId,
+        podcastGenre = podcastGenre,
+        publishedDate = publishedDate,
+        episodeType = episodeType,
+        duration = duration
+    )
+
+    private fun podcast(
+        id: String,
+        type: String = "episodic",
+        genre: String = "Comedy",
+        preferredSort: String? = null,
+        latestEpisode: Episode? = null
+    ) = Podcast(
+        id = id,
+        title = "Podcast $id",
+        artist = "Artist $id",
+        imageUrl = "https://img/$id.png",
+        type = type,
+        genre = genre,
+        preferredSort = preferredSort,
+        latestEpisode = latestEpisode
+    )
+
+    private fun currentItem(id: Long) = EpisodeItem(id = id, title = "Episode $id")
+
+    private fun resumeEntry(
+        episodeId: String,
+        podcastId: String,
+        progressMs: Long,
+        durationMs: Long = 100_000,
+        lastPlayedAt: Long = now - 1000,
+        isLiked: Boolean = false
+    ) = ListeningHistoryEntity(
+        episodeId = episodeId,
+        podcastId = podcastId,
+        episodeTitle = "Episode $episodeId",
+        episodeImageUrl = null,
+        podcastImageUrl = "https://img/$podcastId.png",
+        episodeAudioUrl = "https://audio/$episodeId.mp3",
+        podcastName = "Podcast $podcastId",
+        progressMs = progressMs,
+        durationMs = durationMs,
+        isCompleted = false,
+        isLiked = isLiked,
+        lastPlayedAt = lastPlayedAt
+    )
+
+    private fun engine(sources: FakeSources, skipMemory: QueueSkipMemory? = null) =
+        DefaultSmartQueueEngine(sources = sources, skipMemory = skipMemory, nowMs = { now })
+
+    private fun skipMemory(): QueueSkipMemory {
+        var raw: String? = null
+        return QueueSkipMemory(readRaw = { raw }, writeRaw = { raw = it }, nowMs = { now })
+    }
+
+    // ── Tier 0: same-podcast continuation ───────────────────────────────────
+
+    @Test
+    fun `serial podcast continues chronologically after the current episode`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..6L).map { episode(it) }
+
+        val batch = engine(sources).getNextEpisodes(currentItem(3), podcast("pod1", type = "serial"))
+
+        assertEquals(listOf("4", "5", "6"), batch.map { it.episode.id.toString() })
+        assertTrue(batch.all { it.source == SmartQueueEngine.SOURCE_SAME_PODCAST })
+        // Binge fast path: no network tiers at all.
+        assertEquals(0, sources.recommendationsCalls)
+        assertEquals(0, sources.trendingCalls)
+    }
+
+    @Test
+    fun `preferredSort oldest forces chronological continuation on an episodic show`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..6L).map { episode(it) }
+
+        val batch = engine(sources).getNextEpisodes(
+            currentItem(2), podcast("pod1", type = "episodic"), preferredSort = "oldest"
+        )
+
+        assertEquals(listOf("3", "4", "5", "6"), batch.map { it.episode.id.toString() })
+    }
+
+    @Test
+    fun `news-style episodic show jumps to freshest unplayed episodes`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..5L).map { episode(it, podcastGenre = "News") }
+
+        val batch = engine(sources).getNextEpisodes(
+            currentItem(2), podcast("pod1", type = "episodic", genre = "News")
+        )
+
+        // Newest first, current excluded.
+        assertEquals(listOf("5", "4", "3", "1"), batch.map { it.episode.id.toString() })
+    }
+
+    @Test
+    fun `completed episodes and trailers are never suggested`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = listOf(
+            episode(1), episode(2), episode(3),
+            episode(4, episodeType = "trailer"),
+            episode(5)
+        )
+        sources.completedIds = setOf("3")
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertEquals(listOf("2", "5"), batch.map { it.episode.id.toString() })
+    }
+
+    @Test
+    fun `episodes already in the live queue are excluded`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..5L).map { episode(it) }
+
+        val batch = engine(sources).getNextEpisodes(
+            currentItem(1), podcast("pod1", type = "serial"),
+            excludeEpisodeIds = setOf("2", "4")
+        )
+
+        assertEquals(listOf("3", "5"), batch.map { it.episode.id.toString() })
+    }
+
+    @Test
+    fun `batch never contains duplicates`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..10L).map { episode(it) }
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertEquals(batch.size, batch.map { it.episode.id }.distinct().size)
+    }
+
+    // ── Tier 1: resume ──────────────────────────────────────────────────────
+
+    @Test
+    fun `show exhausted falls back to one resume candidate`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = listOf(episode(1)) // nothing after current
+        sources.resumeCandidates = listOf(
+            resumeEntry("101", "pod2", progressMs = 50_000),
+            resumeEntry("102", "pod3", progressMs = 40_000)
+        )
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        val resumes = batch.filter { it.source == SmartQueueEngine.SOURCE_RESUME }
+        assertEquals("at most one resume nudge per batch", 1, resumes.size)
+        assertEquals("101", resumes.first().episode.id.toString())
+    }
+
+    @Test
+    fun `resume ignores barely-started, nearly-done, stale and same-podcast episodes`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.resumeCandidates = listOf(
+            resumeEntry("201", "pod2", progressMs = 5_000),                    // < 10%
+            resumeEntry("202", "pod2", progressMs = 95_000),                   // > 90%
+            resumeEntry("203", "pod1", progressMs = 50_000),                   // same podcast
+            resumeEntry("204", "pod2", progressMs = 50_000,
+                lastPlayedAt = now - 31L * 24 * 60 * 60 * 1000)                // stale
+        )
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertTrue(batch.none { it.source == SmartQueueEngine.SOURCE_RESUME })
+    }
+
+    // ── Tier 2: scored subscriptions ────────────────────────────────────────
+
+    @Test
+    fun `fallback pulls newest unplayed episodes from subscriptions`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.subscriptions = listOf(podcast("sub1"), podcast("sub2"))
+        sources.episodesByPodcast["sub1"] = listOf(episode(301, "sub1"), episode(302, "sub1"))
+        sources.episodesByPodcast["sub2"] = listOf(episode(401, "sub2"))
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        val subs = batch.filter { it.source == SmartQueueEngine.SOURCE_SUBSCRIPTION }
+        assertTrue(subs.isNotEmpty())
+        // Round-robin: one episode per show, newest first within a show.
+        assertEquals(setOf("sub1", "sub2"), subs.map { it.podcast.id }.toSet())
+        assertTrue(subs.any { it.episode.id == 302L })
+    }
+
+    @Test
+    fun `recently played subscriptions are skipped to avoid loops`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.subscriptions = listOf(podcast("sub1"), podcast("sub2"))
+        sources.recentlyPlayedPodcastIds = setOf("sub1")
+        sources.episodesByPodcast["sub1"] = listOf(episode(301, "sub1"))
+        sources.episodesByPodcast["sub2"] = listOf(episode(401, "sub2"))
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        val subs = batch.filter { it.source == SmartQueueEngine.SOURCE_SUBSCRIPTION }
+        assertTrue(subs.none { it.podcast.id == "sub1" })
+    }
+
+    // ── Skip memory ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `skipped episodes are never re-suggested`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..4L).map { episode(it) }
+        val memory = skipMemory()
+        memory.recordSkip("3", "pod1", "same_podcast")
+
+        val batch = engine(sources, memory).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertEquals(listOf("2", "4"), batch.map { it.episode.id.toString() })
+    }
+
+    @Test
+    fun `podcasts with repeated skips are down-ranked in subscription fallback`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.subscriptions = listOf(podcast("subBad"), podcast("subGood"))
+        sources.episodesByPodcast["subBad"] = listOf(episode(501, "subBad"))
+        sources.episodesByPodcast["subGood"] = listOf(episode(601, "subGood"))
+        val memory = skipMemory()
+        memory.recordSkip("801", "subBad", "subscription")
+        memory.recordSkip("802", "subBad", "subscription")
+
+        val batch = engine(sources, memory).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        val subs = batch.filter { it.source == SmartQueueEngine.SOURCE_SUBSCRIPTION }
+        assertTrue(subs.isNotEmpty())
+        assertEquals("subGood", subs.first().podcast.id)
+    }
+
+    // ── Tier 3 + 4: network tiers ───────────────────────────────────────────
+
+    @Test
+    fun `network tiers fire only when local tiers are thin and receive the region`() = runTest {
+        val sources = FakeSources()
+        sources.region = "in"
+        sources.episodesByPodcast["pod1"] = listOf(episode(1)) // exhausted
+        sources.recommendations = listOf(episode(701, "recPod"), episode(702, "recPod2"))
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertEquals(1, sources.recommendationsCalls)
+        assertEquals("in", sources.lastRecommendationCountry)
+        assertTrue(batch.any { it.source == SmartQueueEngine.SOURCE_SERVER_REC })
+    }
+
+    @Test
+    fun `trending is region-aware and used when recommendations come back empty`() = runTest {
+        val sources = FakeSources()
+        sources.region = "de"
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.recommendations = emptyList()
+        sources.trendingPodcasts = listOf(podcast("trend1"))
+        sources.episodesByPodcast["trend1"] = listOf(episode(901, "trend1"))
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", genre = "Comedy", type = "serial"))
+
+        assertEquals(1, sources.trendingCalls)
+        assertEquals("de", sources.lastTrendingCountry)
+        assertEquals("Comedy", sources.lastTrendingCategory)
+        assertTrue(batch.any { it.source == SmartQueueEngine.SOURCE_TRENDING })
+    }
+
+    @Test
+    fun `healthy same-show continuation makes no network calls at all`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = (1L..10L).map { episode(it) }
+
+        engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertEquals(0, sources.recommendationsCalls)
+        assertEquals(0, sources.trendingCalls)
+        assertEquals(0, sources.similarCalls)
+    }
+
+    @Test
+    fun `offline degradation returns local results without throwing`() = runTest {
+        val sources = object : FakeSources() {
+            override suspend fun getPersonalizedRecommendations(
+                history: List<HistoryItem>, interests: List<String>, country: String?,
+                subscribedPodcastIds: List<String>, subscribedGenres: List<String>
+            ): List<Episode> = throw RuntimeException("offline")
+
+            override suspend fun getTrendingPodcasts(country: String, category: String?): List<Podcast> =
+                throw RuntimeException("offline")
+
+            override suspend fun getSimilarEpisodes(
+                episodeId: String, podcastId: String, title: String,
+                description: String, podcastTitle: String, country: String?
+            ): List<Episode> = throw RuntimeException("offline")
+        }
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.resumeCandidates = listOf(resumeEntry("101", "pod2", progressMs = 50_000))
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        // Whatever local tiers produced still comes back.
+        assertEquals(listOf(SmartQueueEngine.SOURCE_RESUME), batch.map { it.source })
+    }
+
+    // ── Tier 3.5: liked similarity boost ────────────────────────────────────
+
+    @Test
+    fun `recent like triggers a region-aware similar-episode boost when tiers are thin`() = runTest {
+        val sources = FakeSources()
+        sources.region = "gb"
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.recentHistory = listOf(
+            resumeEntry("111", "pod9", progressMs = 60_000, isLiked = true)
+        )
+        sources.similarEpisodes = listOf(episode(951, "simPod"))
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertEquals(1, sources.similarCalls)
+        assertEquals("gb", sources.lastSimilarCountry)
+        assertTrue(batch.any { it.episode.id == 951L && it.source == SmartQueueEngine.SOURCE_SERVER_REC })
+    }
+
+    // ── Briefing handling ───────────────────────────────────────────────────
+
+    @Test
+    fun `briefing skips same-show tier and prefers short episodes in fallback`() = runTest {
+        val sources = FakeSources()
+        sources.region = "us"
+        sources.subscriptions = listOf(podcast("subLong"), podcast("subShort"))
+        sources.episodesByPodcast["subLong"] = listOf(episode(311, "subLong", duration = 3600))
+        sources.episodesByPodcast["subShort"] = listOf(episode(312, "subShort", duration = 600))
+
+        val briefingItem = EpisodeItem(id = 0L, title = "Morning Briefing")
+        val briefingPodcast = podcast("briefing_daily", genre = "News")
+
+        val batch = engine(sources).getNextEpisodes(briefingItem, briefingPodcast)
+
+        assertTrue(batch.isNotEmpty())
+        assertTrue(batch.none { it.source == SmartQueueEngine.SOURCE_SAME_PODCAST })
+        // Short episode sorted ahead of the long one.
+        val ids = batch.map { it.episode.id }
+        assertTrue(ids.indexOf(312L) < ids.indexOf(311L))
+    }
+
+    @Test
+    fun `briefing trending fallback uses the News genre`() = runTest {
+        val sources = FakeSources()
+        sources.region = "in"
+        sources.trendingPodcasts = listOf(podcast("trendNews", genre = "News"))
+        sources.episodesByPodcast["trendNews"] = listOf(episode(971, "trendNews"))
+
+        val briefingItem = EpisodeItem(id = 0L, title = "Morning Briefing")
+        val batch = engine(sources).getNextEpisodes(briefingItem, podcast("briefing_daily", genre = "Podcast"))
+
+        assertEquals(1, sources.trendingCalls)
+        assertEquals("News", sources.lastTrendingCategory)
+        assertEquals("in", sources.lastTrendingCountry)
+        assertTrue(batch.any { it.source == SmartQueueEngine.SOURCE_TRENDING })
+    }
+
+    // ── batch invariants ────────────────────────────────────────────────────
+
+    @Test
+    fun `null podcast returns an empty batch instead of throwing`() = runTest {
+        val batch = engine(FakeSources()).getNextEpisodes(currentItem(1), null)
+        assertTrue(batch.isEmpty())
+    }
+
+    @Test
+    fun `fallback batch is capped at the target size`() = runTest {
+        val sources = FakeSources()
+        sources.episodesByPodcast["pod1"] = listOf(episode(1))
+        sources.subscriptions = (1..10).map { podcast("sub$it") }
+        (1..10).forEach { i ->
+            sources.episodesByPodcast["sub$i"] = listOf(episode((1000 + i).toLong(), "sub$i"))
+        }
+
+        val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+        assertTrue(
+            "fallback batch of ${batch.size} must be <= ${DefaultSmartQueueEngine.FALLBACK_BATCH_TARGET}",
+            batch.size <= DefaultSmartQueueEngine.FALLBACK_BATCH_TARGET
+        )
+        assertFalse(batch.isEmpty())
+    }
+}

--- a/feature/player/build.gradle.kts
+++ b/feature/player/build.gradle.kts
@@ -51,4 +51,5 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.smooth.corner.rect)
+    implementation(libs.reorderable)
 }

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/FullPlayerContent.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/FullPlayerContent.kt
@@ -117,6 +117,7 @@ fun FullPlayerContent(
     
     // Queue bottom sheet state
     var showQueueSheet by remember { mutableStateOf(false) }
+    val queueSnackbarHostState = remember { SnackbarHostState() }
     var showShareSheet by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     
@@ -384,6 +385,13 @@ fun FullPlayerContent(
             onFullscreenVideoChange = onFullscreenVideoChange,
             modifier = Modifier.fillMaxSize()
         )
+        }
+        SnackbarHost(
+            hostState = queueSnackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 16.dp)
+        )
     }
     
     // Queue Bottom Sheet
@@ -404,75 +412,68 @@ fun FullPlayerContent(
                 )
             }
         ) {
-            val queueSnackbarHostState = remember { SnackbarHostState() }
-            Box {
-                QueueSheetContent(
-                    queue = state.queue.drop(1), // Skip currently playing
-                    currentPodcast = podcast,
-                    colorScheme = colorScheme,
-                    onPlayEpisode = { ep ->
-                        scope.launch {
-                            val freshQueue = playbackRepository.playerState.value.queue
-                            val epPodcastId = ep.podcastId
-                            val episodePodcast = if (epPodcastId != null && epPodcastId != podcast.id) {
-                                cx.aswin.boxcast.core.model.Podcast(
-                                    id = epPodcastId,
-                                    title = ep.podcastTitle ?: "Unknown",
-                                    artist = ep.podcastArtist ?: "",
-                                    imageUrl = ep.podcastImageUrl ?: "",
-                                    description = null,
-                                    genre = ep.podcastGenre ?: ""
-                                )
-                            } else {
-                                podcast
-                            }
-                            playbackRepository.playFromQueueIndex(ep.id, freshQueue, episodePodcast)
-                            showQueueSheet = false
-                        }
-                    },
-                    onRemoveEpisode = { ep ->
-                        scope.launch {
-                            // Defer the AUTO_FILL rejection signal until the undo window
-                            // lapses, so an undone remove doesn't count as a rejection.
-                            val removed = playbackRepository.removeFromQueue(ep.id, deferSkipSignal = true)
-                            if (removed != null) {
-                                val result = queueSnackbarHostState.showSnackbar(
-                                    message = "Removed from queue",
-                                    actionLabel = "Undo",
-                                    duration = SnackbarDuration.Short
-                                )
-                                if (result == SnackbarResult.ActionPerformed) {
-                                    playbackRepository.undoQueueRemoval(removed)
+            QueueSheetContent(
+                queue = state.queue.drop(1), // Skip currently playing
+                currentPodcast = podcast,
+                colorScheme = colorScheme,
+                actions = QueueSheetActions(
+                        onPlayEpisode = { ep ->
+                            scope.launch {
+                                val freshQueue = playbackRepository.playerState.value.queue
+                                val epPodcastId = ep.podcastId
+                                val episodePodcast = if (epPodcastId != null && epPodcastId != podcast.id) {
+                                    cx.aswin.boxcast.core.model.Podcast(
+                                        id = epPodcastId,
+                                        title = ep.podcastTitle ?: "Unknown",
+                                        artist = ep.podcastArtist ?: "",
+                                        imageUrl = ep.podcastImageUrl ?: "",
+                                        description = null,
+                                        genre = ep.podcastGenre ?: ""
+                                    )
                                 } else {
-                                    playbackRepository.confirmQueueRemoval(removed)
+                                    podcast
+                                }
+                                playbackRepository.playFromQueueIndex(ep.id, freshQueue, episodePodcast)
+                                showQueueSheet = false
+                            }
+                        },
+                        onRemoveEpisode = { ep ->
+                            scope.launch {
+                                // Defer the AUTO_FILL rejection signal until the undo window
+                                // lapses, so an undone remove doesn't count as a rejection.
+                                val removed = playbackRepository.removeFromQueue(ep.id, deferSkipSignal = true)
+                                if (removed != null) {
+                                    val result = queueSnackbarHostState.showSnackbar(
+                                        message = "Removed from queue",
+                                        actionLabel = "Undo",
+                                        duration = SnackbarDuration.Short
+                                    )
+                                    if (result == SnackbarResult.ActionPerformed) {
+                                        playbackRepository.undoQueueRemoval(removed)
+                                    } else {
+                                        playbackRepository.confirmQueueRemoval(removed)
+                                    }
                                 }
                             }
-                        }
-                    },
-                    onClose = { showQueueSheet = false },
-                    onMove = { fromUi, toUi ->
-                        // The sheet hides the playing item, so UI indices are offset by 1.
-                        playbackRepository.moveQueueItem(
-                            cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(fromUi),
-                            cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(toUi)
-                        )
-                    },
-                    onDragEnd = { episodeId, fromUi, toUi ->
-                        // Persist once on drag end (rapid mid-drag moves stay in memory).
-                        scope.launch {
-                            playbackRepository.persistQueueOrder(
-                                movedEpisodeId = episodeId,
-                                fromQueueIndex = cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(fromUi),
-                                toQueueIndex = cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(toUi)
+                        },
+                        onClose = { showQueueSheet = false },
+                        onMove = { fromUi, toUi ->
+                            playbackRepository.moveQueueItem(
+                                cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(fromUi),
+                                cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(toUi)
                             )
+                        },
+                        onDragEnd = { episodeId, fromUi, toUi ->
+                            scope.launch {
+                                playbackRepository.persistQueueOrder(
+                                    movedEpisodeId = episodeId,
+                                    fromQueueIndex = cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(fromUi),
+                                    toQueueIndex = cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(toUi)
+                                )
+                            }
                         }
-                    }
+                    )
                 )
-                SnackbarHost(
-                    hostState = queueSnackbarHostState,
-                    modifier = Modifier.align(Alignment.BottomCenter)
-                )
-            }
         }
     }
 
@@ -776,5 +777,4 @@ fun FullPlayerContent(
             }
         )
     }
-}
 }

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/FullPlayerContent.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/FullPlayerContent.kt
@@ -404,37 +404,75 @@ fun FullPlayerContent(
                 )
             }
         ) {
-            QueueSheetContent(
-                queue = state.queue.drop(1), // Skip currently playing
-                currentPodcast = podcast,
-                colorScheme = colorScheme,
-                onPlayEpisode = { ep ->
-                    scope.launch {
-                        val freshQueue = playbackRepository.playerState.value.queue
-                        val epPodcastId = ep.podcastId
-                        val episodePodcast = if (epPodcastId != null && epPodcastId != podcast.id) {
-                            cx.aswin.boxcast.core.model.Podcast(
-                                id = epPodcastId,
-                                title = ep.podcastTitle ?: "Unknown",
-                                artist = ep.podcastArtist ?: "",
-                                imageUrl = ep.podcastImageUrl ?: "",
-                                description = null,
-                                genre = ep.podcastGenre ?: ""
-                            )
-                        } else {
-                            podcast
+            val queueSnackbarHostState = remember { SnackbarHostState() }
+            Box {
+                QueueSheetContent(
+                    queue = state.queue.drop(1), // Skip currently playing
+                    currentPodcast = podcast,
+                    colorScheme = colorScheme,
+                    onPlayEpisode = { ep ->
+                        scope.launch {
+                            val freshQueue = playbackRepository.playerState.value.queue
+                            val epPodcastId = ep.podcastId
+                            val episodePodcast = if (epPodcastId != null && epPodcastId != podcast.id) {
+                                cx.aswin.boxcast.core.model.Podcast(
+                                    id = epPodcastId,
+                                    title = ep.podcastTitle ?: "Unknown",
+                                    artist = ep.podcastArtist ?: "",
+                                    imageUrl = ep.podcastImageUrl ?: "",
+                                    description = null,
+                                    genre = ep.podcastGenre ?: ""
+                                )
+                            } else {
+                                podcast
+                            }
+                            playbackRepository.playFromQueueIndex(ep.id, freshQueue, episodePodcast)
+                            showQueueSheet = false
                         }
-                        playbackRepository.playFromQueueIndex(ep.id, freshQueue, episodePodcast)
-                        showQueueSheet = false
+                    },
+                    onRemoveEpisode = { ep ->
+                        scope.launch {
+                            // Defer the AUTO_FILL rejection signal until the undo window
+                            // lapses, so an undone remove doesn't count as a rejection.
+                            val removed = playbackRepository.removeFromQueue(ep.id, deferSkipSignal = true)
+                            if (removed != null) {
+                                val result = queueSnackbarHostState.showSnackbar(
+                                    message = "Removed from queue",
+                                    actionLabel = "Undo",
+                                    duration = SnackbarDuration.Short
+                                )
+                                if (result == SnackbarResult.ActionPerformed) {
+                                    playbackRepository.undoQueueRemoval(removed)
+                                } else {
+                                    playbackRepository.confirmQueueRemoval(removed)
+                                }
+                            }
+                        }
+                    },
+                    onClose = { showQueueSheet = false },
+                    onMove = { fromUi, toUi ->
+                        // The sheet hides the playing item, so UI indices are offset by 1.
+                        playbackRepository.moveQueueItem(
+                            cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(fromUi),
+                            cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(toUi)
+                        )
+                    },
+                    onDragEnd = { episodeId, fromUi, toUi ->
+                        // Persist once on drag end (rapid mid-drag moves stay in memory).
+                        scope.launch {
+                            playbackRepository.persistQueueOrder(
+                                movedEpisodeId = episodeId,
+                                fromQueueIndex = cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(fromUi),
+                                toQueueIndex = cx.aswin.boxcast.core.data.QueueMath.uiIndexToQueueIndex(toUi)
+                            )
+                        }
                     }
-                },
-                onRemoveEpisode = { ep ->
-                    scope.launch {
-                        playbackRepository.removeFromQueue(ep.id)
-                    }
-                },
-                onClose = { showQueueSheet = false }
-            )
+                )
+                SnackbarHost(
+                    hostState = queueSnackbarHostState,
+                    modifier = Modifier.align(Alignment.BottomCenter)
+                )
+            }
         }
     }
 

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/QueueScreen.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/QueueScreen.kt
@@ -36,7 +36,9 @@ internal fun queueSourceLabel(episode: Episode): String? = when (episode.context
         "same_podcast" -> "Continuing series"
         "resume" -> "Pick up where you left off"
         "subscription" -> "From your subscriptions"
-        "server_rec" -> "Recommended for you"
+        "server_rec", "personalized_rec" -> "Recommended for you"
+        "similar_episode" -> "Based on what you're playing"
+        "similar_liked" -> "Based on something you liked"
         "trending" -> episode.podcastGenre
             ?.takeIf { it.isNotBlank() && it != "Podcast" }
             ?.let { "Trending in $it" } ?: "Trending now"

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/QueueScreen.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/QueueScreen.kt
@@ -26,6 +26,22 @@ import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
+data class QueueSheetActions(
+    val onPlayEpisode: (Episode) -> Unit,
+    val onRemoveEpisode: (Episode) -> Unit,
+    val onClose: () -> Unit,
+    val onMove: (fromUiIndex: Int, toUiIndex: Int) -> Unit = { _, _ -> },
+    val onDragEnd: (episodeId: String, fromUiIndex: Int, toUiIndex: Int) -> Unit = { _, _, _ -> }
+)
+
+data class QueueItemDisplay(
+    val episode: Episode,
+    val podcast: Podcast?,
+    val sourceLabel: String? = null,
+    val isDragging: Boolean = false,
+    val dragHandleModifier: Modifier? = null
+)
+
 /**
  * Small caption explaining why an item is in the queue, derived from the provenance
  * persisted on each queue row (contextType + contextSourceId).
@@ -50,7 +66,7 @@ internal fun queueSourceLabel(episode: Episode): String? = when (episode.context
 /**
  * Queue bottom sheet content: header with close button + drag-to-reorder queue list.
  *
- * Indices in [onMove]/[onDragEnd] are UI list indices — the currently playing episode
+ * Indices in [actions.onMove]/[actions.onDragEnd] are UI list indices — the currently playing episode
  * is hidden from this sheet, so callers must map them with QueueMath.uiIndexToQueueIndex.
  */
 @Composable
@@ -58,13 +74,12 @@ fun QueueSheetContent(
     queue: List<Episode>,
     currentPodcast: Podcast?,
     colorScheme: ColorScheme,
-    onPlayEpisode: (Episode) -> Unit,
-    onRemoveEpisode: (Episode) -> Unit,
-    onClose: () -> Unit,
-    onMove: (fromUiIndex: Int, toUiIndex: Int) -> Unit = { _, _ -> },
-    onDragEnd: (episodeId: String, fromUiIndex: Int, toUiIndex: Int) -> Unit = { _, _, _ -> },
+    actions: QueueSheetActions,
     modifier: Modifier = Modifier
 ) {
+    val lazyListState = rememberLazyListState()
+    val dragStartIndex = remember { mutableIntStateOf(-1) }
+
     Column(modifier = modifier.fillMaxWidth()) {
         // Header: "Up Next" + Close button
         Row(
@@ -90,7 +105,7 @@ fun QueueSheetContent(
             
             Spacer(modifier = Modifier.width(12.dp))
 
-            IconButton(onClick = onClose) {
+            IconButton(onClick = actions.onClose) {
                 Icon(
                     Icons.Rounded.Close,
                     contentDescription = "Close queue",
@@ -118,11 +133,8 @@ fun QueueSheetContent(
                 )
             }
         } else {
-            val lazyListState = rememberLazyListState()
-            // Where the active drag started, so drag-end can report from -> to once.
-            val dragStartIndex = remember { mutableIntStateOf(-1) }
             val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
-                onMove(from.index, to.index)
+                actions.onMove(from.index, to.index)
             }
             LazyColumn(
                 state = lazyListState,
@@ -132,22 +144,24 @@ fun QueueSheetContent(
                 itemsIndexed(queue, key = { _, episode -> episode.id }) { index, episode ->
                     ReorderableItem(reorderableState, key = episode.id) { isDragging ->
                         QueueItemRow(
-                            episode = episode,
-                            podcast = currentPodcast,
+                            display = QueueItemDisplay(
+                                episode = episode,
+                                podcast = currentPodcast,
+                                sourceLabel = queueSourceLabel(episode),
+                                isDragging = isDragging,
+                                dragHandleModifier = Modifier.draggableHandle(
+                                    onDragStarted = { dragStartIndex.intValue = index },
+                                    onDragStopped = {
+                                        val from = dragStartIndex.intValue
+                                        dragStartIndex.intValue = -1
+                                        val to = queue.indexOfFirst { it.id == episode.id }
+                                        if (from != -1 && to != -1) actions.onDragEnd(episode.id, from, to)
+                                    }
+                                )
+                            ),
                             colorScheme = colorScheme,
-                            onClick = { onPlayEpisode(episode) },
-                            onRemove = { onRemoveEpisode(episode) },
-                            sourceLabel = queueSourceLabel(episode),
-                            isDragging = isDragging,
-                            dragHandleModifier = Modifier.draggableHandle(
-                                onDragStarted = { dragStartIndex.intValue = index },
-                                onDragStopped = {
-                                    val from = dragStartIndex.intValue
-                                    dragStartIndex.intValue = -1
-                                    val to = queue.indexOfFirst { it.id == episode.id }
-                                    if (from != -1 && to != -1) onDragEnd(episode.id, from, to)
-                                }
-                            )
+                            onClick = { actions.onPlayEpisode(episode) },
+                            onRemove = { actions.onRemoveEpisode(episode) }
                         )
                     }
                 }
@@ -158,21 +172,19 @@ fun QueueSheetContent(
 
 @Composable
 fun QueueItemRow(
-    episode: Episode,
-    podcast: Podcast?,
+    display: QueueItemDisplay,
     colorScheme: ColorScheme,
     onClick: () -> Unit,
     onRemove: (() -> Unit)? = null,
-    sourceLabel: String? = null,
-    isDragging: Boolean = false,
-    dragHandleModifier: Modifier? = null,
     modifier: Modifier = Modifier
 ) {
+    val episode = display.episode
+    val podcast = display.podcast
     Row(
         modifier = modifier
             .fillMaxWidth()
             .background(
-                if (isDragging) colorScheme.surfaceVariant.copy(alpha = 0.6f)
+                if (display.isDragging) colorScheme.surfaceVariant.copy(alpha = 0.6f)
                 else colorScheme.surface.copy(alpha = 0f)
             )
             .expressiveClickable { onClick() }
@@ -210,7 +222,7 @@ fun QueueItemRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
-            if (sourceLabel != null) {
+            display.sourceLabel?.let { sourceLabel ->
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = sourceLabel,
@@ -222,7 +234,6 @@ fun QueueItemRow(
             }
         }
         
-        // Remove button
         if (onRemove != null) {
             IconButton(
                 onClick = onRemove,
@@ -237,8 +248,7 @@ fun QueueItemRow(
             }
         }
 
-        // Drag-to-reorder handle
-        if (dragHandleModifier != null) {
+        display.dragHandleModifier?.let { dragHandleModifier ->
             Icon(
                 Icons.Rounded.DragHandle,
                 contentDescription = "Reorder",

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/QueueScreen.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/QueueScreen.kt
@@ -3,10 +3,14 @@ package cx.aswin.boxcast.feature.player
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -19,9 +23,33 @@ import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
 import androidx.compose.foundation.background
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 /**
- * Queue bottom sheet content: header with close button + scrollable queue list.
+ * Small caption explaining why an item is in the queue, derived from the provenance
+ * persisted on each queue row (contextType + contextSourceId).
+ */
+internal fun queueSourceLabel(episode: Episode): String? = when (episode.contextType) {
+    "LORE" -> "From Lore"
+    "AUTO_FILL" -> when (episode.contextSourceId) {
+        "same_podcast" -> "Continuing series"
+        "resume" -> "Pick up where you left off"
+        "subscription" -> "From your subscriptions"
+        "server_rec" -> "Recommended for you"
+        "trending" -> episode.podcastGenre
+            ?.takeIf { it.isNotBlank() && it != "Podcast" }
+            ?.let { "Trending in $it" } ?: "Trending now"
+        else -> "Added for you"
+    }
+    else -> null // MANUAL and unknown rows get no label
+}
+
+/**
+ * Queue bottom sheet content: header with close button + drag-to-reorder queue list.
+ *
+ * Indices in [onMove]/[onDragEnd] are UI list indices — the currently playing episode
+ * is hidden from this sheet, so callers must map them with QueueMath.uiIndexToQueueIndex.
  */
 @Composable
 fun QueueSheetContent(
@@ -31,6 +59,8 @@ fun QueueSheetContent(
     onPlayEpisode: (Episode) -> Unit,
     onRemoveEpisode: (Episode) -> Unit,
     onClose: () -> Unit,
+    onMove: (fromUiIndex: Int, toUiIndex: Int) -> Unit = { _, _ -> },
+    onDragEnd: (episodeId: String, fromUiIndex: Int, toUiIndex: Int) -> Unit = { _, _, _ -> },
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
@@ -86,18 +116,38 @@ fun QueueSheetContent(
                 )
             }
         } else {
+            val lazyListState = rememberLazyListState()
+            // Where the active drag started, so drag-end can report from -> to once.
+            val dragStartIndex = remember { mutableIntStateOf(-1) }
+            val reorderableState = rememberReorderableLazyListState(lazyListState) { from, to ->
+                onMove(from.index, to.index)
+            }
             LazyColumn(
+                state = lazyListState,
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(bottom = 32.dp)
             ) {
-                itemsIndexed(queue, key = { index, episode -> "${episode.id}_$index" }) { _, episode ->
-                    QueueItemRow(
-                        episode = episode,
-                        podcast = currentPodcast,
-                        colorScheme = colorScheme,
-                        onClick = { onPlayEpisode(episode) },
-                        onRemove = { onRemoveEpisode(episode) }
-                    )
+                itemsIndexed(queue, key = { _, episode -> episode.id }) { index, episode ->
+                    ReorderableItem(reorderableState, key = episode.id) { isDragging ->
+                        QueueItemRow(
+                            episode = episode,
+                            podcast = currentPodcast,
+                            colorScheme = colorScheme,
+                            onClick = { onPlayEpisode(episode) },
+                            onRemove = { onRemoveEpisode(episode) },
+                            sourceLabel = queueSourceLabel(episode),
+                            isDragging = isDragging,
+                            dragHandleModifier = Modifier.draggableHandle(
+                                onDragStarted = { dragStartIndex.intValue = index },
+                                onDragStopped = {
+                                    val from = dragStartIndex.intValue
+                                    dragStartIndex.intValue = -1
+                                    val to = queue.indexOfFirst { it.id == episode.id }
+                                    if (from != -1 && to != -1) onDragEnd(episode.id, from, to)
+                                }
+                            )
+                        )
+                    }
                 }
             }
         }
@@ -111,11 +161,18 @@ fun QueueItemRow(
     colorScheme: ColorScheme,
     onClick: () -> Unit,
     onRemove: (() -> Unit)? = null,
+    sourceLabel: String? = null,
+    isDragging: Boolean = false,
+    dragHandleModifier: Modifier? = null,
     modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .background(
+                if (isDragging) colorScheme.surfaceVariant.copy(alpha = 0.6f)
+                else colorScheme.surface.copy(alpha = 0f)
+            )
             .expressiveClickable { onClick() }
             .padding(start = 20.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -151,6 +208,16 @@ fun QueueItemRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
+            if (sourceLabel != null) {
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = sourceLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = colorScheme.primary.copy(alpha = 0.85f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
         
         // Remove button
@@ -166,6 +233,18 @@ fun QueueItemRow(
                     modifier = Modifier.size(18.dp)
                 )
             }
+        }
+
+        // Drag-to-reorder handle
+        if (dragHandleModifier != null) {
+            Icon(
+                Icons.Rounded.DragHandle,
+                contentDescription = "Reorder",
+                tint = colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                modifier = dragHandleModifier
+                    .size(40.dp)
+                    .padding(8.dp)
+            )
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,8 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version = "1.7.3" }
 kotlinx-coroutines-guava = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-guava", version = "1.7.3" }
 smooth-corner-rect = { group = "com.github.racra", name = "smooth-corner-rect-android-compose", version = "v1.0.0" }
+reorderable = { group = "sh.calvin.reorderable", name = "reorderable", version = "2.5.1" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version = "1.7.3" }
 
 # Firebase
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }


### PR DESCRIPTION
## Summary

Rewrites the queue auto-refill system into a tiered, offline-first engine that batches 3–5 relevant episodes per refill, learns from user rejections, respects region, and unifies all refill paths behind a single service-side guard. Also adds Lore queue independence, drag-to-reorder, source labels, undo-remove, and analytics.

**Post-review refinements (latest commit):**
- **Signal-aware Tier 3:** warm users → `/recommendations` (`personalized_rec`); cold users → `/episodes/similar` on the current episode; skip Tier 3 when metadata is missing
- **Tier 3.5 guard:** skip liked-similar boost when Tier 3 already used episode-similar (avoids duplicate similar calls)
- **Tier 0 newest-sort fix:** episodic/news only queue episodes *newer* than current — no archive rewind on latest episode
- **Discovery landing guard:** skip Tier 0 deep continuation when playing resume/rec/similar/trending/subscription refills (prevents queue bloat after one suggested episode)
- **Queue labels:** provenance-style captions (`Based on what you're playing`, `Based on something you liked`) instead of button-like copy

## Engine (`DefaultSmartQueueEngine`)

- **Tier 0:** Same-podcast continuation (serial/oldest chronological, news/episodic newest-forward; skips completed + trailers; skipped on discovery landings)
- **Tier 1:** Resume nudge (10–90% progress, last 30 days, max 1 per batch)
- **Tier 2:** Scored subscriptions via `PodcastScoring` (round-robin variety)
- **Tier 3:** Signal-aware network pick — personalized recs (warm) or episode-similar (cold) when local tiers are thin
- **Tier 3.5:** Liked-episode similar boost (skipped if Tier 3 already used similar)
- **Tier 4:** Region-aware trending fallback
- **Briefing:** Skips same-show tier; prefers short follow-ups; trending uses News genre
- **`QueueSkipMemory`:** Never re-suggests skipped/removed AUTO_FILL episodes; down-ranks podcasts with 2+ recent skips

```mermaid
flowchart TD
    T0[Tier 0: Same podcast] -->|≥3 items| DONE[Return batch]
    T0 -->|thin| T1[Tier 1: Resume]
    T1 --> T2[Tier 2: Scored subscriptions]
    T2 -->|≥3 items| DONE
    T2 -->|still thin| T3{Tier 3: Signal-aware}
    T3 -->|warm history| REC["GET /recommendations"]
    T3 -->|cold + metadata| SIM["GET /episodes/similar"]
    T3 -->|no signal| SKIP[Skip Tier 3]
    REC --> T35{Tier 3.5: Liked similar?}
    SIM --> T4[Tier 4: Region trending]
    SKIP --> T35
    T35 -->|not already similar| LIKED[Liked-episode similar]
    T35 -->|already similar| T4
    LIKED --> T4
    T4 --> DONE
```

## Refill orchestration

- Removed `QueueManager.refillQueue()` and `PlaybackRepository.queueRefillCallback` — **single refill path** in `BoxLorePlaybackService`
- Android Auto `buildAndAppendQueueAsync` routed through the same engine + `isRefilling` guard
- Sleep-timer end-of-episode guard skips refill
- Persist-before-append with `AUTO_FILL` + tier `contextSourceId` provenance
- Passes current episode `contextSourceId` into engine to gate Tier 0
- `PlaybackRepository.reconcileQueueWithController()` keeps UI in sync when service appends

## Lore queue independence

- Lore items persisted with `contextType = LORE`
- Swipe-to-queue from Lore screen shows conflict dialog when a normal queue exists
- "Start Lore queue" clears normal queue; episode-info "Add to Queue" unchanged

## Queue UX

- Drag-to-reorder in queue sheet (`sh.calvin.reorderable`)
- Source labels per row (Continuing series, Recommended for you, Based on what you're playing, etc.)
- Undo snackbar on remove (deferred skip-memory recording)
- `moveQueueItem` + debounced `persistQueueOrder` sync Media3 / PlayerState / Room

## Analytics

- Extended `smart_queue_refilled` (region, per-tier counts, `used_server_recommendations`)
- Added `queue_reordered`, `lore_queue_conflict_shown`, `lore_queue_conflict_result`

## Tests (43+ JVM tests)

- `SmartQueueEngineTest` — tier fallthrough, sort modes, signal-aware Tier 3, discovery landing guard, region, skip memory, briefing, batch invariants
- `QueueSkipMemoryTest` — expiry, cap, down-rank counting
- `QueueMathTest` — UI/queue index mapping, Lore detection, prefix stripping

## Test plan

- [ ] Binge a serial show — Tier 0 fills with "Continuing series", no network calls
- [ ] Episodic/newest on latest episode — no older episodes queued behind
- [ ] Cold account refill — queue shows "Based on what you're playing", not "Recommended for you"
- [ ] Warm account refill — "Recommended for you" for personalized picks
- [ ] Auto-advance into trending/rec/resume episode — next refill stays mixed variety (no show backfill)
- [ ] Intentional binge (manual or same-podcast) — Tier 0 still deep-continues
- [ ] Remove AUTO_FILL row — undo snackbar; skipped episode not re-suggested
- [ ] Drag reorder in queue sheet — order persists after close/reopen
- [ ] Lore swipe-to-queue with existing queue — conflict dialog
- [ ] Sleep timer end-of-episode — no refill at episode end