### PR TITLE
fix: survey dark contrast and fcm topic reconciliation

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -48,6 +48,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.withStyle
@@ -403,6 +406,25 @@ class MainActivity : ComponentActivity() {
             
             // 4. Subscription Repository
             val subscriptionRepository = remember { cx.aswin.boxcast.core.data.SubscriptionRepository(database.podcastDao()) }
+
+            // Reconcile FCM topic subscriptions after a backup restore.
+            // The sentinel file lives in noBackupFilesDir so it is NOT restored —
+            // its absence signals a fresh install or restore, triggering re-subscription.
+            LaunchedEffect(Unit) {
+                kotlinx.coroutines.Dispatchers.IO.let { io ->
+                    kotlinx.coroutines.withContext(io) {
+                        val sentinel = java.io.File(noBackupFilesDir, "fcm_topics_synced")
+                        if (!sentinel.exists()) {
+                            subscriptionRepository.reconcileFcmTopicSubscriptions()
+                            try {
+                                sentinel.createNewFile()
+                            } catch (e: Exception) {
+                                android.util.Log.e("FCM_Topic", "Failed to write sentinel", e)
+                            }
+                        }
+                    }
+                }
+            }
             
             // Privacy & Preferences
             val consentManager = remember { cx.aswin.boxcast.core.data.privacy.ConsentManager(application) }
@@ -858,9 +880,12 @@ class MainActivity : ComponentActivity() {
                 if (onboardingCompleted && activeAnnouncement != null) {
                     val announcement = activeAnnouncement!!
                     val context = LocalContext.current
-                    
-                    @androidx.compose.runtime.Composable
-                    fun parseSimpleMarkdown(text: String): androidx.compose.ui.text.AnnotatedString {
+
+                    // Structured Block Type
+                    data class BodyBlock(val text: androidx.compose.ui.text.AnnotatedString, val isBullet: Boolean)
+
+                    // Inline markdown parsing (bold/italic)
+                    fun parseSimpleMarkdownInline(text: String): androidx.compose.ui.text.AnnotatedString {
                         return androidx.compose.ui.text.buildAnnotatedString {
                             var currentIndex = 0
                             val regex = Regex("\\*\\*(.*?)\\*\\*|\\*(.*?)\\*")
@@ -882,6 +907,26 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
+                    // Parse body text into structured paragraphs and bullet list items
+                    fun parseBodyToBlocks(body: String): List<BodyBlock> {
+                        val lines = body.split("\n")
+                        val blocks = mutableListOf<BodyBlock>()
+                        for (line in lines) {
+                            val trimmed = line.trim()
+                            if (trimmed.isEmpty()) continue
+                            
+                            // Match bullets like "- item", "* item", or "• item"
+                            val bulletMatch = Regex("^(?:-|\\*|•)\\s+(.*)$").matchEntire(trimmed)
+                            if (bulletMatch != null) {
+                                val content = bulletMatch.groupValues[1]
+                                blocks.add(BodyBlock(parseSimpleMarkdownInline(content), isBullet = true))
+                            } else {
+                                blocks.add(BodyBlock(parseSimpleMarkdownInline(line), isBullet = false))
+                            }
+                        }
+                        return blocks
+                    }
+
                     androidx.compose.ui.window.Dialog(
                         onDismissRequest = { 
                             scope.launch { userPrefs.clearAnnouncement() }
@@ -893,12 +938,13 @@ class MainActivity : ComponentActivity() {
                             tonalElevation = 6.dp,
                             modifier = androidx.compose.ui.Modifier
                                 .fillMaxWidth()
+                                .heightIn(max = 520.dp)
                                 .padding(16.dp)
                         ) {
                             androidx.compose.foundation.layout.Column(
                                 modifier = androidx.compose.ui.Modifier.padding(20.dp)
                             ) {
-                                // Custom Megaphone/Branded Category Chip
+                                // 1. Header (Category Chip)
                                 androidx.compose.foundation.layout.Row(
                                     verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
                                     modifier = androidx.compose.ui.Modifier.padding(bottom = 12.dp)
@@ -917,54 +963,93 @@ class MainActivity : ComponentActivity() {
                                                 contentDescription = null,
                                                 tint = androidx.compose.material3.MaterialTheme.colorScheme.onPrimaryContainer,
                                                 modifier = androidx.compose.ui.Modifier.size(12.dp)
-                                            )
-                                            androidx.compose.foundation.layout.Spacer(modifier = androidx.compose.ui.Modifier.width(4.dp))
-                                            androidx.compose.material3.Text(
-                                                 text = announcement.category.uppercase(),
-                                                 style = androidx.compose.material3.MaterialTheme.typography.labelSmall.copy(
-                                                     fontWeight = androidx.compose.ui.text.font.FontWeight.ExtraBold,
-                                                     letterSpacing = 1.2.sp
-                                                 ),
-                                                 color = androidx.compose.material3.MaterialTheme.colorScheme.onPrimaryContainer
                                              )
+                                             androidx.compose.foundation.layout.Spacer(modifier = androidx.compose.ui.Modifier.width(4.dp))
+                                             androidx.compose.material3.Text(
+                                                  text = announcement.category.uppercase(),
+                                                  style = androidx.compose.material3.MaterialTheme.typography.labelSmall.copy(
+                                                      fontWeight = androidx.compose.ui.text.font.FontWeight.ExtraBold,
+                                                      letterSpacing = 1.2.sp
+                                                  ),
+                                                  color = androidx.compose.material3.MaterialTheme.colorScheme.onPrimaryContainer
+                                              )
                                         }
                                     }
                                 }
 
-                                // Image
-                                if (!announcement.imageUrl.isNullOrBlank()) {
-                                    coil.compose.AsyncImage(
-                                        model = announcement.imageUrl,
-                                        contentDescription = "Announcement Image",
-                                        modifier = androidx.compose.ui.Modifier
-                                            .fillMaxWidth()
-                                            .height(160.dp)
-                                            .padding(bottom = 16.dp)
-                                            .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp)),
-                                        contentScale = androidx.compose.ui.layout.ContentScale.Crop
+                                // 2. Scrollable Middle Area (Image, Title, and Parsed Body Blocks)
+                                androidx.compose.foundation.layout.Column(
+                                    modifier = androidx.compose.ui.Modifier
+                                        .weight(1f, fill = false)
+                                        .verticalScroll(androidx.compose.foundation.rememberScrollState())
+                                ) {
+                                    // Image
+                                    if (!announcement.imageUrl.isNullOrBlank()) {
+                                        coil.compose.AsyncImage(
+                                            model = announcement.imageUrl,
+                                            contentDescription = "Announcement Image",
+                                            modifier = androidx.compose.ui.Modifier
+                                                .fillMaxWidth()
+                                                .height(160.dp)
+                                                .padding(bottom = 16.dp)
+                                                .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp)),
+                                            contentScale = androidx.compose.ui.layout.ContentScale.Crop
+                                        )
+                                    }
+
+                                    // Title
+                                    androidx.compose.material3.Text(
+                                        text = announcement.title,
+                                        style = androidx.compose.material3.MaterialTheme.typography.titleLarge.copy(
+                                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                                        ),
+                                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface,
+                                        modifier = androidx.compose.ui.Modifier.padding(bottom = 12.dp)
                                     )
+
+                                    // Body Blocks
+                                    val blocks = remember(announcement.body) { parseBodyToBlocks(announcement.body) }
+                                    androidx.compose.foundation.layout.Column(
+                                        verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        blocks.forEach { block ->
+                                            if (block.isBullet) {
+                                                androidx.compose.foundation.layout.Row(
+                                                    modifier = androidx.compose.ui.Modifier.fillMaxWidth(),
+                                                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.Start,
+                                                    verticalAlignment = androidx.compose.ui.Alignment.Top
+                                                ) {
+                                                    androidx.compose.material3.Text(
+                                                        text = "•",
+                                                        style = androidx.compose.material3.MaterialTheme.typography.bodyMedium.copy(
+                                                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                                                        ),
+                                                        color = androidx.compose.material3.MaterialTheme.colorScheme.primary,
+                                                        modifier = androidx.compose.ui.Modifier.padding(start = 8.dp, end = 8.dp)
+                                                    )
+                                                    androidx.compose.material3.Text(
+                                                        text = block.text,
+                                                        style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+                                                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
+                                                        modifier = androidx.compose.ui.Modifier.weight(1f)
+                                                    )
+                                                }
+                                            } else {
+                                                androidx.compose.material3.Text(
+                                                    text = block.text,
+                                                    style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
+                                                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
+                                                    modifier = androidx.compose.ui.Modifier.fillMaxWidth()
+                                                )
+                                            }
+                                        }
+                                    }
                                 }
 
-                                // Title
-                                androidx.compose.material3.Text(
-                                    text = announcement.title,
-                                    style = androidx.compose.material3.MaterialTheme.typography.titleLarge.copy(
-                                        fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
-                                    ),
-                                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface,
-                                    modifier = androidx.compose.ui.Modifier.padding(bottom = 8.dp)
-                                )
 
-                                // Body
-                                val parsedBody = parseSimpleMarkdown(announcement.body)
-                                androidx.compose.material3.Text(
-                                    text = parsedBody,
-                                    style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
-                                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = androidx.compose.ui.Modifier.padding(bottom = 20.dp)
-                                )
+                                androidx.compose.foundation.layout.Spacer(modifier = androidx.compose.ui.Modifier.height(20.dp))
 
-                                // Buttons Row
+                                // 3. Action Buttons (Pinned to bottom)
                                 androidx.compose.foundation.layout.Row(
                                     modifier = androidx.compose.ui.Modifier.fillMaxWidth(),
                                     horizontalArrangement = androidx.compose.foundation.layout.Arrangement.End,
@@ -1008,6 +1093,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 }
+
 
                 // Currently bundled feature announcements in this app version
                 val featureAnnouncementId = "android_auto_1_3_6"

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -411,17 +411,13 @@ class MainActivity : ComponentActivity() {
             // The sentinel file lives in noBackupFilesDir so it is NOT restored —
             // its absence signals a fresh install or restore, triggering re-subscription.
             LaunchedEffect(Unit) {
-                kotlinx.coroutines.Dispatchers.IO.let { io ->
-                    kotlinx.coroutines.withContext(io) {
-                        val sentinel = java.io.File(noBackupFilesDir, "fcm_topics_synced")
-                        if (!sentinel.exists()) {
-                            subscriptionRepository.reconcileFcmTopicSubscriptions()
-                            try {
-                                sentinel.createNewFile()
-                            } catch (e: Exception) {
-                                android.util.Log.e("FCM_Topic", "Failed to write sentinel", e)
-                            }
-                        }
+                val sentinel = java.io.File(noBackupFilesDir, "fcm_topics_synced")
+                if (!sentinel.exists()) {
+                    subscriptionRepository.reconcileFcmTopicSubscriptions()
+                    try {
+                        sentinel.createNewFile()
+                    } catch (e: Exception) {
+                        android.util.Log.e("FCM_Topic", "Failed to write sentinel", e)
                     }
                 }
             }

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyAppearance.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyAppearance.kt
@@ -93,9 +93,22 @@ internal fun PostHogDisplaySurveyAppearance?.resolve(
     val submitButtonColor = parseSurveyColorOrDefault(this?.submitButtonColor, defaults.primary)
     val submitButtonTextColor =
         parseSurveyColorOrDefault(this?.submitButtonTextColor, defaults.onPrimary)
-    val textColor = parseSurveyColorOrDefault(this?.textColor, defaults.onSurface)
-    val descriptionTextColor =
+    val rawTextColor = parseSurveyColorOrDefault(this?.textColor, defaults.onSurface)
+    val rawDescriptionTextColor =
         parseSurveyColorOrDefault(this?.descriptionTextColor, defaults.onSurfaceVariant)
+    // PostHog may send hardcoded light-mode text colors (e.g. black) from the dashboard
+    // config. The actual sheet background is always MaterialTheme.colorScheme.surface
+    // (defaults.background), not the PostHog backgroundColor, so contrast must be checked
+    // against the real rendered surface to prevent black-on-black in dark mode.
+    val sheetBackground = defaults.background
+    val textColor =
+        if (hasAdequateContrast(rawTextColor, sheetBackground)) rawTextColor else defaults.onSurface
+    val descriptionTextColor =
+        if (hasAdequateContrast(rawDescriptionTextColor, sheetBackground)) {
+            rawDescriptionTextColor
+        } else {
+            defaults.onSurfaceVariant
+        }
     val borderColor = parseSurveyColorOrDefault(this?.borderColor, defaults.outlineVariant)
     val ratingButtonColor =
         parseSurveyColorOrDefault(this?.ratingButtonColor, defaults.surfaceContainerHigh)
@@ -103,11 +116,18 @@ internal fun PostHogDisplaySurveyAppearance?.resolve(
         parseSurveyColorOrDefault(this?.ratingButtonActiveColor, defaults.primaryContainer)
     val ratingButtonActiveTextColor = defaults.onPrimaryContainer
     val submitButtonText = this?.submitButtonText?.takeIf { it.isNotBlank() } ?: "Submit"
-    val questionTextColor = parseSurveyColorOrDefault(this?.textColor, defaults.onSurface)
+    val questionTextColor =
+        if (hasAdequateContrast(rawTextColor, sheetBackground)) rawTextColor else defaults.onSurface
     val inputBackgroundColor =
         parseSurveyColorOrDefault(this?.inputBackground, defaults.surfaceContainerHighest)
-    val inputTextColor =
+    val rawInputTextColor =
         parseSurveyColorOrDefault(this?.inputTextColor, defaults.onSurface)
+    val inputTextColor =
+        if (hasAdequateContrast(rawInputTextColor, inputBackgroundColor)) {
+            rawInputTextColor
+        } else {
+            defaults.onSurface
+        }
     val placeholderTextColor = defaults.onSurfaceVariant.copy(alpha = 0.7f)
     val placeholder = this?.placeholder?.takeIf { it.isNotBlank() } ?: DEFAULT_PLACEHOLDER
     val displayThankYouMessage = this?.displayThankYouMessage ?: false

--- a/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyColor.kt
+++ b/app/src/main/java/cx/aswin/boxcast/surveys/internal/theme/SurveyColor.kt
@@ -46,6 +46,22 @@ internal fun Color.isLight(): Boolean {
     return luminance >= 0.6f
 }
 
+/**
+ * Returns true when [foreground] has enough perceptual contrast against [background]
+ * to remain legible. Uses a simplified relative-luminance ratio check; the threshold
+ * of 1.8 catches obvious clashes like black-on-black or white-on-white while still
+ * accepting most intentional PostHog color pairings.
+ */
+internal fun hasAdequateContrast(foreground: Color, background: Color): Boolean {
+    fun luminance(c: Color): Float =
+        0.2126f * c.red + 0.7152f * c.green + 0.0722f * c.blue
+
+    val fgL = luminance(foreground) + 0.05f
+    val bgL = luminance(background) + 0.05f
+    val ratio = maxOf(fgL, bgL) / minOf(fgL, bgL)
+    return ratio >= 1.8f
+}
+
 private fun isHexDigit(c: Char): Boolean = c in '0'..'9' || c in 'a'..'f' || c in 'A'..'F'
 
 // CSS named-color table (140 entries + transparency aliases). Uppercased keys.

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SubscriptionRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SubscriptionRepository.kt
@@ -202,4 +202,34 @@ class SubscriptionRepository(
     suspend fun setAutoDownloadEnabled(podcastId: String, enabled: Boolean) {
         podcastDao.setAutoDownloadEnabled(podcastId, enabled)
     }
+
+    /**
+     * Re-subscribes all notification-enabled podcasts to their FCM topics.
+     *
+     * After an uninstall/reinstall or device migration, the Room database may be
+     * restored from backup while the FCM token is new and has no topic
+     * subscriptions. This method reconciles the two by iterating every podcast
+     * where [PodcastEntity.notificationsEnabled] is true and calling
+     * [updateFirebaseSubscription] to re-register with Firebase.
+     */
+    suspend fun reconcileFcmTopicSubscriptions() {
+        try {
+            val podcasts = podcastDao.getNotificationEnabledPodcasts()
+            if (podcasts.isEmpty()) return
+            android.util.Log.i(
+                "FCM_Topic",
+                "Reconciling ${podcasts.size} FCM topic subscriptions after restore",
+            )
+            for (entity in podcasts) {
+                updateFirebaseSubscription(
+                    podcastId = entity.podcastId,
+                    title = entity.title,
+                    imageUrl = entity.imageUrl,
+                    isSubscribed = true,
+                )
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("FCM_Topic", "FCM topic reconciliation failed", e)
+        }
+    }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/database/PodcastDao.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/database/PodcastDao.kt
@@ -39,4 +39,7 @@ interface PodcastDao {
 
     @Query("UPDATE podcasts SET autoDownloadEnabled = :enabled WHERE podcastId = :id")
     suspend fun setAutoDownloadEnabled(id: String, enabled: Boolean)
+
+    @Query("SELECT * FROM podcasts WHERE notificationsEnabled = 1")
+    suspend fun getNotificationEnabledPodcasts(): List<PodcastEntity>
 }

--- a/docs/notification-fix.md
+++ b/docs/notification-fix.md
@@ -1,0 +1,35 @@
+# Notification Sync Fix
+
+If you recently reinstalled BoxLore or migrated to a new Android device, you might notice that you are no longer receiving push notifications for new episodes, even though the toggle switches in the app show they are turned **ON**.
+
+Here is why this happens and how you can fix it in under a minute.
+
+---
+
+## Why did this happen?
+
+1. **Database Restore**: When you reinstall BoxLore, Android's Auto Backup system automatically restores your local database (your subscriptions, listening history, and settings).
+2. **New Token**: Because the app was reinstalled, your device generated a fresh Firebase Cloud Messaging (FCM) token.
+3. **Missing Subscriptions**: While your settings show notifications are enabled, the new FCM token was never registered to the podcast release topics on Firebase.
+
+---
+
+## How to fix it (Step-by-Step)
+
+To force your new device token to register with Firebase, follow these quick steps:
+
+1. Open **BoxLore**.
+2. Go to your **Library** and select a podcast you want notifications for.
+3. Tap the **Notification Toggle** (bell icon) to turn it **OFF**.
+4. Tap the toggle again to turn it **ON**.
+5. Repeat this for other subscribed podcasts if necessary.
+
+Toggling the setting off and back on forces BoxLore to send your new token to Firebase and re-subscribe you to the correct release topics.
+
+---
+
+## Will this happen again?
+
+**No.** We have implemented a permanent fix in version **v1.3.7** and later. The app now automatically checks for new device installs and reconciles your notification preferences on launch, so you will never have to manually re-toggle them again.
+
+Thank you for your patience, and happy listening!

--- a/docs/notification-fix.md
+++ b/docs/notification-fix.md
@@ -1,6 +1,6 @@
 # Notification Sync Fix
 
-If you recently reinstalled BoxLore or migrated to a new Android device, you might notice that you are no longer receiving push notifications for new episodes, even though the toggle switches in the app show they are turned **ON**.
+If you recently reinstalled boxlore or migrated to a new Android device, you might notice that you are no longer receiving push notifications for new episodes, even though the toggle switches in the app show they are turned **ON**.
 
 Here is why this happens and how you can fix it in under a minute.
 
@@ -8,7 +8,7 @@ Here is why this happens and how you can fix it in under a minute.
 
 ## Why did this happen?
 
-1. **Database Restore**: When you reinstall BoxLore, Android's Auto Backup system automatically restores your local database (your subscriptions, listening history, and settings).
+1. **Database Restore**: When you reinstall boxlore, Android's Auto Backup system automatically restores your local database (your subscriptions, listening history, and settings).
 2. **New Token**: Because the app was reinstalled, your device generated a fresh Firebase Cloud Messaging (FCM) token.
 3. **Missing Subscriptions**: While your settings show notifications are enabled, the new FCM token was never registered to the podcast release topics on Firebase.
 
@@ -18,13 +18,13 @@ Here is why this happens and how you can fix it in under a minute.
 
 To force your new device token to register with Firebase, follow these quick steps:
 
-1. Open **BoxLore**.
+1. Open **boxlore**.
 2. Go to your **Library** and select a podcast you want notifications for.
 3. Tap the **Notification Toggle** (bell icon) to turn it **OFF**.
 4. Tap the toggle again to turn it **ON**.
 5. Repeat this for other subscribed podcasts if necessary.
 
-Toggling the setting off and back on forces BoxLore to send your new token to Firebase and re-subscribe you to the correct release topics.
+Toggling the setting off and back on forces boxlore to send your new token to Firebase and re-subscribe you to the correct release topics.
 
 ---
 


### PR DESCRIPTION
### Summary
1. **Survey Dark Mode Contrast**: Resolves a bug where PostHog-supplied light-mode colors (e.g. black text) caused illegible dark-on-dark rendering in dark mode. The app now calculates contrast ratios against the Material surface background, falling back to Material theme text tokens when contrast falls below a 1.8 threshold.
2. **FCM Topic Reconciliation**: Fixes a stale notification setup state after an uninstall/reinstall or device migration. Re-subscribes all notification-enabled podcasts to their FCM topics using a sentinel file in `noBackupFilesDir` (which does not persist across reinstalls, signaling a fresh setup).
3. **Markdown List Rendering**: Announcement dialog now parses and renders bullet list items correctly.
4. **Dialog Sizing**: Constrains dialog height with headroom and scroll support.
5. **Documentation**: Added documentation on fcm notification fix for affected users.