### PR TITLE
chore: gitignore Python bytecode cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ local.properties
 # Node
 node_modules/
 
+# Python
+__pycache__/
+*.py[cod]
+
 # Firebase (client config — keep local only; workflows use FCM_SERVICE_ACCOUNT_KEY)
 app/google-services.json
 .firebase/


### PR DESCRIPTION
## Summary

- Adds `__pycache__/` and `*.py[cod]` to `.gitignore` so compiled Python artifacts (e.g. from running `.github/scripts/update_changelog.py` locally) are not accidentally committed
- Deletes stale cloud-agent branch `cursor/cloud-agent-1783765887113-w3w79` (it only contained a `.pyc` file; the actual changelog script changes are already on `master` in `934011e`)

## Test plan

- [ ] Confirm `.gitignore` covers `__pycache__/` and `.pyc` files
- [ ] No runtime/build impact (ignore-only change)

Made with [Cursor](https://cursor.com)