### PR TITLE
feat(ui): redesign Lore and sharing experiences

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,14 @@
     <!-- Included to satisfy Google Play Console Advertising ID declaration requirements -->
     <uses-permission android:name="com.google.android.gms.permission.AD_ID" />
 
+    <queries>
+        <package android:name="com.instagram.android" />
+        <intent>
+            <action android:name="com.instagram.share.ADD_TO_STORY" />
+            <data android:mimeType="image/*" />
+        </intent>
+    </queries>
+
     <application
         android:name=".BoxLoreApplication"
         android:allowBackup="true"

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -482,42 +482,6 @@ class MainActivity : ComponentActivity() {
                 queueManager.addToQueue(episode, podcast, cx.aswin.boxcast.core.model.PlaybackEntryPoint.LEARN)
             }
 
-            loreQueueConflictEpisode?.let { pendingLoreEpisode ->
-                androidx.compose.material3.AlertDialog(
-                    onDismissRequest = {
-                        cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "cancelled")
-                        loreQueueConflictEpisode = null
-                    },
-                    title = { Text("Start a Lore queue?") },
-                    text = {
-                        Text(
-                            "Adding from Lore starts a fresh Lore queue and clears your current queue. " +
-                                "To keep your queue instead, tap the card to open the episode and use \"Add to Queue\" there."
-                        )
-                    },
-                    confirmButton = {
-                        androidx.compose.material3.TextButton(onClick = {
-                            loreQueueConflictEpisode = null
-                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "start_lore_queue")
-                            scope.launch {
-                                try {
-                                    playbackRepository.stopAndClearQueue()
-                                    queueLoreEpisode(pendingLoreEpisode)
-                                } catch (e: Exception) {
-                                    android.util.Log.e("MainActivity", "Failed to start Lore queue", e)
-                                }
-                            }
-                        }) { Text("Start Lore queue") }
-                    },
-                    dismissButton = {
-                        androidx.compose.material3.TextButton(onClick = {
-                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "cancelled")
-                            loreQueueConflictEpisode = null
-                        }) { Text("Cancel") }
-                    }
-                )
-            }
-
             val smartDownloadManager = remember {
                 cx.aswin.boxcast.core.data.SmartDownloadManager(
                     context = application,
@@ -817,6 +781,79 @@ class MainActivity : ComponentActivity() {
                 themeBrand = themeBrand,
                 surfaceStyle = surfaceStyle
             ) {
+                loreQueueConflictEpisode?.let { pendingLoreEpisode ->
+                    androidx.compose.material3.AlertDialog(
+                        onDismissRequest = {
+                            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "cancelled")
+                            loreQueueConflictEpisode = null
+                        },
+                        icon = {
+                            Surface(
+                                shape = CircleShape,
+                                color = MaterialTheme.colorScheme.tertiaryContainer
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Warning,
+                                    contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                                    modifier = Modifier.padding(12.dp).size(24.dp)
+                                )
+                            }
+                        },
+                        title = {
+                            Text(
+                                text = "Start a Lore queue?",
+                                style = MaterialTheme.typography.headlineSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                        },
+                        text = {
+                            Text(
+                                text = "This starts a fresh Lore queue and clears your current queue. " +
+                                    "To keep it, open the episode and use Add to Queue instead.",
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                        },
+                        confirmButton = {
+                            androidx.compose.material3.FilledTonalButton(
+                                onClick = {
+                                    loreQueueConflictEpisode = null
+                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "start_lore_queue")
+                                    scope.launch {
+                                        try {
+                                            playbackRepository.stopAndClearQueue()
+                                            queueLoreEpisode(pendingLoreEpisode)
+                                        } catch (e: Exception) {
+                                            android.util.Log.e("MainActivity", "Failed to start Lore queue", e)
+                                        }
+                                    }
+                                },
+                                shape = CircleShape
+                            ) {
+                                Text("Start Lore queue")
+                            }
+                        },
+                        dismissButton = {
+                            androidx.compose.material3.TextButton(
+                                onClick = {
+                                    cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackLoreQueueConflictResult(pendingLoreEpisode.id, "cancelled")
+                                    loreQueueConflictEpisode = null
+                                },
+                                colors = ButtonDefaults.textButtonColors(
+                                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            ) {
+                                Text("Keep current queue")
+                            }
+                        },
+                        shape = MaterialTheme.shapes.extraLarge,
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        iconContentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                        titleContentColor = MaterialTheme.colorScheme.onSurface,
+                        textContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
                 // Show Announcement Dialog if onboarding is completed
                 if (onboardingCompleted && activeAnnouncement != null) {
                     val announcement = activeAnnouncement!!

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ShareManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ShareManager.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import androidx.core.graphics.drawable.toBitmap
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
+import cx.aswin.boxcast.core.model.ShareLinkBuilder
+import cx.aswin.boxcast.core.model.ShareTarget
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -15,15 +17,25 @@ object ShareManager {
 
     private val shareScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     
-    fun sharePodcast(context: Context, podcast: Podcast) {
-        val shareUrl = "https://aswin.cx/boxlore/share?type=podcast&id=${podcast.id}"
-        val shareText = "*Listen to ${podcast.title} on BoxLore*:\n$shareUrl"
+    fun sharePodcast(
+        context: Context,
+        podcast: Podcast,
+        target: ShareTarget = ShareTarget.MESSAGE
+    ) {
+        val shareUrl = ShareLinkBuilder.podcast(podcast.id)
+        val creator = podcast.artist.takeIf { it.isNotBlank() }?.let { "\n$it" }.orEmpty()
+        val shareText = "I think you'll like this podcast:\n\n" +
+            "${podcast.title}$creator\n\nListen on boxlore:\n$shareUrl"
         
         shareWithCompositeImage(
             context = context,
             text = shareText,
+            shareUrl = shareUrl,
             title = "Share Podcast",
-            imageUrl = podcast.imageUrl
+            cardTitle = podcast.title,
+            cardSubtitle = podcast.artist,
+            imageUrl = podcast.imageUrl,
+            target = target
         )
     }
 
@@ -33,47 +45,56 @@ object ShareManager {
         podcastTitle: String,
         timestampMs: Long? = null,
         startMs: Long? = null,
-        endMs: Long? = null
+        endMs: Long? = null,
+        target: ShareTarget = ShareTarget.MESSAGE
     ) {
-        val baseUrl = "https://aswin.cx/boxlore/share?type=episode&id=${episode.id}"
-        
-        val shareUrl = when {
+        val shareUrl = ShareLinkBuilder.episode(
+            id = episode.id,
+            timestampMs = timestampMs,
+            startMs = startMs,
+            endMs = endMs
+        )
+
+        val timeContext = when {
             startMs != null && endMs != null -> {
-                "$baseUrl&start=${startMs / 1000}&end=${endMs / 1000}"
+                "Clip ${formatTime(startMs)}–${formatTime(endMs)}"
             }
             timestampMs != null && timestampMs > 0 -> {
-                "$baseUrl&t=${timestampMs / 1000}"
+                "Start at ${formatTime(timestampMs)}"
             }
-            else -> baseUrl
+            else -> null
         }
 
-        val timeSuffix = when {
-            startMs != null && endMs != null -> {
-                " (Clip: ${formatTime(startMs)} - ${formatTime(endMs)})"
-            }
-            timestampMs != null && timestampMs > 0 -> {
-                " (at ${formatTime(timestampMs)})"
-            }
-            else -> ""
-        }
-
-        val shareText = "*Listen to \"${episode.title}\" from $podcastTitle$timeSuffix on BoxLore*:\n$shareUrl"
+        val contextLine = listOfNotNull(
+            podcastTitle.takeIf { it.isNotBlank() },
+            timeContext
+        ).joinToString(" • ")
+        val shareText = "This episode is worth a listen:\n\n" +
+            "“${episode.title}”\n$contextLine\n\nListen on boxlore:\n$shareUrl"
         
         shareWithCompositeImage(
             context = context,
             text = shareText,
+            shareUrl = shareUrl,
             title = "Share Episode",
+            cardTitle = episode.title,
+            cardSubtitle = podcastTitle,
             imageUrl = episode.imageUrl,
-            fallbackImageUrl = episode.podcastImageUrl
+            fallbackImageUrl = episode.podcastImageUrl,
+            target = target
         )
     }
 
     private fun shareWithCompositeImage(
         context: Context,
         text: String,
+        shareUrl: String,
         title: String,
+        cardTitle: String,
+        cardSubtitle: String,
         imageUrl: String?,
-        fallbackImageUrl: String? = null
+        fallbackImageUrl: String? = null,
+        target: ShareTarget
     ) {
         shareScope.launch {
             var sharedUri: android.net.Uri? = null
@@ -90,26 +111,25 @@ object ShareManager {
                     val originalBitmap = (result as? coil.request.SuccessResult)?.drawable?.toBitmap()
                     
                     if (originalBitmap != null) {
-                        val width = originalBitmap.width
-                        val height = originalBitmap.height
-                        val mutableBitmap = originalBitmap.copy(android.graphics.Bitmap.Config.ARGB_8888, true)
-                        val canvas = android.graphics.Canvas(mutableBitmap)
-                        
-                        val (adjustedBgColor, logoColor) = resolveContrastColors(originalBitmap)
-                        
-                        drawCustomBadge(
+                        val shareCard = createShareCard(
                             context = context,
-                            canvas = canvas,
-                            width = width,
-                            height = height,
-                            adjustedBgColor = adjustedBgColor,
-                            logoColor = logoColor
+                            artwork = originalBitmap,
+                            title = cardTitle,
+                            subtitle = cardSubtitle,
+                            target = target
                         )
-                        
-                        // Save bitmap to cache directory
-                        val cacheFile = java.io.File(context.cacheDir, "shared_artwork.jpg")
+                        clearExpiredShareCards(context)
+                        val formatName = if (target == ShareTarget.INSTAGRAM_STORY) {
+                            "story"
+                        } else {
+                            "message"
+                        }
+                        val cacheFile = java.io.File(
+                            context.cacheDir,
+                            "boxlore_share_${formatName}_${System.currentTimeMillis()}.png"
+                        )
                         java.io.FileOutputStream(cacheFile).use { out ->
-                            mutableBitmap.compress(android.graphics.Bitmap.CompressFormat.JPEG, 90, out)
+                            shareCard.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)
                         }
                         
                         sharedUri = androidx.core.content.FileProvider.getUriForFile(
@@ -124,23 +144,102 @@ object ShareManager {
             }
             
             withContext(Dispatchers.Main) {
-                val intent = Intent(Intent.ACTION_SEND).apply {
-                    if (sharedUri != null) {
-                        type = "image/jpeg"
-                        putExtra(Intent.EXTRA_STREAM, sharedUri)
-                        putExtra(Intent.EXTRA_TEXT, text)
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    } else {
-                        type = "text/plain"
-                        putExtra(Intent.EXTRA_TEXT, text)
+                val openedInstagram = if (
+                    target == ShareTarget.INSTAGRAM_STORY &&
+                    sharedUri != null
+                ) {
+                    openInstagramStory(
+                        context = context,
+                        imageUri = sharedUri,
+                        shareUrl = shareUrl
+                    )
+                } else {
+                    false
+                }
+
+                if (!openedInstagram) {
+                    if (target == ShareTarget.INSTAGRAM_STORY) {
+                        android.widget.Toast.makeText(
+                            context,
+                            "Instagram isn't available — choose another app",
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
                     }
+                    openShareSheet(
+                        context = context,
+                        imageUri = sharedUri,
+                        text = text,
+                        chooserTitle = title
+                    )
                 }
-                val chooser = Intent.createChooser(intent, title).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-                context.startActivity(chooser)
             }
         }
+    }
+
+    private fun openShareSheet(
+        context: Context,
+        imageUri: android.net.Uri?,
+        text: String,
+        chooserTitle: String
+    ) {
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            if (imageUri != null) {
+                type = "image/png"
+                putExtra(Intent.EXTRA_STREAM, imageUri)
+                clipData = android.content.ClipData.newRawUri("boxlore share card", imageUri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            } else {
+                type = "text/plain"
+            }
+            putExtra(Intent.EXTRA_TEXT, text)
+            putExtra(Intent.EXTRA_TITLE, chooserTitle)
+        }
+        context.startActivity(
+            Intent.createChooser(intent, chooserTitle).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        )
+    }
+
+    private fun openInstagramStory(
+        context: Context,
+        imageUri: android.net.Uri,
+        shareUrl: String
+    ): Boolean {
+        val instagramPackage = "com.instagram.android"
+        val intent = Intent("com.instagram.share.ADD_TO_STORY").apply {
+            setDataAndType(imageUri, "image/png")
+            setPackage(instagramPackage)
+            clipData = android.content.ClipData.newRawUri("boxlore Story", imageUri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (intent.resolveActivity(context.packageManager) == null) return false
+
+        context.grantUriPermission(
+            instagramPackage,
+            imageUri,
+            Intent.FLAG_GRANT_READ_URI_PERMISSION
+        )
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE)
+            as android.content.ClipboardManager
+        clipboard.setPrimaryClip(
+            android.content.ClipData.newPlainText("boxlore link", shareUrl)
+        )
+        android.widget.Toast.makeText(
+            context,
+            "Link copied — add it with Instagram's Link sticker",
+            android.widget.Toast.LENGTH_LONG
+        ).show()
+        context.startActivity(intent)
+        return true
+    }
+
+    private fun clearExpiredShareCards(context: Context) {
+        val expiry = System.currentTimeMillis() - (24 * 60 * 60 * 1000L)
+        context.cacheDir.listFiles()
+            ?.filter { it.name.startsWith("boxlore_share_") && it.lastModified() < expiry }
+            ?.forEach { it.delete() }
     }
 
     private fun formatTime(ms: Long): String {
@@ -155,163 +254,396 @@ object ShareManager {
         }
     }
 
-    private fun getRelativeLuminance(color: Int): Double {
-        val r = android.graphics.Color.red(color) / 255.0
-        val g = android.graphics.Color.green(color) / 255.0
-        val b = android.graphics.Color.blue(color) / 255.0
-        
-        val rL = if (r <= 0.03928) r / 12.92 else Math.pow((r + 0.055) / 1.055, 2.4)
-        val gL = if (g <= 0.03928) g / 12.92 else Math.pow((g + 0.055) / 1.055, 2.4)
-        val bL = if (b <= 0.03928) b / 12.92 else Math.pow((b + 0.055) / 1.055, 2.4)
-        
-        return 0.2126 * rL + 0.7152 * gL + 0.0722 * bL
-    }
+    private fun createShareCard(
+        context: Context,
+        artwork: android.graphics.Bitmap,
+        title: String,
+        subtitle: String,
+        target: ShareTarget
+    ): android.graphics.Bitmap {
+        val isStory = target == ShareTarget.INSTAGRAM_STORY
+        val width = if (isStory) 1080 else 1200
+        val height = if (isStory) 1920 else 1200
+        val output = android.graphics.Bitmap.createBitmap(
+            width,
+            height,
+            android.graphics.Bitmap.Config.ARGB_8888
+        )
+        val canvas = android.graphics.Canvas(output)
+        canvas.drawColor(android.graphics.Color.parseColor("#2E2DD0"))
+        drawShareCardShapes(
+            canvas = canvas,
+            width = width.toFloat(),
+            height = height.toFloat(),
+            isStory = isStory
+        )
 
-    private fun resolveContrastColors(bitmap: android.graphics.Bitmap): Pair<Int, Int> {
-        val palette = androidx.palette.graphics.Palette.from(bitmap).generate()
-        val swatch = palette.dominantSwatch ?: palette.vibrantSwatch ?: palette.mutedSwatch
-        val bgColor = swatch?.rgb ?: android.graphics.Color.parseColor("#0F0C20")
-        
-        val bgLuminance = getRelativeLuminance(bgColor)
-        val darkColorVal = android.graphics.Color.parseColor("#0F0C20")
-        val darkLuminance = getRelativeLuminance(darkColorVal)
-        
-        val contrastWithWhite = (1.0 + 0.05) / (bgLuminance + 0.05)
-        val contrastWithDark = (bgLuminance + 0.05) / (darkLuminance + 0.05)
-        
-        var logoColor = android.graphics.Color.WHITE
-        var adjustedBgColor = bgColor
-        
-        if (contrastWithWhite >= contrastWithDark) {
-            logoColor = android.graphics.Color.WHITE
-            if (contrastWithWhite < 4.5) {
-                val hsl = FloatArray(3)
-                androidx.core.graphics.ColorUtils.colorToHSL(bgColor, hsl)
-                hsl[2] = (hsl[2] - 0.15f).coerceAtLeast(0.12f)
-                adjustedBgColor = androidx.core.graphics.ColorUtils.HSLToColor(hsl)
-            }
+        val artworkSize = if (isStory) 760f else 680f
+        val artworkTop = if (isStory) 290f else 55f
+        val artworkRect = android.graphics.RectF(
+            (width - artworkSize) / 2f,
+            artworkTop,
+            (width + artworkSize) / 2f,
+            artworkTop + artworkSize
+        )
+        drawRoundedArtwork(
+            canvas = canvas,
+            artwork = artwork,
+            destination = artworkRect,
+            cornerRadius = 72f
+        )
+
+        if (isStory) {
+            val textBottom = drawShareText(
+                context = context,
+                canvas = canvas,
+                canvasWidth = width,
+                title = title,
+                subtitle = subtitle,
+                titleTop = 1_110f,
+                titleWidth = 860,
+                titleSize = 60f,
+                subtitleSize = 44f,
+                blockSpacing = 13f
+            )
+            drawShareBranding(
+                context = context,
+                canvas = canvas,
+                canvasWidth = width,
+                brandingTop = textBottom + 44f,
+                brandingLabelSize = 34f,
+                logoWidth = 480,
+                listenNowGap = 22f,
+                listenNowSize = 32f
+            )
         } else {
-            logoColor = darkColorVal
-            if (contrastWithDark < 4.5) {
-                val hsl = FloatArray(3)
-                androidx.core.graphics.ColorUtils.colorToHSL(bgColor, hsl)
-                hsl[2] = (hsl[2] + 0.15f).coerceAtMost(0.88f)
-                adjustedBgColor = androidx.core.graphics.ColorUtils.HSLToColor(hsl)
-            }
+            val textBottom = drawShareText(
+                context = context,
+                canvas = canvas,
+                canvasWidth = width,
+                title = title,
+                subtitle = subtitle,
+                titleTop = 785f,
+                titleWidth = 960,
+                titleSize = 48f,
+                subtitleSize = 36f,
+                blockSpacing = 8f
+            )
+            drawShareBranding(
+                context = context,
+                canvas = canvas,
+                canvasWidth = width,
+                brandingTop = textBottom + 30f,
+                brandingLabelSize = 28f,
+                logoWidth = 400,
+                listenNowGap = 17f,
+                listenNowSize = 28f
+            )
         }
-        return Pair(adjustedBgColor, logoColor)
+
+        return output
     }
 
-    private fun drawCustomBadge(
+    private fun drawShareCardShapes(
+        canvas: android.graphics.Canvas,
+        width: Float,
+        height: Float,
+        isStory: Boolean
+    ) {
+        val paint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+            color = android.graphics.Color.parseColor("#5B5BDF")
+            alpha = 185
+            style = android.graphics.Paint.Style.FILL
+        }
+
+        drawExpressiveShape(
+            canvas = canvas,
+            type = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.DecorativeType.Puffy,
+            left = width - if (isStory) 345f else 315f,
+            top = if (isStory) -145f else -165f,
+            size = if (isStory) 500f else 455f,
+            rotation = 14f,
+            paint = paint
+        )
+        drawExpressiveShape(
+            canvas = canvas,
+            type = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.DecorativeType.PuffyDiamond,
+            left = if (isStory) -195f else -155f,
+            top = if (isStory) 710f else height * 0.35f,
+            size = if (isStory) 390f else 320f,
+            rotation = -18f,
+            paint = paint.apply { alpha = 155 }
+        )
+        drawExpressiveShape(
+            canvas = canvas,
+            type = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.DecorativeType.Cookie4,
+            left = if (isStory) -120f else -100f,
+            top = if (isStory) 35f else -20f,
+            size = if (isStory) 390f else 325f,
+            rotation = -24f,
+            paint = paint.apply { alpha = 130 }
+        )
+        drawExpressiveShape(
+            canvas = canvas,
+            type = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.DecorativeType.SoftBurst,
+            left = width - if (isStory) 230f else 195f,
+            top = if (isStory) 710f else 530f,
+            size = if (isStory) 430f else 370f,
+            rotation = 20f,
+            paint = paint.apply { alpha = 180 }
+        )
+    }
+
+    private fun drawExpressiveShape(
+        canvas: android.graphics.Canvas,
+        type: cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.DecorativeType,
+        left: Float,
+        top: Float,
+        size: Float,
+        rotation: Float,
+        paint: android.graphics.Paint
+    ) {
+        val path = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.androidPath(
+            type = type,
+            width = size,
+            height = size
+        )
+        canvas.save()
+        canvas.translate(left, top)
+        canvas.rotate(rotation, size / 2f, size / 2f)
+        canvas.drawPath(path, paint)
+        canvas.restore()
+    }
+
+    private fun drawShareBranding(
         context: Context,
         canvas: android.graphics.Canvas,
-        width: Int,
-        height: Int,
-        adjustedBgColor: Int,
-        logoColor: Int
+        canvasWidth: Int,
+        brandingTop: Float,
+        brandingLabelSize: Float,
+        logoWidth: Int,
+        listenNowGap: Float,
+        listenNowSize: Float
     ) {
-        val googleSansTypeface = try {
-            val baseFont = androidx.core.content.res.ResourcesCompat.getFont(
-                context,
-                cx.aswin.boxcast.core.designsystem.R.font.google_sans_variable
-            )
-            if (baseFont != null) {
-                android.graphics.Typeface.create(baseFont, android.graphics.Typeface.BOLD)
-            } else {
-                android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.BOLD)
+        val brandingLeft = (canvasWidth - logoWidth) / 2f
+        val brandingRight = brandingLeft + logoWidth
+        val textPaint = android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+            color = android.graphics.Color.WHITE
+            textSize = brandingLabelSize
+            typeface = googleSansTypeface(context, android.graphics.Typeface.BOLD)
+        }
+        val label = "is better on"
+        val labelBaseline = brandingTop - textPaint.fontMetrics.ascent
+        canvas.drawText(label, brandingLeft, labelBaseline, textPaint)
+
+        val waveStart = brandingLeft + textPaint.measureText(label) + 20f
+        val waveCenter = brandingTop + (
+            textPaint.fontMetrics.descent - textPaint.fontMetrics.ascent
+            ) / 2f
+        if (brandingRight > waveStart) {
+            val path = android.graphics.Path()
+            val amplitude = 9f
+            val wavelength = 72f
+            var x = waveStart
+            path.moveTo(x, waveCenter)
+            while (x < brandingRight) {
+                x = (x + 3f).coerceAtMost(brandingRight)
+                val y = waveCenter + amplitude * kotlin.math.sin(
+                    ((x - waveStart) / wavelength) * 2f * kotlin.math.PI.toFloat()
+                )
+                path.lineTo(x, y)
             }
-        } catch (e: Exception) {
-            android.graphics.Typeface.create("sans-serif", android.graphics.Typeface.BOLD)
+            canvas.drawPath(
+                path,
+                android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+                    color = android.graphics.Color.WHITE
+                    style = android.graphics.Paint.Style.STROKE
+                    strokeWidth = 4f
+                    strokeCap = android.graphics.Paint.Cap.ROUND
+                    strokeJoin = android.graphics.Paint.Join.ROUND
+                }
+            )
         }
-        
-        val text = "listen on"
-        
-        val targetTextSize = (height * 0.0396f).coerceAtLeast(20f)
-        val targetLogoHeight = (height * 0.077f).coerceAtLeast(38f)
-        
-        val textPaint = android.graphics.Paint().apply {
-            color = logoColor
-            textSize = targetTextSize
-            typeface = googleSansTypeface
-            isAntiAlias = true
-        }
-        
-        val fontMetrics = textPaint.fontMetrics
-        val textHeight = fontMetrics.descent - fontMetrics.ascent
-        
-        var paddingTop = targetTextSize * 0.35f
-        var paddingBottom = targetLogoHeight * 0.20f
-        var spacing = targetLogoHeight * 0.12f
-        
-        var pillHeight = paddingTop + textHeight + spacing + targetLogoHeight + paddingBottom
-        var logoHeight = targetLogoHeight
-        
-        var logoWidth = logoHeight * (778f / 112f)
-        var radius = pillHeight * 0.40f
-        
-        var paddingLeft = radius + logoHeight * 0.10f
-        var paddingRight = logoHeight * 0.30f
-        var textWidth = textPaint.measureText(text)
-        var maxContentWidth = maxOf(textWidth, logoWidth)
-        var pillWidth = maxContentWidth + paddingLeft + paddingRight
-        
-        if (pillWidth > width * 0.9f) {
-            val scale = (width * 0.9f) / pillWidth
-            val finalScale = scale.coerceAtLeast(0.5f)
-            
-            pillHeight *= finalScale
-            textPaint.textSize = textPaint.textSize * finalScale
-            logoHeight *= finalScale
-            logoWidth = logoHeight * (778f / 112f)
-            paddingLeft *= finalScale
-            paddingRight *= finalScale
-            paddingTop *= finalScale
-            paddingBottom *= finalScale
-            spacing *= finalScale
-            
-            // Recalculate text metrics after scaling
-            textPaint.fontMetrics
-            textWidth = textPaint.measureText(text)
-            maxContentWidth = maxOf(textWidth, logoWidth)
-            pillWidth = maxContentWidth + paddingLeft + paddingRight
-        }
-        
-        val pillLeft = width - pillWidth
-        
-        val paintBack = android.graphics.Paint().apply {
-            color = adjustedBgColor
-            style = android.graphics.Paint.Style.FILL
-            isAntiAlias = true
-        }
-        
-        val path = android.graphics.Path().apply {
-            moveTo(pillLeft, height.toFloat()) // bottom-left of badge
-            lineTo(pillLeft, height - pillHeight + radius) // start of top-left curve
-            quadTo(pillLeft, height - pillHeight, pillLeft + radius, height - pillHeight) // top-left curve
-            lineTo(width.toFloat(), height - pillHeight) // top-right (sharp)
-            lineTo(width.toFloat(), height.toFloat()) // bottom-right (sharp)
-            close()
-        }
-        canvas.drawPath(path, paintBack)
-        
-        val contentEndX = width - paddingRight
-        val textX = contentEndX - textWidth
-        val textY = (height - pillHeight + paddingTop) - fontMetrics.ascent
-        canvas.drawText(text, textX, textY, textPaint)
-        
-        val drawable = androidx.core.content.ContextCompat.getDrawable(
+
+        val labelHeight = textPaint.fontMetrics.descent - textPaint.fontMetrics.ascent
+        val logoTop = (brandingTop + labelHeight + 18f).toInt()
+        val logoHeight = (logoWidth * 110f / 805f).toInt()
+        val logoLeft = (canvasWidth - logoWidth) / 2
+        androidx.core.content.ContextCompat.getDrawable(
             context,
             cx.aswin.boxcast.core.designsystem.R.drawable.ic_boxlore_logo
-        )?.mutate()
-        if (drawable != null) {
-            val logoLeft = contentEndX - logoWidth
-            val logoTop = height - pillHeight + paddingTop + textHeight + spacing
-            val logoRight = contentEndX
-            val logoBottom = logoTop + logoHeight
-            
-            drawable.setBounds(logoLeft.toInt(), logoTop.toInt(), logoRight.toInt(), logoBottom.toInt())
-            drawable.setTint(logoColor)
-            drawable.draw(canvas)
+        )?.mutate()?.apply {
+            setTint(android.graphics.Color.WHITE)
+            setBounds(
+                logoLeft,
+                logoTop,
+                logoLeft + logoWidth,
+                logoTop + logoHeight
+            )
+            draw(canvas)
         }
+        val listenNowTop = logoTop + logoHeight + listenNowGap
+        drawCenteredTextBlock(
+            canvas = canvas,
+            canvasWidth = canvasWidth,
+            text = "listen now",
+            top = listenNowTop,
+            width = logoWidth,
+            textSize = listenNowSize,
+            maxLines = 1,
+            color = android.graphics.Color.parseColor("#DCDCF8"),
+            typeface = googleSansTypeface(context, android.graphics.Typeface.NORMAL)
+        )
     }
+
+    private fun drawShareText(
+        context: Context,
+        canvas: android.graphics.Canvas,
+        canvasWidth: Int,
+        title: String,
+        subtitle: String,
+        titleTop: Float,
+        titleWidth: Int,
+        titleSize: Float,
+        subtitleSize: Float,
+        blockSpacing: Float
+    ): Float {
+        val titleHeight = drawCenteredTextBlock(
+            canvas = canvas,
+            canvasWidth = canvasWidth,
+            text = title,
+            top = titleTop,
+            width = titleWidth,
+            textSize = titleSize,
+            maxLines = 2,
+            color = android.graphics.Color.WHITE,
+            typeface = googleSansTypeface(context, android.graphics.Typeface.BOLD)
+        )
+        var nextTop = titleTop + titleHeight
+        if (subtitle.isNotBlank()) {
+            val bySize = subtitleSize * 0.78f
+            val byTop = nextTop + blockSpacing
+            val byHeight = drawCenteredTextBlock(
+                canvas = canvas,
+                canvasWidth = canvasWidth,
+                text = "by",
+                top = byTop,
+                width = titleWidth,
+                textSize = bySize,
+                maxLines = 1,
+                color = android.graphics.Color.parseColor("#BEBEE8"),
+                typeface = googleSansTypeface(context, android.graphics.Typeface.NORMAL)
+            )
+            val subtitleTop = byTop + byHeight + blockSpacing * 0.5f
+            val subtitleHeight = drawCenteredTextBlock(
+                canvas = canvas,
+                canvasWidth = canvasWidth,
+                text = subtitle,
+                top = subtitleTop,
+                width = titleWidth,
+                textSize = subtitleSize,
+                maxLines = 1,
+                color = android.graphics.Color.parseColor("#DCDCF8"),
+                typeface = googleSansTypeface(context, android.graphics.Typeface.NORMAL)
+            )
+            nextTop = subtitleTop + subtitleHeight
+        }
+        return nextTop
+    }
+
+    private fun drawCenteredTextBlock(
+        canvas: android.graphics.Canvas,
+        canvasWidth: Int,
+        text: String,
+        top: Float,
+        width: Int,
+        textSize: Float,
+        maxLines: Int,
+        color: Int,
+        typeface: android.graphics.Typeface
+    ): Int {
+        val textPaint = android.text.TextPaint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = color
+            this.textSize = textSize
+            this.typeface = typeface
+        }
+        val layout = android.text.StaticLayout.Builder.obtain(
+            text,
+            0,
+            text.length,
+            textPaint,
+            width
+        )
+            .setAlignment(android.text.Layout.Alignment.ALIGN_CENTER)
+            .setIncludePad(false)
+            .setLineSpacing(0f, 1.02f)
+            .setMaxLines(maxLines)
+            .setEllipsize(android.text.TextUtils.TruncateAt.END)
+            .build()
+
+        canvas.save()
+        canvas.translate((canvasWidth - width) / 2f, top)
+        layout.draw(canvas)
+        canvas.restore()
+        return layout.height
+    }
+
+    private fun googleSansTypeface(
+        context: Context,
+        style: Int
+    ): android.graphics.Typeface {
+        val font = androidx.core.content.res.ResourcesCompat.getFont(
+            context,
+            cx.aswin.boxcast.core.designsystem.R.font.google_sans_variable
+        )
+        return android.graphics.Typeface.create(font, style)
+    }
+
+    private fun drawRoundedArtwork(
+        canvas: android.graphics.Canvas,
+        artwork: android.graphics.Bitmap,
+        destination: android.graphics.RectF,
+        cornerRadius: Float
+    ) {
+        val sourceSide = minOf(artwork.width, artwork.height)
+        val sourceLeft = (artwork.width - sourceSide) / 2
+        val sourceTop = (artwork.height - sourceSide) / 2
+        val source = android.graphics.Rect(
+            sourceLeft,
+            sourceTop,
+            sourceLeft + sourceSide,
+            sourceTop + sourceSide
+        )
+        val clipPath = android.graphics.Path().apply {
+            addRoundRect(
+                destination,
+                cornerRadius,
+                cornerRadius,
+                android.graphics.Path.Direction.CW
+            )
+        }
+        canvas.save()
+        canvas.clipPath(clipPath)
+        canvas.drawBitmap(
+            artwork,
+            source,
+            destination,
+            android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+                isFilterBitmap = true
+            }
+        )
+        canvas.restore()
+
+        canvas.drawRoundRect(
+            destination,
+            cornerRadius,
+            cornerRadius,
+            android.graphics.Paint(android.graphics.Paint.ANTI_ALIAS_FLAG).apply {
+                color = android.graphics.Color.argb(52, 255, 255, 255)
+                style = android.graphics.Paint.Style.STROKE
+                strokeWidth = 2f
+            }
+        )
+    }
+
 }

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/ShareBottomSheet.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/ShareBottomSheet.kt
@@ -1,8 +1,6 @@
 package cx.aswin.boxcast.core.designsystem.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,19 +9,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.ChatBubble
 import androidx.compose.material.icons.rounded.ContentCopy
-import androidx.compose.material.icons.rounded.Share
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -34,13 +32,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
+import cx.aswin.boxcast.core.model.ShareLinkBuilder
+import cx.aswin.boxcast.core.model.ShareTarget
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -49,23 +47,23 @@ fun ShareBottomSheet(
     type: String, // "podcast" or "episode"
     title: String,
     subtitle: String,
+    imageUrl: String? = null,
     onDismissRequest: () -> Unit,
     durationMs: Long = 0L,
     currentPositionMs: Long = 0L,
     showTimestampOption: Boolean = false,
-    onShare: (id: String, type: String, timestampMs: Long?) -> Unit
+    onShare: (
+        id: String,
+        type: String,
+        timestampMs: Long?,
+        target: ShareTarget
+    ) -> Unit
 ) {
-    android.util.Log.d("ShareBottomSheet", "ShareBottomSheet composed! id=$id, type=$type")
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
 
-    // Checkbox state
     var includeTimestamp by remember { mutableStateOf(false) }
-
-    // Colors
     val primaryColor = MaterialTheme.colorScheme.primary
-    val secondaryTextColor = MaterialTheme.colorScheme.onSurfaceVariant
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -78,43 +76,61 @@ fun ShareBottomSheet(
                 .fillMaxWidth()
                 .padding(horizontal = 24.dp)
                 .padding(bottom = 32.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            horizontalAlignment = Alignment.Start
         ) {
-            // Header
             Text(
-                text = "Share with Friends",
-                style = MaterialTheme.typography.titleLarge.copy(
-                    fontWeight = FontWeight.Bold,
-                    letterSpacing = 0.5.sp
-                ),
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(bottom = 8.dp)
+                text = "Share the good stuff",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.ExtraBold,
+                color = MaterialTheme.colorScheme.onSurface
             )
+            Text(
+                text = "A polished boxlore card is ready to send.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(18.dp))
 
-            // Content Card Preview
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                    .padding(16.dp)
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.extraLarge,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh
             ) {
                 Row(
+                    modifier = Modifier.padding(14.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    if (!imageUrl.isNullOrBlank()) {
+                        OptimizedImage(
+                            url = imageUrl,
+                            proxyWidth = 160,
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(72.dp)
+                                .clip(RoundedCornerShape(18.dp))
+                        )
+                        Spacer(modifier = Modifier.width(14.dp))
+                    }
                     Column(modifier = Modifier.weight(1f)) {
                         Text(
+                            text = if (type == "podcast") "PODCAST" else "EPISODE",
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = primaryColor
+                        )
+                        Text(
                             text = title,
-                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
                             color = MaterialTheme.colorScheme.onSurface,
-                            maxLines = 1,
+                            maxLines = 2,
                             overflow = TextOverflow.Ellipsis
                         )
                         Spacer(modifier = Modifier.height(2.dp))
                         Text(
                             text = subtitle,
                             style = MaterialTheme.typography.bodyMedium,
-                            color = secondaryTextColor,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
@@ -122,105 +138,143 @@ fun ShareBottomSheet(
                 }
             }
 
-            // Episode Sharing Options (Only when initiated from player share and playing)
             if (type == "episode" && showTimestampOption && currentPositionMs > 1000L) {
-                Spacer(modifier = Modifier.height(16.dp))
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                Spacer(modifier = Modifier.height(12.dp))
+                Surface(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = MaterialTheme.shapes.large,
+                    color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.52f)
                 ) {
-                    Checkbox(
-                        checked = includeTimestamp,
-                        onCheckedChange = { includeTimestamp = it },
-                        colors = CheckboxDefaults.colors(checkedColor = primaryColor)
-                    )
-                    Text(
-                        text = "Share from current time (${formatTime(currentPositionMs)})",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
+                    Row(
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = includeTimestamp,
+                            onCheckedChange = { includeTimestamp = it },
+                            colors = CheckboxDefaults.colors(checkedColor = primaryColor)
+                        )
+                        Text(
+                            text = "Start at ${formatTime(currentPositionMs)}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            color = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                    }
                 }
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
-
-            // Action Buttons Row
+            Spacer(modifier = Modifier.height(20.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
             ) {
-                // Copy Link Button
-                OutlinedButton(
+                ShareActionTile(
+                    icon = Icons.Rounded.ContentCopy,
+                    label = "Copy",
                     onClick = {
-                        val finalLink = generateFinalLink(
+                        val finalLink = ShareLinkBuilder.build(
                             id = id,
                             type = type,
-                            includeTimestamp = includeTimestamp && showTimestampOption,
-                            currentPositionMs = currentPositionMs
+                            timestampMs = currentPositionMs.takeIf {
+                                includeTimestamp && showTimestampOption
+                            }
                         )
-                        clipboardManager.setText(AnnotatedString(finalLink))
-                        android.widget.Toast.makeText(context, "Link copied to clipboard", android.widget.Toast.LENGTH_SHORT).show()
+                        val clipboard = context.getSystemService(
+                            android.content.Context.CLIPBOARD_SERVICE
+                        ) as android.content.ClipboardManager
+                        clipboard.setPrimaryClip(
+                            android.content.ClipData.newPlainText("boxlore link", finalLink)
+                        )
+                        android.widget.Toast.makeText(
+                            context,
+                            "Link copied",
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
                         onDismissRequest()
                     },
-                    modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = ButtonDefaults.outlinedButtonColors(
-                        contentColor = MaterialTheme.colorScheme.primary
-                    )
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.ContentCopy,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = "Copy Link", style = MaterialTheme.typography.labelLarge)
-                }
-
-                // Main Share Button
-                Button(
+                    modifier = Modifier.weight(1f)
+                )
+                ShareActionTile(
+                    icon = Icons.Rounded.ChatBubble,
+                    label = "Send",
                     onClick = {
                         val tMs = if (includeTimestamp && showTimestampOption) currentPositionMs else null
-                        onShare(id, type, tMs)
+                        onShare(id, type, tMs, ShareTarget.MESSAGE)
                         onDismissRequest()
                     },
                     modifier = Modifier.weight(1f),
-                    shape = RoundedCornerShape(12.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = primaryColor,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
-                    )
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Share,
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(text = "Share Link", style = MaterialTheme.typography.labelLarge)
-                }
+                    emphasized = true
+                )
+                ShareActionTile(
+                    icon = Icons.Rounded.AutoAwesome,
+                    label = "Story",
+                    onClick = {
+                        val tMs = if (includeTimestamp && showTimestampOption) currentPositionMs else null
+                        onShare(id, type, tMs, ShareTarget.INSTAGRAM_STORY)
+                        onDismissRequest()
+                    },
+                    modifier = Modifier.weight(1f)
+                )
             }
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Story copies the link so you can add it with Instagram’s Link sticker.",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }
 
-private fun generateFinalLink(
-    id: String,
-    type: String,
-    includeTimestamp: Boolean,
-    currentPositionMs: Long
-): String {
-    return if (type == "podcast") {
-        "https://aswin.cx/boxlore/share?type=podcast&id=$id"
+@Composable
+private fun ShareActionTile(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    emphasized: Boolean = false
+) {
+    val containerColor = if (emphasized) {
+        MaterialTheme.colorScheme.primary
     } else {
-        val baseUrl = "https://aswin.cx/boxlore/share?type=episode&id=$id"
-        if (includeTimestamp && currentPositionMs > 0) {
-            val tSec = currentPositionMs / 1000
-            "$baseUrl&t=$tSec"
-        } else {
-            baseUrl
+        MaterialTheme.colorScheme.surfaceContainerHighest
+    }
+    val contentColor = if (emphasized) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+    Surface(
+        modifier = modifier.expressiveClickable(
+            shape = MaterialTheme.shapes.extraLarge,
+            onClick = onClick
+        ),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = containerColor
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 14.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = contentColor.copy(alpha = 0.12f)
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = contentColor,
+                    modifier = Modifier.padding(8.dp).size(20.dp)
+                )
+            }
+            Spacer(modifier = Modifier.height(7.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                color = contentColor
+            )
         }
     }
 }

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/theme/ExpressiveShapes.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/theme/ExpressiveShapes.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.asAndroidPath
 import androidx.compose.ui.graphics.asComposePath
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
@@ -98,6 +99,13 @@ class CachedPolygonShape(
  * Uses CachedPolygonShape and CachedPathShape to eliminate draw-time allocations.
  */
 object ExpressiveShapes {
+
+    enum class DecorativeType {
+        Puffy,
+        PuffyDiamond,
+        SoftBurst,
+        Cookie4
+    }
 
     // --- Basic Shapes ---
     val Circle = CircleShape
@@ -317,6 +325,41 @@ object ExpressiveShapes {
         Heart, Bun, GhostIsh,
         Diamond, Gem, Pentagon
     )
+
+    fun androidPath(
+        type: DecorativeType,
+        width: Float,
+        height: Float
+    ): android.graphics.Path {
+        val shape = when (type) {
+            DecorativeType.Puffy -> Puffy
+            DecorativeType.PuffyDiamond -> PuffyDiamond
+            DecorativeType.SoftBurst -> SoftBurst
+            DecorativeType.Cookie4 -> Cookie4
+        }
+        val outline = shape.createOutline(
+            size = Size(width, height),
+            layoutDirection = LayoutDirection.Ltr,
+            density = Density(1f)
+        )
+        return when (outline) {
+            is Outline.Generic -> outline.path.asAndroidPath()
+            is Outline.Rectangle -> android.graphics.Path().apply {
+                addRect(0f, 0f, width, height, android.graphics.Path.Direction.CW)
+            }
+            is Outline.Rounded -> android.graphics.Path().apply {
+                addRoundRect(
+                    0f,
+                    0f,
+                    width,
+                    height,
+                    outline.roundRect.topLeftCornerRadius.x,
+                    outline.roundRect.topLeftCornerRadius.y,
+                    android.graphics.Path.Direction.CW
+                )
+            }
+        }
+    }
 
     // --- Raw Polygons (for LoadingIndicator) ---
     object Polygons {

--- a/core/model/src/main/java/cx/aswin/boxcast/core/model/ShareLinkBuilder.kt
+++ b/core/model/src/main/java/cx/aswin/boxcast/core/model/ShareLinkBuilder.kt
@@ -1,0 +1,42 @@
+package cx.aswin.boxcast.core.model
+
+object ShareLinkBuilder {
+    private const val BASE_URL = "https://aswin.cx/boxlore/share"
+
+    fun podcast(id: String): String = "$BASE_URL?type=podcast&id=$id"
+
+    fun episode(
+        id: String,
+        timestampMs: Long? = null,
+        startMs: Long? = null,
+        endMs: Long? = null
+    ): String {
+        val baseUrl = "$BASE_URL?type=episode&id=$id"
+        return when {
+            startMs != null && endMs != null -> {
+                "$baseUrl&start=${startMs / 1000}&end=${endMs / 1000}"
+            }
+            timestampMs != null && timestampMs > 0 -> {
+                "$baseUrl&t=${timestampMs / 1000}"
+            }
+            else -> baseUrl
+        }
+    }
+
+    fun build(
+        type: String,
+        id: String,
+        timestampMs: Long? = null,
+        startMs: Long? = null,
+        endMs: Long? = null
+    ): String = if (type == "podcast") {
+        podcast(id)
+    } else {
+        episode(
+            id = id,
+            timestampMs = timestampMs,
+            startMs = startMs,
+            endMs = endMs
+        )
+    }
+}

--- a/core/model/src/main/java/cx/aswin/boxcast/core/model/ShareTarget.kt
+++ b/core/model/src/main/java/cx/aswin/boxcast/core/model/ShareTarget.kt
@@ -1,0 +1,6 @@
+package cx.aswin.boxcast.core.model
+
+enum class ShareTarget {
+    MESSAGE,
+    INSTAGRAM_STORY
+}

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/CuriosityCardStack.kt
@@ -1,45 +1,76 @@
 package cx.aswin.boxcast.feature.explore
 
+import android.graphics.drawable.BitmapDrawable
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
+import coil.request.ImageRequest
 import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import cx.aswin.boxcast.core.designsystem.components.optimizedImageUrl
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import kotlin.math.abs
+import kotlin.math.PI
 import kotlin.math.roundToInt
+import kotlin.math.sin
 
 sealed interface CardAction {
+    data object Dismiss : CardAction
+    data object Queue : CardAction
     data object Play : CardAction
     data object Click : CardAction
     data object PodcastClick : CardAction
@@ -48,6 +79,7 @@ sealed interface CardAction {
 @Composable
 fun CuriosityCardStack(
     questions: List<DailyCuriosityDto>,
+    isCurrentEpisode: (String) -> Boolean,
     isCurrentlyPlaying: (String) -> Boolean,
     isCurrentlyLoading: (String) -> Boolean,
     onSwipeLeft: (DailyCuriosityDto) -> Unit,
@@ -61,8 +93,7 @@ fun CuriosityCardStack(
     if (questions.isEmpty()) {
         Box(
             modifier = modifier
-                .fillMaxWidth()
-                .height(340.dp),
+                .fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
             Text(
@@ -74,138 +105,103 @@ fun CuriosityCardStack(
         return
     }
 
+    val daily = questions.first()
+    val swipeThresholdPx = with(LocalDensity.current) { 88.dp.toPx() }
+    val swipeState = rememberSwipeableCardState(key = daily.episode.id) { direction ->
+        if (direction == SwipeDirection.Left) {
+            onSwipeLeft(daily)
+        } else {
+            onSwipeRight(daily)
+        }
+    }
+    val swipeProgress by remember(swipeState, swipeThresholdPx) {
+        derivedStateOf {
+            (abs(swipeState.offset.value.x) / swipeThresholdPx).coerceIn(0f, 1f)
+        }
+    }
+    val visibleCards = questions.take(3)
+
     Box(
         modifier = modifier
-            .fillMaxWidth()
-            .height(490.dp),
-        contentAlignment = Alignment.BottomCenter
+            .fillMaxSize()
+            .widthIn(max = 520.dp)
+            .padding(bottom = 28.dp),
+        contentAlignment = Alignment.TopCenter
     ) {
-        val cardsToShow = questions.take(4).reversed()
-
-        cardsToShow.forEach { daily ->
-            val stackIndex = questions.indexOf(daily)
-            val isTopCard = stackIndex == 0
-
-            val swipeState = rememberSwipeableCardState(key = daily.episode.id) { direction ->
-                if (direction == SwipeDirection.Left) {
-                    onSwipeLeft(daily)
-                } else {
-                    onSwipeRight(daily)
-                }
-            }
-
-            val scaleTarget = when (stackIndex) {
-                0 -> 1f
-                1 -> 0.96f
-                2 -> 0.92f
-                else -> 0.88f
-            }
-            val scale by animateFloatAsState(
-                targetValue = scaleTarget,
-                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow),
-                label = "CardScale"
-            )
-
-            val offsetTarget = when (stackIndex) {
-                0 -> 0.dp
-                1 -> (-14).dp
-                2 -> (-26).dp
-                else -> (-36).dp
-            }
-            val verticalOffset by animateDpAsState(
-                targetValue = offsetTarget,
-                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow),
-                label = "CardOffset"
-            )
-
-            val rotationTarget = when (stackIndex) {
-                0 -> 0f
-                1 -> -3.5f
-                2 -> 3.5f
-                else -> -1.5f
-            }
-            val rotationAngle by animateFloatAsState(
-                targetValue = rotationTarget,
-                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow),
-                label = "CardRotation"
-            )
-
-            val alphaTarget = when (stackIndex) {
-                0 -> 1f
-                1 -> 0.85f
-                2 -> 0.65f
-                else -> 0.45f
-            }
-            val alphaVal by animateFloatAsState(
-                targetValue = alphaTarget,
-                animationSpec = spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMedium),
-                label = "CardAlpha"
-            )
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight()
-                    .offset {
-                        if (isTopCard) {
+        visibleCards.asReversed().forEach { card ->
+            key(card.episode.id) {
+                val depth = visibleCards.indexOf(card)
+                val isActive = depth == 0
+                val cardModifier = when (depth) {
+                    2 -> Modifier
+                        .matchParentSize()
+                        .offset(y = (24f - (10f * swipeProgress)).dp)
+                        .scale(0.93f + (0.035f * swipeProgress))
+                        .graphicsLayer {
+                            rotationZ = 1.8f * (1f - swipeProgress)
+                        }
+                    1 -> Modifier
+                        .matchParentSize()
+                        .offset(y = (13f - (11f * swipeProgress)).dp)
+                        .scale(0.965f + (0.025f * swipeProgress))
+                        .graphicsLayer {
+                            rotationZ = -1.15f * (1f - swipeProgress)
+                        }
+                    else -> Modifier
+                        .fillMaxSize()
+                        .offset {
                             IntOffset(
                                 swipeState.offset.value.x.roundToInt(),
-                                swipeState.offset.value.y.roundToInt()
+                                0
                             )
-                        } else {
-                            IntOffset(0, 0)
                         }
-                    }
-                    .offset(y = verticalOffset)
-                    .scale(scale)
-                    .graphicsLayer {
-                        rotationZ = if (isTopCard) {
-                            rotationAngle + (swipeState.offset.value.x / 40f)
-                        } else {
-                            rotationAngle
+                        .graphicsLayer {
+                            rotationZ = (swipeState.offset.value.x / 180f)
+                                .coerceIn(-2.5f, 2.5f)
+                            cameraDistance = 12f * density
                         }
-                        alpha = alphaVal
-                        cameraDistance = 12f * density
-                    }
-                    .then(
-                        if (isTopCard) {
-                            Modifier.pointerInput(daily.episode.id) {
-                                detectDragGestures(
-                                    onDragEnd = {
-                                        val offsetX = swipeState.offset.value.x
-                                        if (offsetX > 400f) {
-                                            swipeState.swipe(SwipeDirection.Right)
-                                        } else if (offsetX < -400f) {
-                                            swipeState.swipe(SwipeDirection.Left)
-                                        } else {
-                                            swipeState.reset()
-                                        }
-                                    },
-                                    onDragCancel = {
+                        .pointerInput(card.episode.id) {
+                            detectHorizontalDragGestures(
+                                onDragEnd = {
+                                    val offsetX = swipeState.offset.value.x
+                                    if (offsetX > swipeThresholdPx) {
+                                        swipeState.swipe(SwipeDirection.Right)
+                                    } else if (offsetX < -swipeThresholdPx) {
+                                        swipeState.swipe(SwipeDirection.Left)
+                                    } else {
                                         swipeState.reset()
-                                    },
-                                    onDrag = { change, dragAmount ->
-                                        change.consume()
-                                        swipeState.drag(dragAmount)
                                     }
-                                )
-                            }
-                        } else {
-                            Modifier
+                                },
+                                onDragCancel = swipeState::reset,
+                                onHorizontalDrag = { change, dragAmount ->
+                                    change.consume()
+                                    swipeState.drag(
+                                        androidx.compose.ui.geometry.Offset(
+                                            x = dragAmount,
+                                            y = 0f
+                                        )
+                                    )
+                                }
+                            )
                         }
-                    )
-            ) {
-                CuriosityCardContent(
-                    daily = daily,
-                    isCurrentlyPlaying = isCurrentlyPlaying(daily.episode.id.toString()),
-                    isCurrentlyLoading = isCurrentlyLoading(daily.episode.id.toString()),
-                    accentColor = accentColor,
+                }
+
+                DeckCard(
+                    daily = card,
+                    isCurrentEpisode = isCurrentEpisode(card.episode.id.toString()),
+                    isCurrentlyPlaying = isCurrentlyPlaying(card.episode.id.toString()),
+                    isCurrentlyLoading = isCurrentlyLoading(card.episode.id.toString()),
+                    fallbackAccentColor = accentColor,
+                    interactive = isActive,
+                    modifier = cardModifier,
                     onAction = { action ->
-                        if (isTopCard) {
+                        if (isActive) {
                             when (action) {
-                                CardAction.Play -> onPlayClick(daily)
-                                CardAction.Click -> onEpisodeClick(daily)
-                                CardAction.PodcastClick -> onPodcastClick(daily)
+                                CardAction.Dismiss -> onSwipeLeft(card)
+                                CardAction.Queue -> onSwipeRight(card)
+                                CardAction.Play -> onPlayClick(card)
+                                CardAction.Click -> onEpisodeClick(card)
+                                CardAction.PodcastClick -> onPodcastClick(card)
                             }
                         }
                     }
@@ -216,124 +212,291 @@ fun CuriosityCardStack(
 }
 
 @Composable
+private fun DeckCard(
+    daily: DailyCuriosityDto,
+    isCurrentEpisode: Boolean,
+    isCurrentlyPlaying: Boolean,
+    isCurrentlyLoading: Boolean,
+    fallbackAccentColor: Color,
+    interactive: Boolean,
+    onAction: (CardAction) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val accentColor = rememberArtworkAccentColor(
+        daily = daily,
+        fallback = fallbackAccentColor
+    )
+    CuriosityCardContent(
+        daily = daily,
+        isCurrentEpisode = isCurrentEpisode,
+        isCurrentlyPlaying = isCurrentlyPlaying,
+        isCurrentlyLoading = isCurrentlyLoading,
+        accentColor = accentColor,
+        interactive = interactive,
+        onAction = onAction,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun rememberArtworkAccentColor(
+    daily: DailyCuriosityDto,
+    fallback: Color
+): Color {
+    val context = LocalContext.current
+    val imageUrl = daily.episode.image ?: daily.episode.feedImage
+    var extractedColor by remember(imageUrl) { mutableStateOf<Color?>(null) }
+
+    LaunchedEffect(imageUrl) {
+        if (imageUrl.isNullOrBlank()) {
+            extractedColor = null
+            return@LaunchedEffect
+        }
+        extractedColor = runCatching {
+            val request = ImageRequest.Builder(context)
+                .data(imageUrl.optimizedImageUrl(width = 160))
+                .allowHardware(false)
+                .size(80, 80)
+                .build()
+            val result = coil.Coil.imageLoader(context).execute(request)
+                as? coil.request.SuccessResult
+                ?: return@runCatching null
+            val bitmap = (result.drawable as? BitmapDrawable)?.bitmap
+                ?: return@runCatching null
+            withContext(Dispatchers.Default) {
+                extractDominantColor(bitmap)
+            }
+        }.getOrNull()
+    }
+
+    return animateColorAsState(
+        targetValue = extractedColor ?: fallback,
+        animationSpec = tween(durationMillis = 450),
+        label = "StackedCardAccent"
+    ).value
+}
+
+@Composable
 private fun CuriosityCardContent(
     daily: DailyCuriosityDto,
+    isCurrentEpisode: Boolean,
     isCurrentlyPlaying: Boolean,
     isCurrentlyLoading: Boolean,
     accentColor: Color,
+    interactive: Boolean = true,
     onAction: (CardAction) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val coverArt = daily.episode.image ?: daily.episode.feedImage ?: ""
+    val artworkShape = RoundedCornerShape(14.dp)
+    val tertiaryColor = MaterialTheme.colorScheme.tertiary
+    val cardShape = MaterialTheme.shapes.extraLarge
+    var hidePodcastMetadata by remember(daily.episode.id, daily.explanation) {
+        mutableStateOf(false)
+    }
 
     OutlinedCard(
-        shape = MaterialTheme.shapes.extraLarge,
+        shape = cardShape,
         colors = CardDefaults.outlinedCardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+            containerColor = Color.Black
         ),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+        border = BorderStroke(1.dp, accentColor.copy(alpha = 0.45f)),
         modifier = modifier
             .fillMaxWidth()
-            .height(480.dp)
-            .expressiveClickable(onClick = { onAction(CardAction.Click) })
-    ) {
-        Box(modifier = Modifier.fillMaxSize()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .blur(60.dp)
-            ) {
-                OptimizedImage(
-                    url = coverArt,
-                    proxyWidth = 200,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier.fillMaxSize()
-                )
-            }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.75f))
+            .fillMaxHeight()
+            .then(
+                if (interactive) {
+                    Modifier.expressiveClickable(
+                        shape = cardShape,
+                        onClick = { onAction(CardAction.Click) }
+                    )
+                } else {
+                    Modifier
+                }
             )
-
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            OptimizedImage(
+                url = coverArt,
+                proxyWidth = 320,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleX = 1.24f
+                        scaleY = 1.24f
+                    }
+                    .blur(
+                        radius = 64.dp,
+                        edgeTreatment = BlurredEdgeTreatment.Unbounded
+                    )
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.72f))
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .drawWithCache {
+                    val upperWash = Brush.radialGradient(
+                        colors = listOf(
+                            accentColor.copy(alpha = 0.34f),
+                            accentColor.copy(alpha = 0.10f),
+                            Color.Transparent
+                        ),
+                        center = Offset(size.width * 0.08f, size.height * 0.02f),
+                        radius = size.maxDimension * 0.8f
+                    )
+                    val lowerWash = Brush.radialGradient(
+                        colors = listOf(
+                            tertiaryColor.copy(alpha = 0.18f),
+                            Color.Transparent
+                        ),
+                        center = Offset(size.width, size.height),
+                        radius = size.maxDimension * 0.7f
+                    )
+                    onDrawBehind {
+                        drawRect(upperWash)
+                        drawRect(lowerWash)
+                    }
+                }
+            )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .height(4.dp)
+                    .background(
+                        Brush.horizontalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                accentColor.copy(alpha = 0.9f),
+                                tertiaryColor.copy(alpha = 0.75f),
+                                Color.Transparent
+                            )
+                        )
+                    )
+            )
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = 24.dp, vertical = 20.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Spacer(modifier = Modifier.height(6.dp))
-
-                OptimizedImage(
-                    url = coverArt,
-                    proxyWidth = 200,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .size(100.dp)
-                        .clip(RoundedCornerShape(12.dp))
+                CardQuickActions(
+                    enabled = interactive,
+                    onDismiss = { onAction(CardAction.Dismiss) },
+                    onInfo = { onAction(CardAction.Click) },
+                    onQueue = { onAction(CardAction.Queue) },
+                    modifier = Modifier.padding(
+                        start = 14.dp,
+                        end = 14.dp,
+                        top = 12.dp
+                    )
                 )
-
-                Spacer(modifier = Modifier.height(10.dp))
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
+                Column(
                     modifier = Modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .expressiveClickable(onClick = { onAction(CardAction.PodcastClick) })
-                        .padding(horizontal = 8.dp, vertical = 2.dp)
+                        .weight(1f)
+                        .padding(
+                            start = 24.dp,
+                            end = 24.dp,
+                            top = 18.dp,
+                            bottom = 18.dp
+                        ),
+                    verticalArrangement = Arrangement.Center
                 ) {
                     Text(
-                        text = (daily.episode.feedTitle ?: "Podcast").uppercase(),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Black,
-                        letterSpacing = 1.5.sp,
-                        color = Color.White.copy(alpha = 0.8f),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f, fill = false)
+                        text = daily.question,
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.ExtraBold,
+                        color = Color.White,
+                        textAlign = TextAlign.Start,
+                        modifier = Modifier.semantics { heading() }
                     )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                        contentDescription = "Go to podcast",
-                        tint = Color.White.copy(alpha = 0.6f),
-                        modifier = Modifier.size(16.dp)
-                    )
+                    if (!daily.explanation.isNullOrBlank()) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = daily.explanation.orEmpty(),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = Color.White.copy(alpha = 0.78f),
+                            textAlign = TextAlign.Start,
+                            onTextLayout = { result ->
+                                if (result.hasVisualOverflow) {
+                                    hidePodcastMetadata = true
+                                }
+                            }
+                        )
+                    }
                 }
 
-                Spacer(modifier = Modifier.weight(1f))
+                if (!hidePodcastMetadata) {
+                    Column(
+                        modifier = Modifier.padding(
+                            start = 24.dp,
+                            end = 24.dp,
+                            bottom = 18.dp
+                        )
+                    ) {
+                        HorizontalDivider(
+                            color = Color.White.copy(alpha = 0.18f)
+                        )
+                        Spacer(modifier = Modifier.height(14.dp))
 
-                Text(
-                    text = daily.question,
-                    fontSize = 24.sp,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Black,
-                    color = Color.White,
-                    lineHeight = 30.sp,
-                    textAlign = TextAlign.Center
-                )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(12.dp))
+                                .expressiveClickable(
+                                    enabled = interactive,
+                                    onClick = { onAction(CardAction.PodcastClick) }
+                                )
+                                .padding(vertical = 2.dp)
+                        ) {
+                            OptimizedImage(
+                                url = coverArt,
+                                proxyWidth = 128,
+                                contentDescription = "Episode artwork",
+                                contentScale = ContentScale.Crop,
+                                modifier = Modifier
+                                    .size(48.dp)
+                                    .border(
+                                        width = 1.dp,
+                                        color = accentColor.copy(alpha = 0.45f),
+                                        shape = artworkShape
+                                    )
+                                    .clip(artworkShape)
+                            )
+                            Text(
+                                text = daily.episode.feedTitle ?: "Podcast",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.White.copy(alpha = 0.72f),
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                                contentDescription = "Open podcast",
+                                tint = Color.White.copy(alpha = 0.62f),
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                    }
+                }
 
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = daily.explanation ?: "",
-                    fontSize = 14.sp,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White.copy(alpha = 0.75f),
-                    lineHeight = 20.sp,
-                    textAlign = TextAlign.Center
-                )
-
-                Spacer(modifier = Modifier.weight(1.2f))
-
-                CircularPlayButton(
+                EpisodePlayButton(
+                    isCurrentEpisode = isCurrentEpisode,
                     isPlaying = isCurrentlyPlaying,
                     isLoading = isCurrentlyLoading,
                     accentColor = accentColor,
+                    enabled = interactive,
                     onClick = { onAction(CardAction.Play) }
                 )
             }
@@ -342,62 +505,241 @@ private fun CuriosityCardContent(
 }
 
 @Composable
-private fun CircularPlayButton(
-    isPlaying: Boolean,
-    isLoading: Boolean,
-    accentColor: Color,
+private fun CardQuickActions(
+    enabled: Boolean,
+    onDismiss: () -> Unit,
+    onInfo: () -> Unit,
+    onQueue: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CardQuickAction(
+            icon = Icons.AutoMirrored.Rounded.ArrowBack,
+            label = "Skip",
+            enabled = enabled,
+            onClick = onDismiss,
+            modifier = Modifier.weight(1f)
+        )
+        CardQuickAction(
+            icon = Icons.Rounded.Info,
+            label = "Info",
+            enabled = enabled,
+            onClick = onInfo,
+            modifier = Modifier.weight(1f)
+        )
+        CardQuickAction(
+            icon = Icons.AutoMirrored.Rounded.ArrowForward,
+            label = "Queue",
+            enabled = enabled,
+            onClick = onQueue,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Composable
+private fun CardQuickAction(
+    icon: ImageVector,
+    label: String,
+    enabled: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val buttonBackground = if (isPlaying) {
-        Modifier.background(
-            Brush.radialGradient(
-                colors = listOf(
-                    accentColor,
-                    accentColor.copy(alpha = 0.8f)
-                )
-            )
+    Row(
+        modifier = modifier
+            .heightIn(min = 40.dp)
+            .expressiveClickable(
+                enabled = enabled,
+                shape = CircleShape,
+                onClick = onClick
+            ),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Color.White.copy(alpha = 0.52f),
+            modifier = Modifier.size(14.dp)
         )
-    } else {
-        Modifier.background(
-            Brush.radialGradient(
-                colors = listOf(
-                    Color.White,
-                    Color.White.copy(alpha = 0.9f)
-                )
-            )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Medium,
+            color = Color.White.copy(alpha = 0.58f)
         )
     }
+}
 
-    val iconColor = if (isPlaying) Color.White else Color.Black
+@Composable
+private fun EpisodePlayButton(
+    isCurrentEpisode: Boolean,
+    isPlaying: Boolean,
+    isLoading: Boolean,
+    accentColor: Color,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val eyebrow = when {
+        isLoading -> "GETTING READY"
+        isPlaying -> "LISTENING"
+        isCurrentEpisode -> "CONTINUE"
+        else -> "LISTEN NOW"
+    }
+    val label = when {
+        isLoading -> "Loading episode"
+        isPlaying -> "Pause episode"
+        isCurrentEpisode -> "Resume episode"
+        else -> "Play episode"
+    }
     val iconVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow
-    val iconDescription = if (isPlaying) "Pause" else "Play"
-    val iconOffset = if (isPlaying) Modifier else Modifier.offset(x = 1.dp)
+    val darkAccent = lerp(accentColor, Color.Black, 0.58f)
+    val waveColor = lerp(accentColor, Color.White, 0.34f)
+    val railShape = RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp)
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val pressScale by animateFloatAsState(
+        targetValue = if (isPressed) 0.975f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "PlaybackRailPress"
+    )
 
     Box(
         modifier = modifier
-            .size(56.dp)
-            .border(1.5.dp, Color.White.copy(alpha = 0.25f), CircleShape)
-            .padding(4.dp)
-            .clip(CircleShape)
-            .then(buttonBackground)
-            .expressiveClickable(enabled = !isLoading, onClick = onClick),
+            .fillMaxWidth()
+            .graphicsLayer {
+                scaleX = pressScale
+                scaleY = pressScale
+            }
+            .clip(railShape)
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(
+                        Color(0xFF111016),
+                        Color(0xFF15131B),
+                        darkAccent
+                    )
+                )
+            )
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = enabled && !isLoading,
+                onClick = onClick
+            ),
         contentAlignment = Alignment.Center
     ) {
-        if (isLoading) {
-            BoxLoreLoader.CircularWavy(
-                size = 28.dp,
-                color = iconColor
-            )
-        } else {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 68.dp)
+                .padding(horizontal = 20.dp, vertical = 11.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             Icon(
                 imageVector = iconVector,
-                contentDescription = iconDescription,
-                tint = iconColor,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(29.dp)
+            )
+            Spacer(modifier = Modifier.width(15.dp))
+            Column {
+                Text(
+                    text = eyebrow,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = waveColor.copy(alpha = 0.76f)
+                )
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = Color.White
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            PlaybackWave(
+                active = enabled && (isPlaying || isLoading),
+                color = waveColor,
                 modifier = Modifier
-                    .size(24.dp)
-                    .then(iconOffset)
+                    .weight(1f)
+                    .height(30.dp)
             )
         }
+    }
+}
+
+@Composable
+private fun PlaybackWave(
+    active: Boolean,
+    color: Color,
+    modifier: Modifier = Modifier
+) {
+    val amplitudeFactor by animateFloatAsState(
+        targetValue = if (active) 1f else 0f,
+        animationSpec = tween(durationMillis = 450),
+        label = "PlaybackWaveAmplitude"
+    )
+    val phaseAnimation = remember { Animatable(0f) }
+    LaunchedEffect(active) {
+        if (!active) return@LaunchedEffect
+        while (isActive) {
+            phaseAnimation.snapTo(0f)
+            phaseAnimation.animateTo(
+                targetValue = (2f * PI).toFloat(),
+                animationSpec = tween(
+                    durationMillis = 1_200,
+                    easing = LinearEasing
+                )
+            )
+        }
+    }
+
+    Canvas(modifier = modifier) {
+        val strokeWidth = 5.dp.toPx()
+        val startX = strokeWidth / 2f
+        val endX = size.width - (strokeWidth / 2f)
+        if (endX <= startX) return@Canvas
+
+        val centerY = size.height / 2f
+        val amplitude = 3.dp.toPx() * amplitudeFactor
+        if (amplitude <= 0.15f) {
+            drawLine(
+                color = color,
+                start = Offset(startX, centerY),
+                end = Offset(endX, centerY),
+                strokeWidth = strokeWidth,
+                cap = StrokeCap.Round
+            )
+            return@Canvas
+        }
+
+        val wavelength = 36.dp.toPx()
+        val path = Path()
+        var x = startX
+        path.moveTo(
+            startX,
+            centerY + amplitude * sin(phaseAnimation.value)
+        )
+        while (x < endX) {
+            x = (x + 3f).coerceAtMost(endX)
+            val y = centerY + amplitude *
+                sin((x / wavelength) * 2f * PI.toFloat() + phaseAnimation.value)
+            path.lineTo(x, y)
+        }
+
+        drawPath(
+            path = path,
+            color = color,
+            style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+        )
     }
 }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnHistoryScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnHistoryScreen.kt
@@ -16,15 +16,13 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.Undo
 import androidx.compose.material.icons.rounded.ClearAll
 import androidx.compose.material.icons.rounded.History
-import androidx.compose.material.icons.rounded.Undo
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -100,65 +98,118 @@ fun LearnHistoryScreen(
         )
     }
 
-    Scaffold(
-        topBar = {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .windowInsetsPadding(WindowInsets.statusBars)
-                    .padding(horizontal = 8.dp, vertical = 16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                IconButton(onClick = onBack) {
-                    Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "Card History",
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.weight(1f)
-                )
-                if (uiState is LearnHistoryUiState.Success &&
-                    (uiState as LearnHistoryUiState.Success).entries.isNotEmpty()
+    LoreHaloBackground(accentColor = MaterialTheme.colorScheme.primary) {
+        Scaffold(
+            topBar = {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets.statusBars)
+                        .padding(horizontal = 16.dp, vertical = 10.dp)
                 ) {
-                    IconButton(onClick = { showClearDialog = true }) {
-                        Icon(Icons.Rounded.ClearAll, contentDescription = "Clear history")
+                    Surface(
+                        shape = androidx.compose.foundation.shape.CircleShape,
+                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        tonalElevation = 2.dp,
+                        modifier = Modifier.align(Alignment.CenterStart)
+                    ) {
+                        IconButton(onClick = onBack) {
+                            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+                        }
+                    }
+                    androidx.compose.foundation.Image(
+                        painter = androidx.compose.ui.res.painterResource(
+                            id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore
+                        ),
+                        contentDescription = "Lore",
+                        colorFilter = androidx.compose.ui.graphics.ColorFilter.tint(
+                            MaterialTheme.colorScheme.primary
+                        ),
+                        modifier = Modifier
+                            .height(32.dp)
+                            .align(Alignment.Center)
+                    )
+                    if (uiState is LearnHistoryUiState.Success &&
+                        (uiState as LearnHistoryUiState.Success).entries.isNotEmpty()
+                    ) {
+                        Surface(
+                            shape = androidx.compose.foundation.shape.CircleShape,
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            tonalElevation = 2.dp,
+                            modifier = Modifier.align(Alignment.CenterEnd)
+                        ) {
+                            IconButton(onClick = { showClearDialog = true }) {
+                                Icon(Icons.Rounded.ClearAll, contentDescription = "Clear history")
+                            }
+                        }
                     }
                 }
-            }
-        },
-        containerColor = MaterialTheme.colorScheme.surface
-    ) { innerPadding ->
-        when (val state = uiState) {
-            is LearnHistoryUiState.Loading -> Unit
-            is LearnHistoryUiState.Success -> {
-                if (state.entries.isEmpty()) {
-                    LearnHistoryEmptyState(
+            },
+            containerColor = androidx.compose.ui.graphics.Color.Transparent
+        ) { innerPadding ->
+            when (val state = uiState) {
+                is LearnHistoryUiState.Loading -> {
+                    Box(
                         modifier = Modifier
                             .fillMaxSize()
                             .padding(innerPadding)
-                            .padding(bottom = bottomContentPadding)
-                    )
-                } else {
-                    LazyColumn(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(
-                            start = 16.dp,
-                            end = 16.dp,
-                            top = 8.dp,
-                            bottom = bottomContentPadding + 16.dp
-                        ),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                            .padding(bottom = bottomContentPadding),
+                        contentAlignment = Alignment.Center
                     ) {
-                        items(state.entries, key = { it.episodeId }) { entry ->
-                            LearnHistoryRow(
-                                entry = entry,
-                                onClick = { onEpisodeClick(entry.toDailyCuriosityDto().episode.toEpisode()) },
-                                onRestore = { viewModel.restoreEntry(entry.episodeId) }
-                            )
+                        cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader.Expressive(size = 64.dp)
+                    }
+                }
+                is LearnHistoryUiState.Success -> {
+                    if (state.entries.isEmpty()) {
+                        LearnHistoryEmptyState(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(innerPadding)
+                                .padding(bottom = bottomContentPadding)
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(innerPadding),
+                            contentPadding = androidx.compose.foundation.layout.PaddingValues(
+                                start = 16.dp,
+                                end = 16.dp,
+                                top = 8.dp,
+                                bottom = bottomContentPadding + 16.dp
+                            ),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            item {
+                                Column(
+                                    modifier = Modifier.padding(
+                                        start = 4.dp,
+                                        end = 4.dp,
+                                        bottom = 8.dp
+                                    )
+                                ) {
+                                    Text(
+                                        text = "Your Lore history",
+                                        style = MaterialTheme.typography.headlineMedium,
+                                        fontWeight = FontWeight.ExtraBold
+                                    )
+                                    Spacer(modifier = Modifier.height(6.dp))
+                                    Text(
+                                        text = "Questions you dismissed or queued, ready to rediscover.",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                            items(state.entries, key = { it.episodeId }) { entry ->
+                                LearnHistoryRow(
+                                    entry = entry,
+                                    onClick = {
+                                        onEpisodeClick(entry.toDailyCuriosityDto().episode.toEpisode())
+                                    },
+                                    onRestore = { viewModel.restoreEntry(entry.episodeId) }
+                                )
+                            }
                         }
                     }
                 }
@@ -169,35 +220,51 @@ fun LearnHistoryScreen(
 
 @Composable
 private fun LearnHistoryEmptyState(modifier: Modifier = Modifier) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 32.dp, vertical = 32.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+    Box(
+        modifier = modifier.padding(horizontal = 24.dp),
+        contentAlignment = Alignment.Center
     ) {
-        Icon(
-            imageVector = Icons.Rounded.History,
-            contentDescription = null,
-            modifier = Modifier.size(56.dp),
-            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-        Text(
-            text = "No cards yet",
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center,
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 4.dp,
             modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "Episodes you dismiss or queue on Learn show up here so you can find them again.",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
-        )
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 28.dp, vertical = 36.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Surface(
+                    shape = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.Cookie6,
+                    color = MaterialTheme.colorScheme.primaryContainer
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.History,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .size(36.dp),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                }
+                Spacer(modifier = Modifier.height(20.dp))
+                Text(
+                    text = "No Lore to revisit yet",
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.ExtraBold,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+                Text(
+                    text = "Questions you dismiss or queue will wait here, ready for another look.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
     }
 }
 
@@ -224,32 +291,32 @@ private fun LearnHistoryRow(
         modifier = Modifier
             .fillMaxWidth()
             .expressiveClickable(onClick = onClick),
-        shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerHigh
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 2.dp
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(12.dp),
-            verticalAlignment = Alignment.CenterVertically
+                .padding(16.dp),
+            verticalAlignment = Alignment.Top
         ) {
             OptimizedImage(
                 url = imageUrl.orEmpty(),
                 proxyWidth = 160,
                 contentDescription = null,
                 modifier = Modifier
-                    .size(64.dp)
-                    .clip(RoundedCornerShape(12.dp))
+                    .size(72.dp)
+                    .clip(androidx.compose.foundation.shape.RoundedCornerShape(14.dp))
             )
-            Spacer(modifier = Modifier.width(12.dp))
+            Spacer(modifier = Modifier.width(14.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = entry.question.ifBlank { entry.episodeTitle },
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.ExtraBold
                 )
+                Spacer(modifier = Modifier.height(6.dp))
                 if (entry.question.isNotBlank()) {
                     Text(
                         text = entry.episodeTitle,
@@ -268,15 +335,27 @@ private fun LearnHistoryRow(
                         overflow = TextOverflow.Ellipsis
                     )
                 }
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = listOf(actionLabel, dateLabel).filter { it.isNotBlank() }.joinToString(" · "),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                Spacer(modifier = Modifier.height(10.dp))
+                Surface(
+                    shape = androidx.compose.foundation.shape.CircleShape,
+                    color = when (entry.action) {
+                        LearnHistoryAction.DISMISS -> MaterialTheme.colorScheme.errorContainer
+                        LearnHistoryAction.QUEUE -> MaterialTheme.colorScheme.tertiaryContainer
+                    }
+                ) {
+                    Text(
+                        text = listOf(actionLabel, dateLabel)
+                            .filter { it.isNotBlank() }
+                            .joinToString(" · "),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp)
+                    )
+                }
             }
-            IconButton(onClick = onRestore) {
-                Icon(Icons.Rounded.Undo, contentDescription = "Restore card")
+            Spacer(modifier = Modifier.width(8.dp))
+            androidx.compose.material3.FilledTonalIconButton(onClick = onRestore) {
+                Icon(Icons.AutoMirrored.Rounded.Undo, contentDescription = "Restore card")
             }
         }
     }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -2,56 +2,28 @@ package cx.aswin.boxcast.feature.explore
 
 import android.graphics.drawable.BitmapDrawable
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.keyframes
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowForward
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material.icons.rounded.History
-import androidx.compose.material.icons.rounded.TouchApp
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -68,34 +40,22 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImagePainter
-import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
-import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
 import cx.aswin.boxcast.core.designsystem.components.optimizedImageUrl
-import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Episode
-import cx.aswin.boxcast.core.network.model.CuratedCuriosityPodcastDto
 import cx.aswin.boxcast.core.network.model.DailyCuriosityDto
 import cx.aswin.boxcast.core.data.toEpisode
 import cx.aswin.boxcast.core.designsystem.theme.TrackScreenSession
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -111,7 +71,14 @@ fun LearnScreen(
     modifier: Modifier = Modifier
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val playerState by playbackRepository.playerState.collectAsState()
+    val stablePlayerState = remember(playbackRepository) {
+        playbackRepository.playerState
+            .map { it.copy(position = 0L, bufferedPosition = 0L) }
+            .distinctUntilChanged()
+    }
+    val playerState by stablePlayerState.collectAsState(
+        initial = cx.aswin.boxcast.core.data.PlayerState()
+    )
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
 
@@ -131,31 +98,8 @@ fun LearnScreen(
     // Animate color transition smoothly for ambient background gradient and tinting
     val animatedAccentColor by animateColorAsState(
         targetValue = baseAccentColor,
-        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        animationSpec = tween(durationMillis = 700),
         label = "AccentColorTransition"
-    )
-
-    // Infinite transition for fluid background glow animations (pulsing and drifting)
-    val infiniteTransition = rememberInfiniteTransition(label = "BackgroundGlowPulse")
-    
-    val pulseScale by infiniteTransition.animateFloat(
-        initialValue = 0.88f,
-        targetValue = 1.12f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 7000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "GlowPulseScale"
-    )
-    
-    val driftX by infiniteTransition.animateFloat(
-        initialValue = -25f,
-        targetValue = 25f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 11000, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "GlowDriftX"
     )
 
     // Trigger color extraction based on active card cover artwork changes
@@ -200,44 +144,9 @@ fun LearnScreen(
         modifier = modifier.fillMaxSize(),
         containerColor = Color.Transparent
     ) { _ ->
-        // Ambient background gradient glow wrapping the pull to refresh box
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .drawBehind {
-                    val density = this
-                    val driftXPx = with(density) { driftX.dp.toPx() }
-
-                    // 1. Top-center ambient glow orb (Breathing and drifting gently)
-                    val topGlowBrush = Brush.radialGradient(
-                        colors = listOf(
-                            animatedAccentColor.copy(alpha = 0.25f),
-                            animatedAccentColor.copy(alpha = 0.06f),
-                            Color.Transparent
-                        ),
-                        center = Offset(
-                            x = size.width / 2f + driftXPx,
-                            y = -size.height * 0.1f
-                        ),
-                        radius = size.height * 0.85f * pulseScale
-                    )
-                    drawRect(brush = topGlowBrush)
-
-                    // 2. Bottom-right ambient glow orb (Pulsing out-of-phase for a fluid lava-lamp atmosphere)
-                    val bottomGlowBrush = Brush.radialGradient(
-                        colors = listOf(
-                            animatedAccentColor.copy(alpha = 0.18f),
-                            animatedAccentColor.copy(alpha = 0.04f),
-                            Color.Transparent
-                        ),
-                        center = Offset(
-                            x = size.width * 0.8f - driftXPx,
-                            y = size.height * 0.95f
-                        ),
-                        radius = size.height * 0.65f * (2f - pulseScale)
-                    )
-                    drawRect(brush = bottomGlowBrush)
-                }
+        LoreHaloBackground(
+            accentColor = animatedAccentColor,
+            modifier = Modifier.fillMaxSize()
         ) {
             val isRefreshing = when (val state = uiState) {
                 is LearnUiState.Success -> state.isRefreshing
@@ -258,37 +167,29 @@ fun LearnScreen(
                 when (val state = uiState) {
                     is LearnUiState.Loading -> {
                         Box(
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(bottom = bottomContentPaddingCalculated),
                             contentAlignment = Alignment.Center
                         ) {
                             BoxLoreLoader.Expressive(size = 64.dp)
                         }
                     }
                     is LearnUiState.CaughtUp -> {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(horizontal = 32.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.Center
+                        LoreStateCard(
+                            accentColor = animatedAccentColor,
+                            title = "You’re all caught up",
+                            description = "New curiosities arrive daily. Restore a favorite from your Lore history whenever inspiration strikes.",
+                            bottomContentPadding = bottomContentPaddingCalculated
                         ) {
-                            Text(
-                                text = "You’re all caught up",
-                                style = MaterialTheme.typography.headlineSmall,
-                                fontWeight = FontWeight.Bold
-                            )
-                            Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = "New curiosities arrive daily. You can also restore cards from your history.",
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Spacer(modifier = Modifier.height(20.dp))
-                            FilledTonalButton(onClick = viewModel::refresh) {
+                            FilledTonalButton(
+                                onClick = viewModel::refresh,
+                                shape = CircleShape
+                            ) {
                                 Text("Check for new cards")
                             }
                             TextButton(onClick = onNavigateToHistory) {
-                                Text("Review history")
+                                Text("Open Lore history")
                             }
                         }
                     }
@@ -355,39 +256,40 @@ fun LearnScreen(
                                 .padding(bottom = bottomContentPaddingCalculated),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            // 1. Brand logo with history action
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(6.dp))
                             Box(
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(horizontal = 16.dp)
+                                    .padding(horizontal = 20.dp, vertical = 4.dp)
                             ) {
                                 Image(
                                     painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
                                     contentDescription = "Lore",
                                     colorFilter = ColorFilter.tint(animatedAccentColor),
                                     modifier = Modifier
-                                        .height(32.dp)
+                                        .height(34.dp)
                                         .align(Alignment.Center)
                                 )
-                                IconButton(
-                                    onClick = onNavigateToHistory,
+                                Surface(
+                                    shape = CircleShape,
+                                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                    tonalElevation = 2.dp,
                                     modifier = Modifier.align(Alignment.CenterEnd)
                                 ) {
-                                    Icon(
-                                        imageVector = Icons.Rounded.History,
-                                        contentDescription = "Card history",
-                                        tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.85f)
-                                    )
+                                    IconButton(onClick = onNavigateToHistory) {
+                                        Icon(
+                                            imageVector = Icons.Rounded.History,
+                                            contentDescription = "Lore history",
+                                            tint = MaterialTheme.colorScheme.onSurface
+                                        )
+                                    }
                                 }
                             }
 
-                            // 2. Top flexible spacer (absorbs 50% of the dynamic vertical margin)
-                            Spacer(modifier = Modifier.weight(1f))
-
-                            // 3. Curiosity Card Stack with 28.dp horizontal padding to avoid being too wide
+                            Spacer(modifier = Modifier.height(30.dp))
                             CuriosityCardStack(
                                 questions = state.questionsStack,
+                                isCurrentEpisode = { id -> playerState.currentEpisode?.id == id },
                                 isCurrentlyPlaying = { id -> playerState.currentEpisode?.id == id && playerState.isPlaying },
                                 isCurrentlyLoading = { id -> playerState.currentEpisode?.id == id && playerState.isLoading },
                                 onSwipeLeft = { handleLearnCardAction("dismiss", it) },
@@ -398,41 +300,24 @@ fun LearnScreen(
                                 accentColor = animatedAccentColor,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .padding(horizontal = 28.dp)
+                                    .weight(1f)
+                                    .padding(horizontal = 20.dp)
                             )
-
-                            // 4. Middle spacer between card stack and controls (Tightly bounded to 10.dp)
-                            Spacer(modifier = Modifier.height(10.dp))
-
-                            // 5. Deck controls row (Dismiss, Info, Queue compact pill buttons on the screen bg below the card)
-                            val activeCard = state.questionsStack.firstOrNull()
-                            DeckControlsRow(
-                                activeCard = activeCard,
-                                onDismissClick = {
-                                    activeCard?.let { handleLearnCardAction("dismiss", it) }
-                                },
-                                onInfoClick = {
-                                    activeCard?.let { handleLearnCardAction("info", it) }
-                                },
-                                onQueueClick = {
-                                    activeCard?.let { handleLearnCardAction("queue", it) }
-                                }
-                            )
-
-                            // 6. Bottom flexible spacer (absorbs the other 50% of the dynamic vertical margin)
-                            Spacer(modifier = Modifier.weight(1f))
                         }
                     }
                     is LearnUiState.Error -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
+                        LoreStateCard(
+                            accentColor = animatedAccentColor,
+                            title = "Lore lost the thread",
+                            description = state.message,
+                            bottomContentPadding = bottomContentPaddingCalculated
                         ) {
-                            Text(
-                                text = state.message,
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.bodyMedium
-                            )
+                            FilledTonalButton(
+                                onClick = viewModel::refresh,
+                                shape = CircleShape
+                            ) {
+                                Text("Try again")
+                            }
                         }
                     }
                 }
@@ -442,122 +327,62 @@ fun LearnScreen(
 }
 
 @Composable
-private fun DeckControlsRow(
-    activeCard: DailyCuriosityDto?,
-    onDismissClick: () -> Unit,
-    onInfoClick: () -> Unit,
-    onQueueClick: () -> Unit,
-    modifier: Modifier = Modifier
+private fun LoreStateCard(
+    accentColor: Color,
+    title: String,
+    description: String,
+    bottomContentPadding: Dp,
+    content: @Composable () -> Unit
 ) {
-    if (activeCard == null) return
-
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = bottomContentPadding),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        // Dismiss Pill Button (Left)
-        Box(
+        Image(
+            painter = painterResource(id = cx.aswin.boxcast.core.designsystem.R.drawable.logo_lore),
+            contentDescription = "Lore",
+            colorFilter = ColorFilter.tint(accentColor),
+            modifier = Modifier.height(38.dp)
+        )
+        Spacer(modifier = Modifier.height(28.dp))
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 4.dp,
             modifier = Modifier
-                .height(36.dp)
-                .background(Color.Black.copy(alpha = 0.45f), RoundedCornerShape(18.dp))
-                .border(1.dp, Color.White.copy(alpha = 0.15f), RoundedCornerShape(18.dp))
-                .clip(RoundedCornerShape(18.dp))
-                .expressiveClickable(onClick = onDismissClick)
-                .padding(horizontal = 12.dp),
-            contentAlignment = Alignment.Center
+                .fillMaxWidth()
+                .widthIn(max = 460.dp)
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
+            Column(
+                modifier = Modifier.padding(horizontal = 28.dp, vertical = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Icon(
-                    imageVector = Icons.Filled.ArrowBack,
-                    contentDescription = null,
-                    tint = Color(0xFFFF6B6B),
-                    modifier = Modifier.size(14.dp)
-                )
-                Spacer(modifier = Modifier.width(6.dp))
                 Text(
-                    text = "DISMISS",
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.Black,
-                    letterSpacing = 1.1.sp,
-                    color = Color(0xFFFF6B6B)
+                    text = title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.ExtraBold,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
                 )
-            }
-        }
-
-        Spacer(modifier = Modifier.width(10.dp))
-
-        // Info Pill Button (Center)
-        Box(
-            modifier = Modifier
-                .height(36.dp)
-                .background(Color.Black.copy(alpha = 0.45f), RoundedCornerShape(18.dp))
-                .border(1.dp, Color.White.copy(alpha = 0.15f), RoundedCornerShape(18.dp))
-                .clip(RoundedCornerShape(18.dp))
-                .expressiveClickable(onClick = onInfoClick)
-                .padding(horizontal = 12.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.TouchApp,
-                    contentDescription = null,
-                    tint = Color.White.copy(alpha = 0.7f),
-                    modifier = Modifier.size(14.dp)
-                )
-                Spacer(modifier = Modifier.width(6.dp))
+                Spacer(modifier = Modifier.height(10.dp))
                 Text(
-                    text = "INFO",
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.Black,
-                    letterSpacing = 1.1.sp,
-                    color = Color.White.copy(alpha = 0.9f)
+                    text = description,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
                 )
-            }
-        }
-
-        Spacer(modifier = Modifier.width(10.dp))
-
-        // Queue Pill Button (Right)
-        Box(
-            modifier = Modifier
-                .height(36.dp)
-                .background(Color.Black.copy(alpha = 0.45f), RoundedCornerShape(18.dp))
-                .border(1.dp, Color.White.copy(alpha = 0.15f), RoundedCornerShape(18.dp))
-                .clip(RoundedCornerShape(18.dp))
-                .expressiveClickable(onClick = onQueueClick)
-                .padding(horizontal = 12.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.ArrowForward,
-                    contentDescription = null,
-                    tint = Color(0xFF69DB7C),
-                    modifier = Modifier.size(14.dp)
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Text(
-                    text = "QUEUE",
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.Black,
-                    letterSpacing = 1.1.sp,
-                    color = Color(0xFF69DB7C)
-                )
+                Spacer(modifier = Modifier.height(24.dp))
+                content()
             }
         }
     }
 }
 
-private fun extractDominantColor(bitmap: android.graphics.Bitmap): Color {
+internal fun extractDominantColor(bitmap: android.graphics.Bitmap): Color {
     val palette = androidx.palette.graphics.Palette.from(bitmap).generate()
     
     // 1. Get the absolute dominant swatch from the image palette
@@ -582,51 +407,6 @@ private fun extractDominantColor(bitmap: android.graphics.Bitmap): Color {
     // 5. Convert back to RGB and then Compose Color
     val colorInt = androidx.core.graphics.ColorUtils.HSLToColor(hsl)
     return Color(colorInt)
-}
-
-@Composable
-private fun CuratedShowItem(
-    show: CuratedCuriosityPodcastDto,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Column(
-        modifier = modifier
-            .width(110.dp)
-            .expressiveClickable(onClick = onClick)
-    ) {
-        OptimizedImage(
-            url = show.artwork ?: show.image ?: "",
-            proxyWidth = 220,
-            contentDescription = null,
-            modifier = Modifier
-                .size(110.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant)
-        )
-        
-        Spacer(modifier = Modifier.height(6.dp))
-        
-        Text(
-            text = show.title,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = FontWeight.Bold,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-        
-        val author = show.author
-        if (!author.isNullOrEmpty()) {
-            Text(
-                text = author,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-    }
 }
 
 private fun trackLearnCardAction(

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LoreVisuals.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LoreVisuals.kt
@@ -1,0 +1,144 @@
+package cx.aswin.boxcast.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+
+@Composable
+internal fun LoreHaloBackground(
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    val transition = rememberInfiniteTransition(label = "LoreHalo")
+    val pulse by transition.animateFloat(
+        initialValue = 0.92f,
+        targetValue = 1.08f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 8_000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "LoreHaloPulse"
+    )
+    val drift by transition.animateFloat(
+        initialValue = -24f,
+        targetValue = 24f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 12_000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "LoreHaloDrift"
+    )
+    val isDarkTheme = isSystemInDarkTheme()
+    val backgroundColor = MaterialTheme.colorScheme.background
+    val density = LocalDensity.current
+    val driftPx = with(density) { drift.dp.toPx() }
+    val pageBrush = remember(accentColor, backgroundColor, isDarkTheme) {
+        Brush.verticalGradient(
+            colors = if (isDarkTheme) {
+                listOf(backgroundColor, backgroundColor)
+            } else {
+                listOf(
+                    lerp(backgroundColor, accentColor, 0.07f),
+                    backgroundColor,
+                    lerp(backgroundColor, accentColor, 0.045f)
+                )
+            }
+        )
+    }
+    val topBrush = remember(accentColor, isDarkTheme) {
+        Brush.radialGradient(
+            colors = listOf(
+                accentColor.copy(alpha = if (isDarkTheme) 0.28f else 0.48f),
+                accentColor.copy(alpha = if (isDarkTheme) 0.08f else 0.16f),
+                Color.Transparent
+            )
+        )
+    }
+    val bottomBrush = remember(accentColor, isDarkTheme) {
+        Brush.radialGradient(
+            colors = listOf(
+                accentColor.copy(alpha = if (isDarkTheme) 0.20f else 0.36f),
+                accentColor.copy(alpha = if (isDarkTheme) 0.05f else 0.11f),
+                Color.Transparent
+            )
+        )
+    }
+    val sideBrush = remember(accentColor, isDarkTheme) {
+        Brush.radialGradient(
+            colors = listOf(
+                accentColor.copy(alpha = if (isDarkTheme) 0.10f else 0.22f),
+                Color.Transparent
+            )
+        )
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(pageBrush)
+            .clipToBounds()
+    ) {
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .offset(y = (-250).dp)
+                .size(540.dp)
+                .graphicsLayer {
+                    translationX = driftPx
+                    scaleX = pulse
+                    scaleY = pulse
+                }
+                .background(topBrush, CircleShape)
+        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .offset(x = 150.dp, y = 190.dp)
+                .size(440.dp)
+                .graphicsLayer {
+                    translationX = -driftPx
+                    val inversePulse = 2f - pulse
+                    scaleX = inversePulse
+                    scaleY = inversePulse
+                }
+                .background(bottomBrush, CircleShape)
+        )
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .offset(x = (-245).dp, y = 20.dp)
+                .size(500.dp)
+                .graphicsLayer {
+                    translationX = driftPx * 0.45f
+                    scaleX = 2f - pulse
+                    scaleY = 2f - pulse
+                }
+                .background(sideBrush, CircleShape)
+        )
+        content()
+    }
+}

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/SwipeableCardState.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/SwipeableCardState.kt
@@ -1,8 +1,9 @@
 package cx.aswin.boxcast.feature.explore
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.VectorConverter
-import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.spring
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -25,7 +26,10 @@ class SwipeableCardState(
             val targetX = if (direction == SwipeDirection.Left) -1500f else 1500f
             offset.animateTo(
                 targetValue = Offset(targetX, offset.value.y),
-                animationSpec = tween(durationMillis = 350)
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = Spring.StiffnessMedium
+                )
             )
             onSwiped(direction)
             offset.snapTo(Offset.Zero)
@@ -34,7 +38,12 @@ class SwipeableCardState(
 
     fun drag(dragAmount: Offset) {
         coroutineScope.launch {
-            offset.snapTo(offset.value + dragAmount)
+            offset.snapTo(
+                Offset(
+                    x = offset.value.x + dragAmount.x,
+                    y = 0f
+                )
+            )
         }
     }
 
@@ -42,7 +51,10 @@ class SwipeableCardState(
         coroutineScope.launch {
             offset.animateTo(
                 targetValue = Offset.Zero,
-                animationSpec = tween(durationMillis = 250)
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioLowBouncy,
+                    stiffness = Spring.StiffnessMedium
+                )
             )
         }
     }

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoScreen.kt
@@ -1091,12 +1091,19 @@ fun EpisodeInfoScreen(
                             type = "episode",
                             title = shareEpisode.title,
                             subtitle = podcastTitle,
+                            imageUrl = shareEpisode.imageUrl ?: shareEpisode.podcastImageUrl,
                             onDismissRequest = { showShareSheet = false },
                             durationMs = shareEpisode.duration * 1000L,
                             currentPositionMs = currentSuccessState?.resumePositionMs ?: 0L,
                             showTimestampOption = false,
-                            onShare = { _, _, t ->
-                                cx.aswin.boxcast.core.data.ShareManager.shareEpisode(context, shareEpisode, podcastTitle, t)
+                            onShare = { _, _, timestamp, target ->
+                                cx.aswin.boxcast.core.data.ShareManager.shareEpisode(
+                                    context = context,
+                                    episode = shareEpisode,
+                                    podcastTitle = podcastTitle,
+                                    timestampMs = timestamp,
+                                    target = target
+                                )
                             }
                         )
                     }

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoScreen.kt
@@ -1462,9 +1462,14 @@ fun PodcastInfoScreen(
                                     type = "podcast",
                                     title = sharePodcast.title,
                                     subtitle = sharePodcast.artist,
+                                    imageUrl = sharePodcast.imageUrl,
                                     onDismissRequest = { showShareSheet = false },
-                                    onShare = { _, _, _ ->
-                                        cx.aswin.boxcast.core.data.ShareManager.sharePodcast(context, sharePodcast)
+                                    onShare = { _, _, _, target ->
+                                        cx.aswin.boxcast.core.data.ShareManager.sharePodcast(
+                                            context = context,
+                                            podcast = sharePodcast,
+                                            target = target
+                                        )
                                     }
                                 )
                             }

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/v2/FullPlayerV2.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/v2/FullPlayerV2.kt
@@ -530,16 +530,18 @@ private fun PlayerShareSheet(
         type = "episode",
         title = model.episode.title,
         subtitle = model.podcast.title,
+        imageUrl = model.episode.imageUrl ?: model.podcast.imageUrl,
         onDismissRequest = { ui.showShareSheet = false },
         durationMs = model.episode.duration * 1000L,
         currentPositionMs = currentPosition,
         showTimestampOption = true,
-        onShare = { _, _, timestamp ->
+        onShare = { _, _, timestamp, target ->
             cx.aswin.boxcast.core.data.ShareManager.shareEpisode(
-                context,
-                model.episode,
-                model.podcast.title,
-                timestamp
+                context = context,
+                episode = model.episode,
+                podcastTitle = model.podcast.title,
+                timestampMs = timestamp,
+                target = target
             )
         }
     )
@@ -852,15 +854,13 @@ private fun MarqueeMetadataText(
     velocity: androidx.compose.ui.unit.Dp,
     onClick: () -> Unit
 ) {
-    var overflows by remember(text) { mutableStateOf(false) }
     Text(
         text = text,
         style = style,
         color = color,
         maxLines = 1,
         overflow = TextOverflow.Clip,
-        textAlign = if (overflows) TextAlign.Start else TextAlign.Center,
-        onTextLayout = { overflows = it.hasVisualOverflow },
+        textAlign = TextAlign.Center,
         modifier = Modifier
             .fillMaxWidth()
             .clipToBounds()
@@ -869,19 +869,13 @@ private fun MarqueeMetadataText(
                 indication = null,
                 onClick = onClick
             )
-            .then(
-                if (overflows) {
-                    Modifier.basicMarquee(
-                        iterations = Int.MAX_VALUE,
-                        animationMode = MarqueeAnimationMode.Immediately,
-                        repeatDelayMillis = 1_600,
-                        initialDelayMillis = 1_800,
-                        spacing = MarqueeSpacing.fractionOfContainer(0.18f),
-                        velocity = velocity
-                    )
-                } else {
-                    Modifier
-                }
+            .basicMarquee(
+                iterations = Int.MAX_VALUE,
+                animationMode = MarqueeAnimationMode.Immediately,
+                repeatDelayMillis = 1_600,
+                initialDelayMillis = 1_800,
+                spacing = MarqueeSpacing.fractionOfContainer(0.18f),
+                velocity = velocity
             )
     )
 }


### PR DESCRIPTION
## Summary

This PR delivers a full visual and interaction overhaul across Lore and sharing. It gives Lore a distinct branded identity while preserving Material 3 behavior, ensures curiosity content remains readable on constrained layouts, and introduces purpose-built message and Instagram Story sharing.

## Lore experience

- Rebuilds the Lore screen around an adaptive, palette-driven halo background that responds to episode artwork and remains visible in both light and dark themes.
- Replaces the previous feed treatment with a layered, fully rendered swipe deck so upcoming cards retain their artwork, color, metadata, and depth.
- Adds smoother card promotion, palette transitions, swipe arbitration, and expressive press feedback without the previous blinking or pop-in behavior.
- Moves dismiss, information, and queue actions into a compact in-card action row to keep emphasis on the curiosity itself.
- Introduces an integrated playback rail with a seekbar-inspired animated wave, clear loading/playback states, and balanced rounded geometry.
- Expands the Lore history screen with the same branded visual language and complete, untruncated curiosity text.

## Adaptive content and queue behavior

- Keeps questions and explanations readable without fixed line truncation.
- Detects explanation overflow and hides the podcast metadata strip only on affected cards, reclaiming space for the primary content.
- Adds a themed queue-conflict confirmation before replacing a normal queue with a Lore queue.
- Ensures the queue prompt is rendered inside the active app theme so its surfaces, text, icon, and actions follow light/dark mode correctly.

## Playback stability

- Removes the marquee overflow-state feedback loop in the expanded player by applying marquee behavior consistently, preventing vibrating or double-rendered metadata.

## Sharing experience

- Redesigns the share sheet around Copy, Send, and Story destinations with artwork preview and optional episode timestamp support.
- Generates polished square message cards and 9:16 Instagram Story cards with artwork, episode/podcast hierarchy, the boxlore wordmark, “is better on” wave branding, and a clearer “listen now” call to action.
- Uses Material expressive shapes from the shared design system for the generated card backgrounds.
- Adds direct Instagram Story intent support, URI permissions, availability fallback, and link-copy guidance for Instagram’s Link sticker.
- Improves message copy for podcast and episode shares while retaining timestamp and clip context in links.
- Centralizes podcast, episode, timestamp, and clip URL generation in `ShareLinkBuilder` to prevent copied and shared links from drifting.
- Adds `ShareTarget` routing so message and Story destinations can use layouts and intent behavior appropriate to each surface.

## Technical notes

- Adds reusable Lore visual primitives and Android-canvas rendering support for selected design-system expressive shapes.
- Updates all three share entry points: full player, episode details, and podcast details.
- Declares Instagram Story intent visibility in the application manifest.

## Test plan

- [x] Run `./gradlew compileDebugKotlin`
- [x] Run staged secret scan with gitleaks
- [x] Install the debug build on the connected physical device with `./gradlew installDebug`
- [x] Manually exercise Lore card layouts, card swiping, playback, queue conflict handling, and light/dark presentation
- [x] Manually exercise podcast and episode sharing through Copy, Send, and Instagram Story paths

Made with [Cursor](https://cursor.com)