### PR TITLE
feat(announcements): polish in-app dialog and skip Play Store release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,15 @@
 - [ ] `user-impact-low`
 - [ ] `no-user-impact`
 
+### Listener impact — **required when** `user-impact-high` or `user-impact-medium`
+
+<!-- Write this for a listener, not an engineer. What is different in their day-to-day use of boxlore after this ships? -->
+<!-- Skip only for `user-impact-low` or `no-user-impact`. -->
+
+**What changes in the user’s life:**
+
+-
+
 ### Backend — optional, **pairable** with any user-impact level
 
 | Label | Use when |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,14 @@
+## Title (required)
+
+Use Conventional Commits. Examples from this repo:
+
+- `feat(scope): short description`
+- `fix(scope): short description`
+- `chore: short description`
+- `release: vX.Y.Z [skip changelog]`
+
+Do **not** use sentence-case titles without a type prefix (e.g. avoid `Polish the announcement dialog`).
+
 ## Summary
 
 <!-- What changed and why. Release notes / changelog bullets are derived from this — be specific. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,24 @@
 ## Summary
 
-<!-- What changed and why (1–3 bullets). Keep it clear — release notes are derived from this. -->
+<!-- What changed and why. Release notes / changelog bullets are derived from this — be specific. -->
+
+-
+
+## Motivation
+
+<!-- Why this change exists. What problem or gap does it address for listeners or maintainers? -->
+
+-
+
+## What changed
+
+<!-- Concrete product / code changes. Prefer bullets over vague summaries. -->
+
+-
+
+## Behavior & compatibility
+
+<!-- User-visible behavior before/after. Call out FCM/API/payload compatibility, defaults, and anything older clients still rely on. -->
 
 -
 
@@ -34,9 +52,12 @@ Add the labels on the PR (`gh pr edit <n> --add-label user-impact-high --add-lab
 
 ## Test plan
 
+<!-- Checklist of concrete verification steps for this PR. Mark items done before merge when possible. -->
+
 - [ ] Built / installed locally (`./gradlew installDebug`) when UI or app behavior changed
 - [ ] Manual checks for the user-visible paths touched by this PR
+- [ ]
 
 ## Notes (optional)
 
-<!-- Screenshots, rollout risks, follow-ups. -->
+<!-- Screenshots, rollout risks, follow-ups, related deploys (e.g. admin hosting), out of scope. -->

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -900,7 +900,7 @@ def notification_bullets(content: str, version: AppVersion) -> list[str]:
         ):
             continue
         bullets.append(shorten_notification_line(candidate))
-        if len(bullets) == 3:
+        if len(bullets) == 5:
             break
     if not bullets:
         fail(f"README What's New block for {version.tag} has no notification text")

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -105,6 +105,7 @@ import cx.aswin.boxcast.core.designsystem.component.ExpressiveAnimatedBackground
 import cx.aswin.boxcast.core.designsystem.theme.ExpressiveMotion
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
+import cx.aswin.boxcast.util.isInstalledFromPlayStore
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.CircularProgressIndicator
@@ -875,218 +876,34 @@ class MainActivity : ComponentActivity() {
                 // Show Announcement Dialog if onboarding is completed
                 if (onboardingCompleted && activeAnnouncement != null) {
                     val announcement = activeAnnouncement!!
-                    val context = LocalContext.current
+                    val announcementContext = LocalContext.current
+                    val suppressWhatsNewOnPlay =
+                        announcementContext.isInstalledFromPlayStore() &&
+                            cx.aswin.boxcast.ui.announcement.resolveAnnouncementLayout(announcement.category) ==
+                            cx.aswin.boxcast.ui.announcement.AnnouncementLayout.WhatsNew
 
-                    // Structured Block Type
-                    data class BodyBlock(val text: androidx.compose.ui.text.AnnotatedString, val isBullet: Boolean)
-
-                    // Inline markdown parsing (bold/italic)
-                    fun parseSimpleMarkdownInline(text: String): androidx.compose.ui.text.AnnotatedString {
-                        return androidx.compose.ui.text.buildAnnotatedString {
-                            var currentIndex = 0
-                            val regex = Regex("\\*\\*(.*?)\\*\\*|\\*(.*?)\\*")
-                            val matches = regex.findAll(text)
-                            for (match in matches) {
-                                append(text.substring(currentIndex, match.range.first))
-                                if (match.groups[1] != null) {
-                                    withStyle(androidx.compose.ui.text.SpanStyle(fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)) {
-                                        append(match.groupValues[1])
-                                    }
-                                } else if (match.groups[2] != null) {
-                                    withStyle(androidx.compose.ui.text.SpanStyle(fontStyle = androidx.compose.ui.text.font.FontStyle.Italic)) {
-                                        append(match.groupValues[2])
-                                    }
-                                }
-                                currentIndex = match.range.last + 1
-                            }
-                            append(text.substring(currentIndex))
+                    if (suppressWhatsNewOnPlay) {
+                        LaunchedEffect(announcement.timestamp, announcement.category) {
+                            userPrefs.clearAnnouncement()
                         }
-                    }
-
-                    // Parse body text into structured paragraphs and bullet list items
-                    fun parseBodyToBlocks(body: String): List<BodyBlock> {
-                        val lines = body.split("\n")
-                        val blocks = mutableListOf<BodyBlock>()
-                        for (line in lines) {
-                            val trimmed = line.trim()
-                            if (trimmed.isEmpty()) continue
-                            
-                            // Match bullets like "- item", "* item", or "• item"
-                            val bulletMatch = Regex("^(?:-|\\*|•)\\s+(.*)$").matchEntire(trimmed)
-                            if (bulletMatch != null) {
-                                val content = bulletMatch.groupValues[1]
-                                blocks.add(BodyBlock(parseSimpleMarkdownInline(content), isBullet = true))
-                            } else {
-                                blocks.add(BodyBlock(parseSimpleMarkdownInline(line), isBullet = false))
-                            }
-                        }
-                        return blocks
-                    }
-
-                    androidx.compose.ui.window.Dialog(
-                        onDismissRequest = { 
-                            scope.launch { userPrefs.clearAnnouncement() }
-                        }
-                    ) {
-                        androidx.compose.material3.Surface(
-                            shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
-                            color = androidx.compose.material3.MaterialTheme.colorScheme.surfaceContainerHigh,
-                            tonalElevation = 6.dp,
-                            modifier = androidx.compose.ui.Modifier
-                                .fillMaxWidth()
-                                .heightIn(max = 520.dp)
-                                .padding(16.dp)
-                        ) {
-                            androidx.compose.foundation.layout.Column(
-                                modifier = androidx.compose.ui.Modifier.padding(20.dp)
-                            ) {
-                                // 1. Header (Category Chip)
-                                androidx.compose.foundation.layout.Row(
-                                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
-                                    modifier = androidx.compose.ui.Modifier.padding(bottom = 12.dp)
-                                ) {
-                                    androidx.compose.material3.Surface(
-                                        color = androidx.compose.material3.MaterialTheme.colorScheme.primaryContainer,
-                                        shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp),
-                                        modifier = androidx.compose.ui.Modifier.padding(end = 8.dp)
-                                    ) {
-                                        androidx.compose.foundation.layout.Row(
-                                            modifier = androidx.compose.ui.Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
-                                            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
-                                        ) {
-                                            androidx.compose.material3.Icon(
-                                                imageVector = androidx.compose.material.icons.Icons.Rounded.NotificationsActive,
-                                                contentDescription = null,
-                                                tint = androidx.compose.material3.MaterialTheme.colorScheme.onPrimaryContainer,
-                                                modifier = androidx.compose.ui.Modifier.size(12.dp)
-                                             )
-                                             androidx.compose.foundation.layout.Spacer(modifier = androidx.compose.ui.Modifier.width(4.dp))
-                                             androidx.compose.material3.Text(
-                                                  text = announcement.category.uppercase(),
-                                                  style = androidx.compose.material3.MaterialTheme.typography.labelSmall.copy(
-                                                      fontWeight = androidx.compose.ui.text.font.FontWeight.ExtraBold,
-                                                      letterSpacing = 1.2.sp
-                                                  ),
-                                                  color = androidx.compose.material3.MaterialTheme.colorScheme.onPrimaryContainer
-                                              )
-                                        }
-                                    }
-                                }
-
-                                // 2. Scrollable Middle Area (Image, Title, and Parsed Body Blocks)
-                                androidx.compose.foundation.layout.Column(
-                                    modifier = androidx.compose.ui.Modifier
-                                        .weight(1f, fill = false)
-                                        .verticalScroll(androidx.compose.foundation.rememberScrollState())
-                                ) {
-                                    // Image
-                                    if (!announcement.imageUrl.isNullOrBlank()) {
-                                        coil.compose.AsyncImage(
-                                            model = announcement.imageUrl,
-                                            contentDescription = "Announcement Image",
-                                            modifier = androidx.compose.ui.Modifier
-                                                .fillMaxWidth()
-                                                .height(160.dp)
-                                                .padding(bottom = 16.dp)
-                                                .clip(androidx.compose.foundation.shape.RoundedCornerShape(12.dp)),
-                                            contentScale = androidx.compose.ui.layout.ContentScale.Crop
+                    } else {
+                        cx.aswin.boxcast.ui.announcement.InAppAnnouncementDialog(
+                            announcement = announcement,
+                            onDismiss = { scope.launch { userPrefs.clearAnnouncement() } },
+                            onAction = { route ->
+                                scope.launch { userPrefs.clearAnnouncement() }
+                                try {
+                                    val intent =
+                                        android.content.Intent(
+                                            android.content.Intent.ACTION_VIEW,
+                                            android.net.Uri.parse(route),
                                         )
-                                    }
-
-                                    // Title
-                                    androidx.compose.material3.Text(
-                                        text = announcement.title,
-                                        style = androidx.compose.material3.MaterialTheme.typography.titleLarge.copy(
-                                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
-                                        ),
-                                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurface,
-                                        modifier = androidx.compose.ui.Modifier.padding(bottom = 12.dp)
-                                    )
-
-                                    // Body Blocks
-                                    val blocks = remember(announcement.body) { parseBodyToBlocks(announcement.body) }
-                                    androidx.compose.foundation.layout.Column(
-                                        verticalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
-                                    ) {
-                                        blocks.forEach { block ->
-                                            if (block.isBullet) {
-                                                androidx.compose.foundation.layout.Row(
-                                                    modifier = androidx.compose.ui.Modifier.fillMaxWidth(),
-                                                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.Start,
-                                                    verticalAlignment = androidx.compose.ui.Alignment.Top
-                                                ) {
-                                                    androidx.compose.material3.Text(
-                                                        text = "•",
-                                                        style = androidx.compose.material3.MaterialTheme.typography.bodyMedium.copy(
-                                                            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
-                                                        ),
-                                                        color = androidx.compose.material3.MaterialTheme.colorScheme.primary,
-                                                        modifier = androidx.compose.ui.Modifier.padding(start = 8.dp, end = 8.dp)
-                                                    )
-                                                    androidx.compose.material3.Text(
-                                                        text = block.text,
-                                                        style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
-                                                        color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
-                                                        modifier = androidx.compose.ui.Modifier.weight(1f)
-                                                    )
-                                                }
-                                            } else {
-                                                androidx.compose.material3.Text(
-                                                    text = block.text,
-                                                    style = androidx.compose.material3.MaterialTheme.typography.bodyMedium,
-                                                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant,
-                                                    modifier = androidx.compose.ui.Modifier.fillMaxWidth()
-                                                )
-                                            }
-                                        }
-                                    }
+                                    announcementContext.startActivity(intent)
+                                } catch (e: Exception) {
+                                    android.util.Log.e("Announcement", "Failed to open route", e)
                                 }
-
-
-                                androidx.compose.foundation.layout.Spacer(modifier = androidx.compose.ui.Modifier.height(20.dp))
-
-                                // 3. Action Buttons (Pinned to bottom)
-                                androidx.compose.foundation.layout.Row(
-                                    modifier = androidx.compose.ui.Modifier.fillMaxWidth(),
-                                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.End,
-                                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
-                                ) {
-                                    // Dismiss Button
-                                    androidx.compose.material3.OutlinedButton(
-                                        onClick = { scope.launch { userPrefs.clearAnnouncement() } },
-                                        shape = androidx.compose.foundation.shape.RoundedCornerShape(10.dp),
-                                        modifier = androidx.compose.ui.Modifier.padding(end = 8.dp)
-                                    ) {
-                                        androidx.compose.material3.Text(text = "Dismiss")
-                                    }
-
-                                    // Action Button
-                                    if (announcement.showActionInApp && !announcement.route.isNullOrBlank()) {
-                                        val buttonText = announcement.actionLabel ?: "View"
-                                        androidx.compose.material3.Button(
-                                            onClick = {
-                                                scope.launch { userPrefs.clearAnnouncement() }
-                                                try {
-                                                    val intent = android.content.Intent(
-                                                        android.content.Intent.ACTION_VIEW,
-                                                        android.net.Uri.parse(announcement.route)
-                                                    )
-                                                    context.startActivity(intent)
-                                                } catch (e: Exception) {
-                                                    android.util.Log.e("Announcement", "Failed to open route", e)
-                                                }
-                                            },
-                                            shape = androidx.compose.foundation.shape.RoundedCornerShape(10.dp),
-                                            colors = androidx.compose.material3.ButtonDefaults.buttonColors(
-                                                containerColor = androidx.compose.material3.MaterialTheme.colorScheme.primary
-                                            )
-                                        ) {
-                                            androidx.compose.material3.Text(text = buttonText)
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                            },
+                        )
                     }
                 }
 

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -105,7 +105,7 @@ import cx.aswin.boxcast.core.designsystem.component.ExpressiveAnimatedBackground
 import cx.aswin.boxcast.core.designsystem.theme.ExpressiveMotion
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
-import cx.aswin.boxcast.util.isInstalledFromPlayStore
+import cx.aswin.boxcast.ui.announcement.shouldSuppressWhatsNewOnPlay
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.CircularProgressIndicator
@@ -878,9 +878,9 @@ class MainActivity : ComponentActivity() {
                     val announcement = activeAnnouncement!!
                     val announcementContext = LocalContext.current
                     val suppressWhatsNewOnPlay =
-                        announcementContext.isInstalledFromPlayStore() &&
-                            cx.aswin.boxcast.ui.announcement.resolveAnnouncementLayout(announcement.category) ==
-                            cx.aswin.boxcast.ui.announcement.AnnouncementLayout.WhatsNew
+                        remember(announcement.category) {
+                            announcementContext.shouldSuppressWhatsNewOnPlay(announcement.category)
+                        }
 
                     if (suppressWhatsNewOnPlay) {
                         LaunchedEffect(announcement.timestamp, announcement.category) {

--- a/app/src/main/java/cx/aswin/boxcast/fcm/BoxLoreFcmService.kt
+++ b/app/src/main/java/cx/aswin/boxcast/fcm/BoxLoreFcmService.kt
@@ -20,6 +20,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
 import com.google.firebase.messaging.FirebaseMessaging
 import cx.aswin.boxcast.core.designsystem.components.optimizedImageUrl
+import cx.aswin.boxcast.ui.announcement.AnnouncementLayout
+import cx.aswin.boxcast.ui.announcement.resolveAnnouncementLayout
+import cx.aswin.boxcast.util.isInstalledFromPlayStore
 
 class BoxLoreFcmService : FirebaseMessagingService() {
 
@@ -220,6 +223,18 @@ class BoxLoreFcmService : FirebaseMessagingService() {
         showActionInApp: Boolean,
         category: String
     ) {
+        // GitHub APK "What's New" / release download CTA is meaningless on Play installs.
+        if (
+            applicationContext.isInstalledFromPlayStore() &&
+            resolveAnnouncementLayout(category) == AnnouncementLayout.WhatsNew
+        ) {
+            android.util.Log.d(
+                "BoxLoreFcmService",
+                "Skipping Whats New in-app announcement on Play Store install (category=$category)",
+            )
+            return
+        }
+
         val prefs = UserPreferencesRepository(applicationContext)
         CoroutineScope(Dispatchers.IO).launch {
             val announcement = UserPreferencesRepository.Announcement(

--- a/app/src/main/java/cx/aswin/boxcast/fcm/BoxLoreFcmService.kt
+++ b/app/src/main/java/cx/aswin/boxcast/fcm/BoxLoreFcmService.kt
@@ -20,9 +20,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.first
 import com.google.firebase.messaging.FirebaseMessaging
 import cx.aswin.boxcast.core.designsystem.components.optimizedImageUrl
-import cx.aswin.boxcast.ui.announcement.AnnouncementLayout
-import cx.aswin.boxcast.ui.announcement.resolveAnnouncementLayout
-import cx.aswin.boxcast.util.isInstalledFromPlayStore
+import cx.aswin.boxcast.ui.announcement.shouldSuppressWhatsNewOnPlay
 
 class BoxLoreFcmService : FirebaseMessagingService() {
 
@@ -69,15 +67,22 @@ class BoxLoreFcmService : FirebaseMessagingService() {
             }
 
             if (parsed.type == "push" || parsed.type == "both") {
-                showPushNotification(
-                    parsed.title,
-                    parsed.body,
-                    parsed.route,
-                    parsed.imageUrl,
-                    parsed.sound,
-                    parsed.actionLabel,
-                    parsed.showActionInPush
-                )
+                if (applicationContext.shouldSuppressWhatsNewOnPlay(parsed.category)) {
+                    android.util.Log.d(
+                        "BoxLoreFcmService",
+                        "Skipping Whats New push on Play Store install (category=${parsed.category})",
+                    )
+                } else {
+                    showPushNotification(
+                        parsed.title,
+                        parsed.body,
+                        parsed.route,
+                        parsed.imageUrl,
+                        parsed.sound,
+                        parsed.actionLabel,
+                        parsed.showActionInPush
+                    )
+                }
             }
         }
     }
@@ -224,10 +229,7 @@ class BoxLoreFcmService : FirebaseMessagingService() {
         category: String
     ) {
         // GitHub APK "What's New" / release download CTA is meaningless on Play installs.
-        if (
-            applicationContext.isInstalledFromPlayStore() &&
-            resolveAnnouncementLayout(category) == AnnouncementLayout.WhatsNew
-        ) {
+        if (applicationContext.shouldSuppressWhatsNewOnPlay(category)) {
             android.util.Log.d(
                 "BoxLoreFcmService",
                 "Skipping Whats New in-app announcement on Play Store install (category=$category)",

--- a/app/src/main/java/cx/aswin/boxcast/ui/announcement/AnnouncementBodyParser.kt
+++ b/app/src/main/java/cx/aswin/boxcast/ui/announcement/AnnouncementBodyParser.kt
@@ -1,0 +1,72 @@
+package cx.aswin.boxcast.ui.announcement
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+
+internal data class BodyBlock(
+    val text: AnnotatedString,
+    val isBullet: Boolean,
+    val isSpacer: Boolean = false,
+)
+
+/** Parses bold (`**…**`) and italic (`*…*`) markers into an [AnnotatedString]. */
+internal fun parseSimpleMarkdownInline(text: String): AnnotatedString {
+    return buildAnnotatedString {
+        var currentIndex = 0
+        val regex = Regex("\\*\\*(.*?)\\*\\*|\\*(.*?)\\*")
+        val matches = regex.findAll(text)
+        for (match in matches) {
+            append(text.substring(currentIndex, match.range.first))
+            if (match.groups[1] != null) {
+                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                    append(match.groupValues[1])
+                }
+            } else if (match.groups[2] != null) {
+                withStyle(SpanStyle(fontStyle = FontStyle.Italic)) {
+                    append(match.groupValues[2])
+                }
+            }
+            currentIndex = match.range.last + 1
+        }
+        append(text.substring(currentIndex))
+    }
+}
+
+/** Splits announcement body into paragraphs, bullets, and blank-line spacers. */
+internal fun parseBodyToBlocks(body: String): List<BodyBlock> {
+    val normalized = body.replace("\r\n", "\n").replace('\r', '\n')
+    val lines = normalized.split("\n")
+    val blocks = mutableListOf<BodyBlock>()
+    var pendingSpacers = 0
+
+    fun flushSpacers() {
+        // Collapse runs of blank lines to a single visual spacer between content
+        if (pendingSpacers > 0 && blocks.isNotEmpty()) {
+            blocks.add(BodyBlock(AnnotatedString(""), isBullet = false, isSpacer = true))
+        }
+        pendingSpacers = 0
+    }
+
+    for (line in lines) {
+        val trimmed = line.trim()
+        if (trimmed.isEmpty()) {
+            pendingSpacers++
+            continue
+        }
+        flushSpacers()
+
+        // Match bullets like "- item", "* item", or "• item"
+        val bulletMatch = Regex("^(?:-|\\*|•)\\s+(.*)$").matchEntire(trimmed)
+        if (bulletMatch != null) {
+            val content = bulletMatch.groupValues[1]
+            blocks.add(BodyBlock(parseSimpleMarkdownInline(content), isBullet = true))
+        } else {
+            blocks.add(BodyBlock(parseSimpleMarkdownInline(line.trimEnd()), isBullet = false))
+        }
+    }
+    return blocks
+}

--- a/app/src/main/java/cx/aswin/boxcast/ui/announcement/AnnouncementLayout.kt
+++ b/app/src/main/java/cx/aswin/boxcast/ui/announcement/AnnouncementLayout.kt
@@ -1,5 +1,6 @@
 package cx.aswin.boxcast.ui.announcement
 
+import android.content.Context
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Campaign
 import androidx.compose.material.icons.rounded.Lightbulb
@@ -9,6 +10,7 @@ import androidx.compose.material.icons.rounded.Warning
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import cx.aswin.boxcast.util.isInstalledFromPlayStore
 
 /**
  * Visual layout for the in-app announcement dialog, resolved from the FCM `category` badge.
@@ -97,3 +99,10 @@ fun announcementLayoutStyle(category: String): AnnouncementLayoutStyle {
             )
     }
 }
+
+/**
+ * GitHub APK "What's New" / release download CTAs are meaningless on Play installs.
+ * Tip / Important / other categories are not gated.
+ */
+fun Context.shouldSuppressWhatsNewOnPlay(category: String): Boolean =
+    isInstalledFromPlayStore() && resolveAnnouncementLayout(category) == AnnouncementLayout.WhatsNew

--- a/app/src/main/java/cx/aswin/boxcast/ui/announcement/AnnouncementLayout.kt
+++ b/app/src/main/java/cx/aswin/boxcast/ui/announcement/AnnouncementLayout.kt
@@ -1,0 +1,99 @@
+package cx.aswin.boxcast.ui.announcement
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Campaign
+import androidx.compose.material.icons.rounded.Lightbulb
+import androidx.compose.material.icons.rounded.NewReleases
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Visual layout for the in-app announcement dialog, resolved from the FCM `category` badge.
+ * Wire format is unchanged — only known badge strings map to specialized layouts.
+ */
+enum class AnnouncementLayout {
+    WhatsNew,
+    NewFeature,
+    Tip,
+    Important,
+    General,
+}
+
+data class AnnouncementLayoutStyle(
+    val layout: AnnouncementLayout,
+    val icon: ImageVector,
+    val imageHeight: Dp,
+    val emphasizeImage: Boolean,
+    val emphasizeBullets: Boolean,
+    val useErrorChip: Boolean,
+    val useTertiaryChip: Boolean,
+)
+
+fun resolveAnnouncementLayout(category: String): AnnouncementLayout {
+    val c = category.trim().uppercase().replace('’', '\'')
+    return when {
+        c == "WHAT'S NEW" || c == "WHATS NEW" || c == "NEW RELEASE" -> AnnouncementLayout.WhatsNew
+        c == "NEW FEATURE" -> AnnouncementLayout.NewFeature
+        c == "TIP" -> AnnouncementLayout.Tip
+        c == "IMPORTANT" || c == "ALERT" -> AnnouncementLayout.Important
+        else -> AnnouncementLayout.General
+    }
+}
+
+fun announcementLayoutStyle(category: String): AnnouncementLayoutStyle {
+    return when (resolveAnnouncementLayout(category)) {
+        AnnouncementLayout.WhatsNew ->
+            AnnouncementLayoutStyle(
+                layout = AnnouncementLayout.WhatsNew,
+                icon = Icons.Rounded.NewReleases,
+                imageHeight = 140.dp,
+                emphasizeImage = false,
+                emphasizeBullets = true,
+                useErrorChip = false,
+                useTertiaryChip = false,
+            )
+        AnnouncementLayout.NewFeature ->
+            AnnouncementLayoutStyle(
+                layout = AnnouncementLayout.NewFeature,
+                icon = Icons.Rounded.Star,
+                imageHeight = 200.dp,
+                emphasizeImage = true,
+                emphasizeBullets = false,
+                useErrorChip = false,
+                useTertiaryChip = false,
+            )
+        AnnouncementLayout.Tip ->
+            AnnouncementLayoutStyle(
+                layout = AnnouncementLayout.Tip,
+                icon = Icons.Rounded.Lightbulb,
+                imageHeight = 140.dp,
+                emphasizeImage = false,
+                emphasizeBullets = false,
+                useErrorChip = false,
+                useTertiaryChip = true,
+            )
+        AnnouncementLayout.Important ->
+            AnnouncementLayoutStyle(
+                layout = AnnouncementLayout.Important,
+                icon = Icons.Rounded.Warning,
+                imageHeight = 140.dp,
+                emphasizeImage = false,
+                emphasizeBullets = false,
+                useErrorChip = true,
+                useTertiaryChip = false,
+            )
+        AnnouncementLayout.General ->
+            AnnouncementLayoutStyle(
+                layout = AnnouncementLayout.General,
+                icon = Icons.Rounded.Campaign,
+                imageHeight = 168.dp,
+                emphasizeImage = false,
+                emphasizeBullets = false,
+                useErrorChip = false,
+                useTertiaryChip = false,
+            )
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/ui/announcement/InAppAnnouncementDialog.kt
+++ b/app/src/main/java/cx/aswin/boxcast/ui/announcement/InAppAnnouncementDialog.kt
@@ -1,0 +1,313 @@
+package cx.aswin.boxcast.ui.announcement
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil.compose.AsyncImage
+import cx.aswin.boxcast.core.data.UserPreferencesRepository.Announcement
+import cx.aswin.boxcast.core.data.analytics.AnalyticsHelper
+
+private val ActionShape = RoundedCornerShape(16.dp)
+private val DialogShape = RoundedCornerShape(28.dp)
+private val ImageShape = RoundedCornerShape(16.dp)
+private val ActionHeight = 52.dp
+
+@Composable
+fun InAppAnnouncementDialog(
+    announcement: Announcement,
+    onDismiss: () -> Unit,
+    onAction: (route: String) -> Unit,
+) {
+    val hasImage = !announcement.imageUrl.isNullOrBlank()
+    val hasAction = announcement.showActionInApp && !announcement.route.isNullOrBlank()
+    val style = remember(announcement.category) { announcementLayoutStyle(announcement.category) }
+
+    LaunchedEffect(announcement.timestamp, announcement.title) {
+        AnalyticsHelper.trackInAppAnnouncementViewed(
+            category = announcement.category,
+            hasImage = hasImage,
+            hasAction = hasAction,
+        )
+    }
+
+    fun dismissExplicitly() {
+        AnalyticsHelper.trackInAppAnnouncementDismissed(
+            category = announcement.category,
+            hasImage = hasImage,
+            hasAction = hasAction,
+        )
+        onDismiss()
+    }
+
+    Dialog(
+        onDismissRequest = { /* outside / back do not dismiss */ },
+        properties =
+            DialogProperties(
+                dismissOnBackPress = false,
+                dismissOnClickOutside = false,
+                usePlatformDefaultWidth = false,
+            ),
+    ) {
+        val surfaceBorder =
+            if (style.useErrorChip) {
+                BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.45f))
+            } else {
+                null
+            }
+
+        Surface(
+            shape = DialogShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            tonalElevation = 6.dp,
+            border = surfaceBorder,
+            modifier =
+                Modifier
+                    .fillMaxWidth(0.94f)
+                    .heightIn(max = 560.dp)
+                    .padding(horizontal = 12.dp, vertical = 16.dp),
+        ) {
+            Box {
+                IconButton(
+                    onClick = { dismissExplicitly() },
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(4.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Close,
+                        contentDescription = "Dismiss",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                Column(modifier = Modifier.padding(20.dp)) {
+                    val chipContainer =
+                        when {
+                            style.useErrorChip -> MaterialTheme.colorScheme.errorContainer
+                            style.useTertiaryChip -> MaterialTheme.colorScheme.tertiaryContainer
+                            else -> MaterialTheme.colorScheme.primaryContainer
+                        }
+                    val chipContent =
+                        when {
+                            style.useErrorChip -> MaterialTheme.colorScheme.onErrorContainer
+                            style.useTertiaryChip -> MaterialTheme.colorScheme.onTertiaryContainer
+                            else -> MaterialTheme.colorScheme.onPrimaryContainer
+                        }
+
+                    Row(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(end = 36.dp, bottom = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        AssistChip(
+                            onClick = {},
+                            label = {
+                                Text(
+                                    text = announcement.category,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = MaterialTheme.typography.labelLarge,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = style.icon,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            },
+                            colors =
+                                AssistChipDefaults.assistChipColors(
+                                    containerColor = chipContainer,
+                                    labelColor = chipContent,
+                                    leadingIconContentColor = chipContent,
+                                ),
+                            border = null,
+                        )
+                    }
+
+                    Column(
+                        modifier =
+                            Modifier
+                                .weight(1f, fill = false)
+                                .verticalScroll(rememberScrollState()),
+                    ) {
+                        if (hasImage) {
+                            AsyncImage(
+                                model = announcement.imageUrl,
+                                contentDescription = null,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .height(style.imageHeight)
+                                        .clip(ImageShape),
+                                contentScale = ContentScale.Crop,
+                            )
+                            Spacer(modifier = Modifier.height(if (style.emphasizeImage) 12.dp else 16.dp))
+                        }
+
+                        Text(
+                            text = announcement.title,
+                            style = MaterialTheme.typography.headlineSmall,
+                            fontWeight =
+                                if (style.layout == AnnouncementLayout.Tip) {
+                                    FontWeight.Medium
+                                } else {
+                                    FontWeight.SemiBold
+                                },
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.padding(bottom = 12.dp),
+                        )
+
+                        val blocks = remember(announcement.body) { parseBodyToBlocks(announcement.body) }
+                        val bodySpacing = if (style.emphasizeBullets) 8.dp else 10.dp
+                        Column(verticalArrangement = Arrangement.spacedBy(bodySpacing)) {
+                            blocks.forEach { block ->
+                                when {
+                                    block.isSpacer -> {
+                                        Spacer(modifier = Modifier.height(6.dp))
+                                    }
+                                    block.isBullet -> {
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            verticalAlignment = Alignment.Top,
+                                        ) {
+                                            Text(
+                                                text = "•",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                fontWeight = FontWeight.Bold,
+                                                color =
+                                                    if (style.useErrorChip) {
+                                                        MaterialTheme.colorScheme.error
+                                                    } else {
+                                                        MaterialTheme.colorScheme.primary
+                                                    },
+                                                modifier = Modifier.padding(start = 4.dp, end = 10.dp),
+                                            )
+                                            Text(
+                                                text = block.text,
+                                                style =
+                                                    if (style.emphasizeBullets) {
+                                                        MaterialTheme.typography.bodyLarge
+                                                    } else {
+                                                        MaterialTheme.typography.bodyMedium
+                                                    },
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                modifier = Modifier.weight(1f),
+                                            )
+                                        }
+                                    }
+                                    else -> {
+                                        Text(
+                                            text = block.text,
+                                            style = MaterialTheme.typography.bodyMedium,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            modifier = Modifier.fillMaxWidth(),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        if (hasAction) {
+                            val route = announcement.route!!
+                            val buttonText = announcement.actionLabel?.takeIf { it.isNotBlank() } ?: "View"
+                            Button(
+                                onClick = {
+                                    AnalyticsHelper.trackInAppAnnouncementAction(
+                                        category = announcement.category,
+                                        hasImage = hasImage,
+                                        actionLabel = buttonText,
+                                    )
+                                    onAction(route)
+                                },
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .height(ActionHeight),
+                                shape = ActionShape,
+                                colors =
+                                    ButtonDefaults.buttonColors(
+                                        containerColor =
+                                            if (style.useErrorChip) {
+                                                MaterialTheme.colorScheme.error
+                                            } else {
+                                                MaterialTheme.colorScheme.primary
+                                            },
+                                    ),
+                            ) {
+                                Text(
+                                    text = buttonText,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    style = MaterialTheme.typography.labelLarge,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
+                            }
+                        }
+
+                        OutlinedButton(
+                            onClick = { dismissExplicitly() },
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .height(ActionHeight),
+                            shape = ActionShape,
+                        ) {
+                            Text(
+                                text = "Dismiss",
+                                style = MaterialTheme.typography.labelLarge,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/cx/aswin/boxcast/ui/announcement/InAppAnnouncementDialog.kt
+++ b/app/src/main/java/cx/aswin/boxcast/ui/announcement/InAppAnnouncementDialog.kt
@@ -1,6 +1,7 @@
 package cx.aswin.boxcast.ui.announcement
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -32,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -65,7 +67,7 @@ fun InAppAnnouncementDialog(
         )
     }
 
-    fun dismissExplicitly() {
+    val dismissExplicitly = {
         AnalyticsHelper.trackInAppAnnouncementDismissed(
             category = announcement.category,
             hasImage = hasImage,
@@ -83,231 +85,322 @@ fun InAppAnnouncementDialog(
                 usePlatformDefaultWidth = false,
             ),
     ) {
-        val surfaceBorder =
-            if (style.useErrorChip) {
-                BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.45f))
-            } else {
-                null
+        AnnouncementDialogCard(
+            announcement = announcement,
+            style = style,
+            hasImage = hasImage,
+            hasAction = hasAction,
+            onDismissExplicitly = dismissExplicitly,
+            onAction = onAction,
+        )
+    }
+}
+
+@Composable
+private fun AnnouncementDialogCard(
+    announcement: Announcement,
+    style: AnnouncementLayoutStyle,
+    hasImage: Boolean,
+    hasAction: Boolean,
+    onDismissExplicitly: () -> Unit,
+    onAction: (route: String) -> Unit,
+) {
+    val surfaceBorder =
+        if (style.useErrorChip) {
+            BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.45f))
+        } else {
+            null
+        }
+
+    Surface(
+        shape = DialogShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        tonalElevation = 6.dp,
+        border = surfaceBorder,
+        modifier =
+            Modifier
+                .fillMaxWidth(0.94f)
+                .heightIn(max = 560.dp)
+                .padding(horizontal = 12.dp, vertical = 16.dp),
+    ) {
+        Box {
+            IconButton(
+                onClick = onDismissExplicitly,
+                modifier =
+                    Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(4.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Close,
+                    contentDescription = "Dismiss",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
             }
 
-        Surface(
-            shape = DialogShape,
-            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-            tonalElevation = 6.dp,
-            border = surfaceBorder,
+            Column(modifier = Modifier.padding(20.dp)) {
+                AnnouncementCategoryChip(
+                    category = announcement.category,
+                    style = style,
+                )
+                AnnouncementScrollBody(
+                    announcement = announcement,
+                    style = style,
+                    hasImage = hasImage,
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+                AnnouncementActions(
+                    announcement = announcement,
+                    style = style,
+                    hasImage = hasImage,
+                    hasAction = hasAction,
+                    onDismissExplicitly = onDismissExplicitly,
+                    onAction = onAction,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AnnouncementCategoryChip(
+    category: String,
+    style: AnnouncementLayoutStyle,
+) {
+    val chipContainer = chipContainerColor(style)
+    val chipContent = chipContentColor(style)
+
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(end = 36.dp, bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AssistChip(
+            onClick = {},
+            label = {
+                Text(
+                    text = category,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = style.icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+            },
+            colors =
+                AssistChipDefaults.assistChipColors(
+                    containerColor = chipContainer,
+                    labelColor = chipContent,
+                    leadingIconContentColor = chipContent,
+                ),
+            border = null,
+        )
+    }
+}
+
+@Composable
+private fun chipContainerColor(style: AnnouncementLayoutStyle): Color =
+    when {
+        style.useErrorChip -> MaterialTheme.colorScheme.errorContainer
+        style.useTertiaryChip -> MaterialTheme.colorScheme.tertiaryContainer
+        else -> MaterialTheme.colorScheme.primaryContainer
+    }
+
+@Composable
+private fun chipContentColor(style: AnnouncementLayoutStyle): Color =
+    when {
+        style.useErrorChip -> MaterialTheme.colorScheme.onErrorContainer
+        style.useTertiaryChip -> MaterialTheme.colorScheme.onTertiaryContainer
+        else -> MaterialTheme.colorScheme.onPrimaryContainer
+    }
+
+@Composable
+private fun ColumnScope.AnnouncementScrollBody(
+    announcement: Announcement,
+    style: AnnouncementLayoutStyle,
+    hasImage: Boolean,
+) {
+    Column(
+        modifier =
+            Modifier
+                .weight(1f, fill = false)
+                .verticalScroll(rememberScrollState()),
+    ) {
+        if (hasImage) {
+            AsyncImage(
+                model = announcement.imageUrl,
+                contentDescription = null,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(style.imageHeight)
+                        .clip(ImageShape),
+                contentScale = ContentScale.Crop,
+            )
+            Spacer(modifier = Modifier.height(if (style.emphasizeImage) 12.dp else 16.dp))
+        }
+
+        Text(
+            text = announcement.title,
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight =
+                if (style.layout == AnnouncementLayout.Tip) {
+                    FontWeight.Medium
+                } else {
+                    FontWeight.SemiBold
+                },
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        AnnouncementBodyBlocks(
+            body = announcement.body,
+            style = style,
+        )
+    }
+}
+
+@Composable
+private fun AnnouncementBodyBlocks(
+    body: String,
+    style: AnnouncementLayoutStyle,
+) {
+    val blocks = remember(body) { parseBodyToBlocks(body) }
+    val bodySpacing = if (style.emphasizeBullets) 8.dp else 10.dp
+    val bulletColor =
+        if (style.useErrorChip) {
+            MaterialTheme.colorScheme.error
+        } else {
+            MaterialTheme.colorScheme.primary
+        }
+    val bulletTextStyle =
+        if (style.emphasizeBullets) {
+            MaterialTheme.typography.bodyLarge
+        } else {
+            MaterialTheme.typography.bodyMedium
+        }
+
+    Column(verticalArrangement = Arrangement.spacedBy(bodySpacing)) {
+        blocks.forEach { block ->
+            AnnouncementBodyBlockRow(
+                block = block,
+                bulletColor = bulletColor,
+                bulletTextStyle = bulletTextStyle,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AnnouncementBodyBlockRow(
+    block: BodyBlock,
+    bulletColor: Color,
+    bulletTextStyle: androidx.compose.ui.text.TextStyle,
+) {
+    when {
+        block.isSpacer -> Spacer(modifier = Modifier.height(6.dp))
+        block.isBullet -> {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.Top,
+            ) {
+                Text(
+                    text = "•",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = bulletColor,
+                    modifier = Modifier.padding(start = 4.dp, end = 10.dp),
+                )
+                Text(
+                    text = block.text,
+                    style = bulletTextStyle,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+        else -> {
+            Text(
+                text = block.text,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AnnouncementActions(
+    announcement: Announcement,
+    style: AnnouncementLayoutStyle,
+    hasImage: Boolean,
+    hasAction: Boolean,
+    onDismissExplicitly: () -> Unit,
+    onAction: (route: String) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        if (hasAction) {
+            val route = announcement.route.orEmpty()
+            val buttonText = announcement.actionLabel?.takeIf { it.isNotBlank() } ?: "View"
+            val containerColor =
+                if (style.useErrorChip) {
+                    MaterialTheme.colorScheme.error
+                } else {
+                    MaterialTheme.colorScheme.primary
+                }
+            Button(
+                onClick = {
+                    AnalyticsHelper.trackInAppAnnouncementAction(
+                        category = announcement.category,
+                        hasImage = hasImage,
+                        actionLabel = buttonText,
+                    )
+                    onAction(route)
+                },
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(ActionHeight),
+                shape = ActionShape,
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor = containerColor,
+                    ),
+            ) {
+                Text(
+                    text = buttonText,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.labelLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+
+        OutlinedButton(
+            onClick = onDismissExplicitly,
             modifier =
                 Modifier
-                    .fillMaxWidth(0.94f)
-                    .heightIn(max = 560.dp)
-                    .padding(horizontal = 12.dp, vertical = 16.dp),
+                    .fillMaxWidth()
+                    .height(ActionHeight),
+            shape = ActionShape,
         ) {
-            Box {
-                IconButton(
-                    onClick = { dismissExplicitly() },
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(4.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Close,
-                        contentDescription = "Dismiss",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-
-                Column(modifier = Modifier.padding(20.dp)) {
-                    val chipContainer =
-                        when {
-                            style.useErrorChip -> MaterialTheme.colorScheme.errorContainer
-                            style.useTertiaryChip -> MaterialTheme.colorScheme.tertiaryContainer
-                            else -> MaterialTheme.colorScheme.primaryContainer
-                        }
-                    val chipContent =
-                        when {
-                            style.useErrorChip -> MaterialTheme.colorScheme.onErrorContainer
-                            style.useTertiaryChip -> MaterialTheme.colorScheme.onTertiaryContainer
-                            else -> MaterialTheme.colorScheme.onPrimaryContainer
-                        }
-
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(end = 36.dp, bottom = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        AssistChip(
-                            onClick = {},
-                            label = {
-                                Text(
-                                    text = announcement.category,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    style = MaterialTheme.typography.labelLarge,
-                                    fontWeight = FontWeight.SemiBold,
-                                )
-                            },
-                            leadingIcon = {
-                                Icon(
-                                    imageVector = style.icon,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(18.dp),
-                                )
-                            },
-                            colors =
-                                AssistChipDefaults.assistChipColors(
-                                    containerColor = chipContainer,
-                                    labelColor = chipContent,
-                                    leadingIconContentColor = chipContent,
-                                ),
-                            border = null,
-                        )
-                    }
-
-                    Column(
-                        modifier =
-                            Modifier
-                                .weight(1f, fill = false)
-                                .verticalScroll(rememberScrollState()),
-                    ) {
-                        if (hasImage) {
-                            AsyncImage(
-                                model = announcement.imageUrl,
-                                contentDescription = null,
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .height(style.imageHeight)
-                                        .clip(ImageShape),
-                                contentScale = ContentScale.Crop,
-                            )
-                            Spacer(modifier = Modifier.height(if (style.emphasizeImage) 12.dp else 16.dp))
-                        }
-
-                        Text(
-                            text = announcement.title,
-                            style = MaterialTheme.typography.headlineSmall,
-                            fontWeight =
-                                if (style.layout == AnnouncementLayout.Tip) {
-                                    FontWeight.Medium
-                                } else {
-                                    FontWeight.SemiBold
-                                },
-                            color = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.padding(bottom = 12.dp),
-                        )
-
-                        val blocks = remember(announcement.body) { parseBodyToBlocks(announcement.body) }
-                        val bodySpacing = if (style.emphasizeBullets) 8.dp else 10.dp
-                        Column(verticalArrangement = Arrangement.spacedBy(bodySpacing)) {
-                            blocks.forEach { block ->
-                                when {
-                                    block.isSpacer -> {
-                                        Spacer(modifier = Modifier.height(6.dp))
-                                    }
-                                    block.isBullet -> {
-                                        Row(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            verticalAlignment = Alignment.Top,
-                                        ) {
-                                            Text(
-                                                text = "•",
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                fontWeight = FontWeight.Bold,
-                                                color =
-                                                    if (style.useErrorChip) {
-                                                        MaterialTheme.colorScheme.error
-                                                    } else {
-                                                        MaterialTheme.colorScheme.primary
-                                                    },
-                                                modifier = Modifier.padding(start = 4.dp, end = 10.dp),
-                                            )
-                                            Text(
-                                                text = block.text,
-                                                style =
-                                                    if (style.emphasizeBullets) {
-                                                        MaterialTheme.typography.bodyLarge
-                                                    } else {
-                                                        MaterialTheme.typography.bodyMedium
-                                                    },
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                modifier = Modifier.weight(1f),
-                                            )
-                                        }
-                                    }
-                                    else -> {
-                                        Text(
-                                            text = block.text,
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            modifier = Modifier.fillMaxWidth(),
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    Spacer(modifier = Modifier.height(20.dp))
-
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(10.dp),
-                    ) {
-                        if (hasAction) {
-                            val route = announcement.route!!
-                            val buttonText = announcement.actionLabel?.takeIf { it.isNotBlank() } ?: "View"
-                            Button(
-                                onClick = {
-                                    AnalyticsHelper.trackInAppAnnouncementAction(
-                                        category = announcement.category,
-                                        hasImage = hasImage,
-                                        actionLabel = buttonText,
-                                    )
-                                    onAction(route)
-                                },
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .height(ActionHeight),
-                                shape = ActionShape,
-                                colors =
-                                    ButtonDefaults.buttonColors(
-                                        containerColor =
-                                            if (style.useErrorChip) {
-                                                MaterialTheme.colorScheme.error
-                                            } else {
-                                                MaterialTheme.colorScheme.primary
-                                            },
-                                    ),
-                            ) {
-                                Text(
-                                    text = buttonText,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    style = MaterialTheme.typography.labelLarge,
-                                    fontWeight = FontWeight.SemiBold,
-                                )
-                            }
-                        }
-
-                        OutlinedButton(
-                            onClick = { dismissExplicitly() },
-                            modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .height(ActionHeight),
-                            shape = ActionShape,
-                        ) {
-                            Text(
-                                text = "Dismiss",
-                                style = MaterialTheme.typography.labelLarge,
-                            )
-                        }
-                    }
-                }
-            }
+            Text(
+                text = "Dismiss",
+                style = MaterialTheme.typography.labelLarge,
+            )
         }
     }
 }

--- a/app/src/main/java/cx/aswin/boxcast/util/InstallSource.kt
+++ b/app/src/main/java/cx/aswin/boxcast/util/InstallSource.kt
@@ -1,0 +1,17 @@
+package cx.aswin.boxcast.util
+
+import android.content.Context
+import android.util.Log
+
+private const val PLAY_STORE_PACKAGE = "com.android.vending"
+private const val TAG = "InstallSource"
+
+/** True when this app install was delivered by the Google Play Store. */
+fun Context.isInstalledFromPlayStore(): Boolean {
+    return try {
+        packageManager.getInstallSourceInfo(packageName).installingPackageName == PLAY_STORE_PACKAGE
+    } catch (e: Exception) {
+        Log.w(TAG, "Failed to resolve install source; treating as non-Play", e)
+        false
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -534,6 +534,54 @@ object AnalyticsHelper {
         )
     }
 
+    fun trackInAppAnnouncementViewed(
+        category: String,
+        hasImage: Boolean,
+        hasAction: Boolean,
+    ) {
+        PostHog.capture(
+            event = "in_app_announcement_viewed",
+            properties =
+                mapOf(
+                    "category" to category,
+                    "has_image" to hasImage,
+                    "has_action" to hasAction,
+                ),
+        )
+    }
+
+    fun trackInAppAnnouncementDismissed(
+        category: String,
+        hasImage: Boolean,
+        hasAction: Boolean,
+    ) {
+        PostHog.capture(
+            event = "in_app_announcement_dismissed",
+            properties =
+                mapOf(
+                    "category" to category,
+                    "has_image" to hasImage,
+                    "has_action" to hasAction,
+                ),
+        )
+    }
+
+    fun trackInAppAnnouncementAction(
+        category: String,
+        hasImage: Boolean,
+        actionLabel: String,
+    ) {
+        PostHog.capture(
+            event = "in_app_announcement_action",
+            properties =
+                mapOf(
+                    "category" to category,
+                    "has_image" to hasImage,
+                    "action_label" to actionLabel,
+                ),
+        )
+    }
+
     // ── 9. Permissions ──────────────────────────────────────────────
 
     fun trackNotificationPermissionRequested() {


### PR DESCRIPTION
## Summary
- Redesign the FCM-driven in-app announcement dialog into a dedicated Material 3 composable with clearer hierarchy, category-based layout variants, and dismiss-only via explicit controls.
- Suppress What’s New / `NEW RELEASE` in-app announcements on Google Play installs so GitHub APK “Download” CTAs only reach sideload / GitHub installs.
- Expand automated release announcement bodies from 3 to 5 bullets and add PostHog analytics for announcement viewed / dismissed / action.

## Motivation
Release and admin-sent announcements were rendered by a large inline Compose block in `MainActivity` with weak hierarchy, cramped chrome, and inconsistent action buttons. Release “What’s New” notifications point at GitHub APK downloads, which is useless (and confusing) for Play Store installs that must update through Play. We needed a cleaner dialog, layout variants keyed off the existing `category` badge (no FCM schema break), and client-side gating for Play installs.

## What changed

### In-app dialog UI
- Extracted `InAppAnnouncementDialog`, `AnnouncementBodyParser`, and `AnnouncementLayout` under `app/.../ui/announcement/`.
- Material 3 polish: AssistChip category badge, optional hero image, `headlineSmall` title, scrollable body, full-width primary + Dismiss at 16dp / 52dp.
- Wider dialog via `usePlatformDefaultWidth = false` and ~94% screen width.
- Outside tap and system back do **not** dismiss; only the top-right **X** or **Dismiss** clears the announcement (primary CTA still clears after opening the route).
- Markdown-ish body support: `**bold**`, `*italic*`, `-` / `*` / `•` bullets; blank lines become spacers.

### Category → layout presets (existing `category` string only)
| Category badge | Layout |
|:--|:--|
| `WHAT'S NEW`, `WHATS NEW`, `NEW RELEASE` | Whats New (changelog / bullet-friendly) |
| `NEW FEATURE` | New Feature (taller image emphasis) |
| `TIP` | Tip (softer / tertiary chip) |
| `IMPORTANT`, `ALERT` | Important (error emphasis) |
| anything else | General |

### Play Store gating
- Added `Context.isInstalledFromPlayStore()` (`installingPackageName == com.android.vending`).
- FCM receive path: do not persist Whats New announcements on Play installs.
- Display path: if a Whats New announcement is already queued on a Play install, clear it without showing the dialog.
- Tip / Important / New Feature / General / Custom are **not** gated.

### Release notify content
- `prepare_release.py notification` now includes up to **5** README What’s New bullets (was 3).
- Release workflow already hardcodes `category: NEW RELEASE` + `action_label: Download` — no workflow YAML change required for Play gating.

### Analytics
- `in_app_announcement_viewed` / `_dismissed` / `_action` with `category`, `has_image`, and `has_action` / `action_label`.

## Behavior & compatibility
- **FCM / DataStore schema unchanged** — same keys. Older app versions keep working on the same payloads.
- Play gating is client-only; `announce-release` may still target `all_users`.
- Admin notify UI presets + markdown preview were updated and deployed separately; `admin-panel/` is gitignored and not in this PR.

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-high`
- [x] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact — **required when** `user-impact-high` or `user-impact-medium`

**What changes in the user’s life:**

- When boxlore sends an in-app announcement (release notes, tips, alerts), listeners see a clearer, wider dialog that is easier to read — especially changelog-style bullet lists for new versions.
- They can only close it with **Dismiss** or the **X** (not by tapping outside), so they are less likely to dismiss release notes by accident.
- Listeners on **Google Play** no longer get a “Download update from GitHub” release popup; that path stays for GitHub/sideload installs only. Other tips/alerts can still appear on Play.

### Backend — optional

- [ ] `backend-change`

## Test plan
- [x] `./gradlew installDebug` on connected sideload device (`installerPackageName=null`)
- [x] Send in-app What’s New / `NEW RELEASE` with 5 `-` bullets + `Download` route → wider dialog, bullets, primary CTA
- [x] Confirm outside tap and back do not dismiss; X and Dismiss do
- [x] Send Tip / Important / custom category → still shows on sideload
- [x] On a Play-installed build (when available): What’s New / `NEW RELEASE` must not appear; other categories still can
- [x] Spot-check PostHog for `in_app_announcement_*` after view / dismiss / action

## Notes
- Label: `user-impact-medium`.
- PR template now requires **Listener impact** for medium/high.
- Optional follow-up: narrow release FCM `target` for less Play noise (not required for correctness).
