### PR TITLE
fix(player): stabilize artwork transition and style next episode chevron

### DIFF
--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/v2/FullPlayerV2.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/v2/FullPlayerV2.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -585,6 +586,11 @@ private fun FullPlayerBody(
             .fillMaxSize()
             .playerCanvas(display.colorScheme)
     ) {
+        val configuration = LocalConfiguration.current
+        val screenWidth = configuration.screenWidthDp.dp
+        val screenHeight = configuration.screenHeightDp.dp
+        val finalMaxHeight = screenHeight - resources.statusBarPadding - resources.navBarPadding
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -606,6 +612,7 @@ private fun FullPlayerBody(
                     .fillMaxSize()
                     .nestedScroll(display.sheetNestedScrollConnection)
             ) {
+                val layoutValues = calculateResponsiveHeroLayout(screenWidth, finalMaxHeight, model.isVideo)
                 FullPlayerScrollableContent(
                     model = model,
                     dependencies = dependencies,
@@ -615,7 +622,7 @@ private fun FullPlayerBody(
                     ui = ui,
                     resources = FullPlayerScrollResources(
                         resources.scope,
-                        calculateResponsiveHeroLayout(maxWidth, maxHeight, model.isVideo)
+                        layoutValues
                     )
                 )
             }

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/v2/PlayerHero.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/v2/PlayerHero.kt
@@ -13,8 +13,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -230,7 +232,6 @@ private fun PlayerArtworkPager(
                 }
             }
             NextEpisodeHint(
-                width = dimensions.width,
                 height = dimensions.height,
                 colorScheme = colorScheme
             )
@@ -239,26 +240,35 @@ private fun PlayerArtworkPager(
 }
 
 @Composable
-private fun NextEpisodeHint(width: Dp, height: Dp, colorScheme: ColorScheme) {
+private fun NextEpisodeHint(height: Dp, colorScheme: ColorScheme) {
     Box(
         modifier = Modifier
-            .width(width + 88.dp)
+            .fillMaxWidth()
             .height(height)
     ) {
-        Surface(
-            modifier = Modifier.align(Alignment.CenterEnd).size(32.dp),
-            shape = CircleShape,
-            color = colorScheme.surface.copy(alpha = 0.72f),
-            contentColor = colorScheme.onSurfaceVariant,
-            shadowElevation = 2.dp
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .offset(x = 16.dp)
+                .size(36.dp),
+            contentAlignment = Alignment.Center
         ) {
-            Box(contentAlignment = Alignment.Center) {
-                Icon(
-                    imageVector = Icons.Rounded.KeyboardArrowRight,
-                    contentDescription = "Swipe for next episode",
-                    modifier = Modifier.size(21.dp)
-                )
-            }
+            // Drop shadow layer: Offset black icon with alpha
+            Icon(
+                imageVector = Icons.Rounded.KeyboardArrowRight,
+                contentDescription = null,
+                tint = Color.Black.copy(alpha = 0.5f),
+                modifier = Modifier
+                    .size(32.dp)
+                    .offset(x = 1.dp, y = 1.5.dp)
+            )
+            // Foreground M3 accent icon
+            Icon(
+                imageVector = Icons.Rounded.KeyboardArrowRight,
+                contentDescription = "Swipe for next episode",
+                tint = colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
         }
     }
 }


### PR DESCRIPTION
This PR fixes the jerky transition of the artwork image in the full player bottom sheet during drag transitions and styles/positions the next episode chevron indicator to match Material 3 accents.