### PR TITLE
feat(personalization): add adaptive content orchestration

### DIFF
--- a/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
@@ -39,15 +39,9 @@ class BoxLoreApplication : Application() {
 
         userPreferencesRepository = UserPreferencesRepository(this)
         engagementPromptCoordinator = EngagementPromptCoordinator(userPreferencesRepository)
-        try {
-            RankingFeedbackRepository.getInstance(this)
-        } catch (error: Exception) {
-            android.util.Log.e(
-                "BoxLoreApplication",
-                "Failed to initialize adaptive ranking",
-                error,
-            )
-        }
+        // getInstance installs a no-op fallback if Room initialization fails, keeping
+        // ranking optional without hiding unrelated startup programming errors here.
+        RankingFeedbackRepository.getInstance(this)
 
         val config = PostHogAndroidConfig(
             apiKey = BuildConfig.POSTHOG_API_KEY,
@@ -77,12 +71,7 @@ class BoxLoreApplication : Application() {
             PostHog.register("is_internal", false)
             PostHog.register("app_environment", "production")
         }
-        applicationScope.launch {
-            val statuses = AdaptiveRankingRepository.getInstance(this@BoxLoreApplication)
-                .aggregateTelemetry()
-            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper
-                .trackAdaptiveRankingStatus(statuses)
-        }
+        reportAdaptiveRankingStatus()
 
         setupAppCheck()
 
@@ -114,6 +103,27 @@ class BoxLoreApplication : Application() {
             })
         } catch (e: Exception) {
             android.util.Log.e("BoxCastApp", "Failed to register connectivity observer", e)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun reportAdaptiveRankingStatus() {
+        applicationScope.launch {
+            try {
+                val statuses = AdaptiveRankingRepository.getInstance(this@BoxLoreApplication)
+                    .aggregateTelemetry()
+                cx.aswin.boxcast.core.data.analytics.AnalyticsHelper
+                    .trackAdaptiveRankingStatus(statuses)
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                // Aggregate telemetry is optional and must never destabilize app startup.
+                android.util.Log.w(
+                    "BoxLoreApplication",
+                    "Failed to report adaptive ranking status",
+                    error,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
@@ -14,6 +14,7 @@ import com.posthog.android.PostHogAndroid
 import com.posthog.android.PostHogAndroidConfig
 import cx.aswin.boxcast.core.data.EngagementPromptCoordinator
 import cx.aswin.boxcast.core.data.UserPreferencesRepository
+import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
 import cx.aswin.boxcast.core.network.NetworkModule
 import cx.aswin.boxcast.surveys.BoxcastPostHogSurveysDelegate
 import java.util.concurrent.TimeUnit
@@ -32,6 +33,7 @@ class BoxLoreApplication : Application() {
 
         userPreferencesRepository = UserPreferencesRepository(this)
         engagementPromptCoordinator = EngagementPromptCoordinator(userPreferencesRepository)
+        RankingFeedbackRepository.getInstance(this)
 
         val config = PostHogAndroidConfig(
             apiKey = BuildConfig.POSTHOG_API_KEY,

--- a/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
@@ -15,11 +15,17 @@ import com.posthog.android.PostHogAndroidConfig
 import cx.aswin.boxcast.core.data.EngagementPromptCoordinator
 import cx.aswin.boxcast.core.data.UserPreferencesRepository
 import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
+import cx.aswin.boxcast.core.data.ranking.AdaptiveRankingRepository
 import cx.aswin.boxcast.core.network.NetworkModule
 import cx.aswin.boxcast.surveys.BoxcastPostHogSurveysDelegate
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 class BoxLoreApplication : Application() {
+    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     lateinit var userPreferencesRepository: UserPreferencesRepository
         private set
@@ -62,6 +68,12 @@ class BoxLoreApplication : Application() {
         } else {
             PostHog.register("is_internal", false)
             PostHog.register("app_environment", "production")
+        }
+        applicationScope.launch {
+            val statuses = AdaptiveRankingRepository.getInstance(this@BoxLoreApplication)
+                .aggregateTelemetry()
+            cx.aswin.boxcast.core.data.analytics.AnalyticsHelper
+                .trackAdaptiveRankingStatus(statuses)
         }
 
         setupAppCheck()

--- a/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxcast/BoxLoreApplication.kt
@@ -39,7 +39,15 @@ class BoxLoreApplication : Application() {
 
         userPreferencesRepository = UserPreferencesRepository(this)
         engagementPromptCoordinator = EngagementPromptCoordinator(userPreferencesRepository)
-        RankingFeedbackRepository.getInstance(this)
+        try {
+            RankingFeedbackRepository.getInstance(this)
+        } catch (error: Exception) {
+            android.util.Log.e(
+                "BoxLoreApplication",
+                "Failed to initialize adaptive ranking",
+                error,
+            )
+        }
 
         val config = PostHogAndroidConfig(
             apiKey = BuildConfig.POSTHOG_API_KEY,

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -753,7 +753,8 @@ class MainActivity : ComponentActivity() {
                             val backupManager = cx.aswin.boxcast.core.data.backup.LibraryBackupManager(
                                 subscriptionRepository,
                                 playbackRepository,
-                                podcastRepository
+                                podcastRepository,
+                                context = applicationContext,
                             )
                             val feeds = backupManager.parseOpmlFeeds(inputStream)
                             inputStream.close()
@@ -809,7 +810,8 @@ class MainActivity : ComponentActivity() {
                             val backupManager = cx.aswin.boxcast.core.data.backup.LibraryBackupManager(
                                 subscriptionRepository,
                                 playbackRepository,
-                                podcastRepository
+                                podcastRepository,
+                                context = applicationContext,
                             )
                             val total = state.podcastsToMark.size
                             for (index in state.podcastsToMark.indices) {
@@ -1674,7 +1676,12 @@ class MainActivity : ComponentActivity() {
                                         onExportOpml = { uri ->
                                             scope.launch(kotlinx.coroutines.Dispatchers.IO) {
                                                 try {
-                                                    val opmlXml = cx.aswin.boxcast.core.data.backup.LibraryBackupManager(subscriptionRepository, playbackRepository, podcastRepository).exportLibraryAsOpml()
+                                                    val opmlXml = cx.aswin.boxcast.core.data.backup.LibraryBackupManager(
+                                                        subscriptionRepository,
+                                                        playbackRepository,
+                                                        podcastRepository,
+                                                        context = application,
+                                                    ).exportLibraryAsOpml()
                                                     (application.contentResolver.openOutputStream(uri) ?: error("Unable to open export destination")).use { it.write(opmlXml.toByteArray()) }
                                                     kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) { android.widget.Toast.makeText(application, "Subscriptions Exported as OPML", android.widget.Toast.LENGTH_SHORT).show() }
                                                 } catch(e: Exception){

--- a/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
+++ b/app/src/main/java/cx/aswin/boxcast/MainActivity.kt
@@ -1797,7 +1797,9 @@ class MainActivity : ComponentActivity() {
                                                 subscriptionRepository, 
                                                 playbackRepository,
                                                 downloadRepository,
-                                                userPrefs
+                                                userPrefs,
+                                                cx.aswin.boxcast.core.data.ranking
+                                                    .AdaptiveCandidateScorer.getInstance(application),
                                             ) as T
                                         }
                                     }
@@ -1860,7 +1862,9 @@ class MainActivity : ComponentActivity() {
                                                 subscriptionRepository, 
                                                 playbackRepository,
                                                 downloadRepository,
-                                                userPrefs
+                                                userPrefs,
+                                                cx.aswin.boxcast.core.data.ranking
+                                                    .AdaptiveCandidateScorer.getInstance(application),
                                             ) as T
                                         }
                                     }
@@ -1911,7 +1915,9 @@ class MainActivity : ComponentActivity() {
                                                 subscriptionRepository,
                                                 playbackRepository,
                                                 downloadRepository,
-                                                userPrefs
+                                                userPrefs,
+                                                cx.aswin.boxcast.core.data.ranking
+                                                    .AdaptiveCandidateScorer.getInstance(application),
                                             ) as T
                                         }
                                     }
@@ -1967,7 +1973,9 @@ class MainActivity : ComponentActivity() {
                                                 subscriptionRepository,
                                                 playbackRepository,
                                                 downloadRepository,
-                                                userPrefs
+                                                userPrefs,
+                                                cx.aswin.boxcast.core.data.ranking
+                                                    .AdaptiveCandidateScorer.getInstance(application),
                                             ) as T
                                         }
                                     }
@@ -2044,7 +2052,9 @@ class MainActivity : ComponentActivity() {
                                                 subscriptionRepository,
                                                 playbackRepository,
                                                 downloadRepository,
-                                                userPrefs
+                                                userPrefs,
+                                                cx.aswin.boxcast.core.data.ranking
+                                                    .AdaptiveCandidateScorer.getInstance(application),
                                             ) as T
                                         }
                                     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
@@ -17,6 +17,9 @@ import cx.aswin.boxcast.core.data.database.DownloadedEpisodeEntity
 import cx.aswin.boxcast.core.data.service.MediaDownloadService
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
+import cx.aswin.boxcast.core.data.ranking.FeedbackTarget
+import cx.aswin.boxcast.core.data.ranking.RankingAction
+import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -163,6 +166,16 @@ class DownloadRepository(
                     isSmartDownloaded = isSmartDownloaded
                 )
                 database.downloadedEpisodeDao().insert(entity)
+                if (!isSmartDownloaded) {
+                    RankingFeedbackRepository.getInstance(context).recordAction(
+                        target = FeedbackTarget(
+                            episodeId = episode.id,
+                            podcastId = podcast.id,
+                            genre = episode.podcastGenre ?: podcast.genre,
+                        ),
+                        action = RankingAction.MANUAL_DOWNLOAD,
+                    )
+                }
                 android.util.Log.d("DownloadRepo", "Optimistic insert successful for ${episode.id}")
             } catch (e: Exception) {
                 android.util.Log.e("DownloadRepo", "Optimistic insert failed for ${episode.id}", e)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/DownloadRepository.kt
@@ -142,13 +142,13 @@ class DownloadRepository(
         android.util.Log.d("DownloadRepo", "Optimistically adding download: ${episode.id}")
         // Optimistically insert into DB as "Downloading"
         CoroutineScope(Dispatchers.IO).launch {
-            try {
+            val entity = try {
                 android.util.Log.d("DownloadRepo", "Inserting optimistic download entity for ${episode.id}")
                 
                 val localEpisodeImg = downloadArtworkLocally(context, episode.imageUrl, "downloaded_artworks", "episode_${episode.id}.png") ?: episode.imageUrl
                 val localPodcastImg = downloadArtworkLocally(context, podcast.imageUrl, "downloaded_artworks", "podcast_${podcast.id}.png") ?: podcast.imageUrl
                 
-                val entity = DownloadedEpisodeEntity(
+                DownloadedEpisodeEntity(
                     episodeId = episode.id,
                     podcastId = podcast.id,
                     episodeTitle = episode.title,
@@ -165,21 +165,27 @@ class DownloadRepository(
                     status = DownloadedEpisodeEntity.STATUS_DOWNLOADING,
                     isSmartDownloaded = isSmartDownloaded
                 )
+            } catch (error: Exception) {
+                android.util.Log.e("DownloadRepo", "Failed to prepare download ${episode.id}", error)
+                return@launch
+            }
+            try {
                 database.downloadedEpisodeDao().insert(entity)
-                if (!isSmartDownloaded) {
-                    RankingFeedbackRepository.getInstance(context).recordAction(
-                        target = FeedbackTarget(
-                            episodeId = episode.id,
-                            podcastId = podcast.id,
-                            genre = episode.podcastGenre ?: podcast.genre,
-                        ),
-                        action = RankingAction.MANUAL_DOWNLOAD,
-                    )
-                }
-                android.util.Log.d("DownloadRepo", "Optimistic insert successful for ${episode.id}")
             } catch (e: Exception) {
                 android.util.Log.e("DownloadRepo", "Optimistic insert failed for ${episode.id}", e)
+                return@launch
             }
+            if (!isSmartDownloaded) {
+                RankingFeedbackRepository.getInstance(context).recordAction(
+                    target = FeedbackTarget(
+                        episodeId = episode.id,
+                        podcastId = podcast.id,
+                        genre = episode.podcastGenre ?: podcast.genre,
+                    ),
+                    action = RankingAction.MANUAL_DOWNLOAD,
+                )
+            }
+            android.util.Log.d("DownloadRepo", "Optimistic insert successful for ${episode.id}")
         }
     }
     

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/MixtapeEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/MixtapeEngine.kt
@@ -20,6 +20,11 @@ object MixtapeEngine {
         val unplayedCount: Int,
     )
 
+    data class AdaptiveRanking(
+        val scorer: AdaptiveCandidateScorer,
+        val objective: RankingObjective = RankingObjective.CONTINUATION,
+    )
+
     private data class Candidate(
         val podcast: Podcast,
         val episode: Episode,
@@ -39,8 +44,7 @@ object MixtapeEngine {
             podcasts = subscriptions.map(Podcast::toScorable),
             allHistory = history,
         ),
-        adaptiveScorer: AdaptiveCandidateScorer? = null,
-        objective: RankingObjective = RankingObjective.CONTINUATION,
+        adaptiveRanking: AdaptiveRanking? = null,
         nowMs: Long = System.currentTimeMillis(),
     ): Result {
         val historyByEpisode = history.associateBy(ListeningHistoryEntity::episodeId)
@@ -64,8 +68,8 @@ object MixtapeEngine {
             subscriptionsById = subscriptionsById,
             historyByEpisode = historyByEpisode,
         )
-        if (adaptiveScorer != null) {
-            val adaptiveScores = adaptiveScorer.scoreEpisodes(
+        if (adaptiveRanking != null) {
+            val adaptiveScores = adaptiveRanking.scorer.scoreEpisodes(
                 inputs = ordered.map { candidate ->
                     EpisodeRankingInput(
                         episode = candidate.episode,
@@ -76,7 +80,7 @@ object MixtapeEngine {
                     )
                 },
                 history = history,
-                objective = objective,
+                objective = adaptiveRanking.objective,
                 nowMs = nowMs,
             )
             ordered = orderCandidates(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/MixtapeEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/MixtapeEngine.kt
@@ -9,6 +9,7 @@ import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.EpisodeStatus
 import cx.aswin.boxcast.core.model.Podcast
+import kotlinx.coroutines.CancellationException
 
 object MixtapeEngine {
     private const val MAX_ITEMS = 15
@@ -63,7 +64,7 @@ object MixtapeEngine {
             podcastScores = podcastScores,
             nowMs = nowMs,
         )
-        var ordered = orderCandidates(candidates).take(MAX_ITEMS).toMutableList()
+        var ordered = orderCandidates(candidates).toMutableList()
         addRecommendationFallbacks(
             candidates = ordered,
             recommendations = recommendations,
@@ -71,26 +72,34 @@ object MixtapeEngine {
             historyByEpisode = historyByEpisode,
         )
         if (adaptiveRanking != null) {
-            val adaptiveScores = adaptiveRanking.scorer.scoreEpisodes(
-                inputs = ordered.map { candidate ->
-                    EpisodeRankingInput(
-                        episode = candidate.episode,
-                        podcast = candidate.podcast,
-                        priorScore = candidate.score,
-                        source = candidate.source,
-                        isNovel = candidate.source == CandidateSource.SERVER_RECOMMENDATION,
-                    )
-                },
-                history = history,
-                objective = adaptiveRanking.objective,
-                surface = adaptiveRanking.surface,
-                nowMs = nowMs,
-            )
-            ordered = orderCandidates(
-                ordered.map { candidate ->
-                    candidate.copy(score = adaptiveScores[candidate.episode.id] ?: candidate.score)
-                },
-            ).take(MAX_ITEMS).toMutableList()
+            ordered = try {
+                val adaptiveScores = adaptiveRanking.scorer.scoreEpisodes(
+                    inputs = ordered.map { candidate ->
+                        EpisodeRankingInput(
+                            episode = candidate.episode,
+                            podcast = candidate.podcast,
+                            priorScore = candidate.score,
+                            source = candidate.source,
+                            isNovel = candidate.source == CandidateSource.SERVER_RECOMMENDATION,
+                        )
+                    },
+                    history = history,
+                    objective = adaptiveRanking.objective,
+                    surface = adaptiveRanking.surface,
+                    nowMs = nowMs,
+                )
+                orderCandidates(
+                    ordered.map { candidate ->
+                        candidate.copy(score = adaptiveScores[candidate.episode.id] ?: candidate.score)
+                    },
+                ).take(MAX_ITEMS).toMutableList()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                orderCandidates(ordered).take(MAX_ITEMS).toMutableList()
+            }
+        } else {
+            ordered = ordered.take(MAX_ITEMS).toMutableList()
         }
         val podcasts = ordered.map { candidate ->
             val status = when {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/MixtapeEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/MixtapeEngine.kt
@@ -1,6 +1,10 @@
 package cx.aswin.boxcast.core.data
 
 import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
+import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.EpisodeStatus
 import cx.aswin.boxcast.core.model.Podcast
@@ -21,11 +25,12 @@ object MixtapeEngine {
         val episode: Episode,
         val score: Double,
         val isProgress: Boolean,
+        val source: CandidateSource,
         val progressMs: Long = 0L,
         val durationMs: Long = 0L,
     )
 
-    fun build(
+    suspend fun build(
         subscriptions: List<Podcast>,
         history: List<ListeningHistoryEntity>,
         resolvedSerialEpisodes: Map<String, Episode> = emptyMap(),
@@ -34,6 +39,8 @@ object MixtapeEngine {
             podcasts = subscriptions.map(Podcast::toScorable),
             allHistory = history,
         ),
+        adaptiveScorer: AdaptiveCandidateScorer? = null,
+        objective: RankingObjective = RankingObjective.CONTINUATION,
         nowMs: Long = System.currentTimeMillis(),
     ): Result {
         val historyByEpisode = history.associateBy(ListeningHistoryEntity::episodeId)
@@ -50,13 +57,34 @@ object MixtapeEngine {
             podcastScores = podcastScores,
             nowMs = nowMs,
         )
-        val ordered = orderCandidates(candidates).take(MAX_ITEMS).toMutableList()
+        var ordered = orderCandidates(candidates).take(MAX_ITEMS).toMutableList()
         addRecommendationFallbacks(
             candidates = ordered,
             recommendations = recommendations,
             subscriptionsById = subscriptionsById,
             historyByEpisode = historyByEpisode,
         )
+        if (adaptiveScorer != null) {
+            val adaptiveScores = adaptiveScorer.scoreEpisodes(
+                inputs = ordered.map { candidate ->
+                    EpisodeRankingInput(
+                        episode = candidate.episode,
+                        podcast = candidate.podcast,
+                        priorScore = candidate.score,
+                        source = candidate.source,
+                        isNovel = candidate.source == CandidateSource.SERVER_RECOMMENDATION,
+                    )
+                },
+                history = history,
+                objective = objective,
+                nowMs = nowMs,
+            )
+            ordered = orderCandidates(
+                ordered.map { candidate ->
+                    candidate.copy(score = adaptiveScores[candidate.episode.id] ?: candidate.score)
+                },
+            ).take(MAX_ITEMS).toMutableList()
+        }
         val podcasts = ordered.map { candidate ->
             val status = when {
                 candidate.isProgress -> EpisodeStatus.IN_PROGRESS
@@ -128,6 +156,7 @@ object MixtapeEngine {
                     progressRatio * 500.0 +
                     AFFINITY_WEIGHT * podcastScores.getOrDefault(item.podcastId, 0.0),
                 isProgress = true,
+                source = CandidateSource.LOCAL_HISTORY,
                 progressMs = item.progressMs,
                 durationMs = item.durationMs,
             )
@@ -172,6 +201,7 @@ object MixtapeEngine {
                 (if (podcast.preferredSort == "oldest") 150.0 else 0.0) +
                 AFFINITY_WEIGHT * podcastScores.getOrDefault(podcast.id, 0.0),
             isProgress = false,
+            source = CandidateSource.SUBSCRIPTION,
         )
     }
 
@@ -220,6 +250,7 @@ object MixtapeEngine {
                     episode = episode,
                     score = 100.0,
                     isProgress = false,
+                    source = CandidateSource.SERVER_RECOMMENDATION,
                 )
             }
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/MixtapeEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/MixtapeEngine.kt
@@ -5,6 +5,7 @@ import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
 import cx.aswin.boxcast.core.data.ranking.CandidateSource
 import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.EpisodeStatus
 import cx.aswin.boxcast.core.model.Podcast
@@ -23,6 +24,7 @@ object MixtapeEngine {
     data class AdaptiveRanking(
         val scorer: AdaptiveCandidateScorer,
         val objective: RankingObjective = RankingObjective.CONTINUATION,
+        val surface: RankingSurface,
     )
 
     private data class Candidate(
@@ -81,6 +83,7 @@ object MixtapeEngine {
                 },
                 history = history,
                 objective = adaptiveRanking.objective,
+                surface = adaptiveRanking.surface,
                 nowMs = nowMs,
             )
             ordered = orderCandidates(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -26,6 +26,10 @@ import cx.aswin.boxcast.core.model.Chapter
 import cx.aswin.boxcast.core.model.PlaybackEntryPoint
 import cx.aswin.boxcast.core.data.service.BoxLorePlaybackService
 import cx.aswin.boxcast.core.data.playback.PlaybackSkipPolicy
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.FeedbackTarget
+import cx.aswin.boxcast.core.data.ranking.RankingAction
+import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
 import cx.aswin.boxcast.core.designsystem.components.AutoTranscriptState
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -109,6 +113,7 @@ class PlaybackRepository(
     private val KEY_DEBUG_SKIP_SLEEP_WINDOW = "debug_skip_sleep_window"
     
     private val userPreferencesRepository = UserPreferencesRepository(context)
+    private val rankingFeedbackRepository = RankingFeedbackRepository.getInstance(context)
     private var currentSkipBehavior: String = "just_skip"
     @Volatile private var currentSkipEndingMs: Long = 0L
 
@@ -1495,6 +1500,19 @@ class PlaybackRepository(
              _playerState.value = _playerState.value.copy(queue = currentQueue + episode)
              Log.d("PlaybackRepo", "addToQueue: Updated local state, queue size=${_playerState.value.queue.size}")
              syncQueueToDb()
+             rankingFeedbackRepository.recordAction(
+                 target = FeedbackTarget(
+                     episodeId = episode.id,
+                     podcastId = podcast.id,
+                     genre = episode.podcastGenre ?: podcast.genre,
+                     source = if (entryPoint == PlaybackEntryPoint.LEARN) {
+                         CandidateSource.CURATED_INTENT
+                     } else {
+                         null
+                     },
+                 ),
+                 action = RankingAction.EXPLICIT_QUEUE,
+             )
         } ?: Log.e("PlaybackRepo", "addToQueue: mediaController still NULL after await!")
      }
 
@@ -1650,6 +1668,17 @@ class PlaybackRepository(
                 podcastId = removed.episode.podcastId,
                 source = removed.contextSourceId
             )
+            repositoryScope.launch {
+                rankingFeedbackRepository.recordAction(
+                    target = FeedbackTarget(
+                        episodeId = removed.episode.id,
+                        podcastId = removed.episode.podcastId.orEmpty(),
+                        genre = removed.episode.podcastGenre,
+                        source = CandidateSource.SERVER_RECOMMENDATION,
+                    ),
+                    action = RankingAction.REMOVE_AUTOFILLED,
+                )
+            }
         } catch (e: Exception) {
             android.util.Log.e("PlaybackRepo", "Failed to record queue removal signal for ${removed.episode.id}", e)
         }
@@ -1739,13 +1768,28 @@ class PlaybackRepository(
             android.util.Log.e("PlaybackRepo", "persistQueueOrder: Failed", e)
         }
         if (movedEpisodeId != null && fromQueueIndex != toQueueIndex && fromQueueIndex >= 0 && toQueueIndex >= 0) {
-            val contextType = queue.firstOrNull { it.id == movedEpisodeId }?.contextType
+            val movedEpisode = queue.firstOrNull { it.id == movedEpisodeId }
+            val contextType = movedEpisode?.contextType
             cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackQueueReordered(
                 episodeId = movedEpisodeId,
                 fromPosition = fromQueueIndex,
                 toPosition = toQueueIndex,
                 contextType = contextType
             )
+            movedEpisode?.let { episode ->
+                rankingFeedbackRepository.recordAction(
+                    target = FeedbackTarget(
+                        episodeId = episode.id,
+                        podcastId = episode.podcastId.orEmpty(),
+                        genre = episode.podcastGenre,
+                    ),
+                    action = if (toQueueIndex < fromQueueIndex) {
+                        RankingAction.MOVE_UP
+                    } else {
+                        RankingAction.MOVE_DOWN
+                    },
+                )
+            }
         }
     }
 
@@ -2341,6 +2385,14 @@ class PlaybackRepository(
             )
             listeningHistoryDao.upsert(entity)
         }
+        rankingFeedbackRepository.recordAction(
+            target = FeedbackTarget(
+                episodeId = episode.id,
+                podcastId = podcastId,
+                genre = episode.podcastGenre,
+            ),
+            action = if (newStatus) RankingAction.LIKE else RankingAction.UNLIKE,
+        )
     }
 
     suspend fun toggleCompletion(episode: Episode, podcastId: String, podcastTitle: String, podcastImageUrl: String?) {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -2457,7 +2457,9 @@ class PlaybackRepository(
                 episodeImageUrl = episode.imageUrl,
                 podcastImageUrl = episode.podcastImageUrl ?: podcast?.imageUrl,
                 episodeAudioUrl = episode.audioUrl,
-                podcastName = episode.podcastTitle ?: podcast?.title ?: "Unknown Podcast",
+                podcastName = episode.podcastTitle.orEmpty().ifBlank {
+                    podcast?.title ?: "Unknown Podcast"
+                },
                 progressMs = 0L, // Reset progress on completion
                 durationMs = episode.duration * 1000L,
                 isCompleted = true,

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PlaybackRepository.kt
@@ -2351,6 +2351,7 @@ class PlaybackRepository(
 
     suspend fun clearHistory() {
         listeningHistoryDao.deleteAll()
+        rankingFeedbackRepository.reset()
     }
 
     suspend fun toggleLike(episode: Episode, podcastId: String, podcastTitle: String, podcastImageUrl: String?) {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PodcastRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PodcastRepository.kt
@@ -684,12 +684,20 @@ class PodcastRepository(
         android.util.Log.d("PodcastRepository", "Recommendation cache miss; fetching candidates")
 
         try {
-            val results = fetchRecommendationV2(
-                history = podcastIndexHistory,
-                interests = interests,
-                country = country,
-                subscribedPodcastIds = podcastIndexSubscriptionIds,
-            ) ?: fetchLegacyRecommendations(
+            val v2Results = try {
+                fetchRecommendationV2(
+                    history = podcastIndexHistory,
+                    interests = interests,
+                    country = country,
+                    subscribedPodcastIds = podcastIndexSubscriptionIds,
+                )
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                android.util.Log.w("BoxCastRepo", "Recommendation v2 failed; using legacy", error)
+                null
+            }
+            val results = v2Results ?: fetchLegacyRecommendations(
                 history = podcastIndexHistory,
                 interests = interests,
                 country = country,
@@ -698,6 +706,8 @@ class PodcastRepository(
             )
             recommendationsCache[cacheKey] = Pair(results, now)
             results
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (e: Exception) {
             android.util.Log.e("BoxCastRepo", "Personalized Recommendations Error", e)
             emptyList()
@@ -950,6 +960,7 @@ class PodcastRepository(
             serverRank = item.serverRank,
             recommendationAlgorithmVersion = item.algorithmVersion,
             language = item.language,
+            podcastGenre = item.genre,
         )
     }
     suspend fun getPodcastType(feedId: String): String = withContext(Dispatchers.IO) {
@@ -1212,7 +1223,8 @@ private fun cx.aswin.boxcast.core.network.model.ContentCatalogResponse.toContent
                 subtitle = intent.subtitleFallback,
                 providerQueryRef = intent.providerQueryRef,
                 layout = layout,
-                refreshPolicy = cx.aswin.boxcast.core.data.content.ContentRefreshPolicy.SESSION,
+                refreshPolicy = intent.refreshPolicy.toContentRefreshPolicy()
+                    ?: cx.aswin.boxcast.core.data.content.ContentRefreshPolicy.SESSION,
                 minimumItems = intent.minCandidates,
                 maximumItems = intent.maxCandidates,
                 protected = intent.layout == "protected_card",
@@ -1253,6 +1265,17 @@ private fun String.toContentLayout(): cx.aswin.boxcast.core.data.content.Content
         "podcast_rail" -> cx.aswin.boxcast.core.data.content.ContentLayout.PODCAST_RAIL
         "compact_list" -> cx.aswin.boxcast.core.data.content.ContentLayout.COMPACT_LIST
         "protected_card" -> cx.aswin.boxcast.core.data.content.ContentLayout.PROTECTED_CARD
+        else -> null
+    }
+}
+
+private fun String?.toContentRefreshPolicy():
+    cx.aswin.boxcast.core.data.content.ContentRefreshPolicy? {
+    return when (this?.lowercase()) {
+        "session" -> cx.aswin.boxcast.core.data.content.ContentRefreshPolicy.SESSION
+        "manual" -> cx.aswin.boxcast.core.data.content.ContentRefreshPolicy.MANUAL
+        "daypart" -> cx.aswin.boxcast.core.data.content.ContentRefreshPolicy.DAYPART
+        "daily" -> cx.aswin.boxcast.core.data.content.ContentRefreshPolicy.DAILY
         else -> null
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/PodcastRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/PodcastRepository.kt
@@ -99,11 +99,15 @@ private data class PodcastIndexScopedInputs(
 class PodcastRepository(
     private val baseUrl: String,
     val publicKey: String,
-    context: android.content.Context,
+    private val context: android.content.Context,
     private val ioDispatcher: kotlinx.coroutines.CoroutineDispatcher = kotlinx.coroutines.Dispatchers.IO
 ) {
     val api: BoxLoreApi = NetworkModule.createBoxLoreApi(baseUrl, context)
     private val rssRepository = RssPodcastRepository.getInstance(context)
+    private val contentCatalogPreferences = context.applicationContext.getSharedPreferences(
+        "content_catalog_cache",
+        android.content.Context.MODE_PRIVATE,
+    )
 
     suspend fun getTrendingPodcasts(country: String = "us", limit: Int = 50, category: String? = null, offset: Int = 0): List<Podcast> = withContext(Dispatchers.IO) {
         // Fallback or non-streaming implementation
@@ -602,6 +606,50 @@ class PodcastRepository(
         return PodcastIndexScopedInputs(podcastIndexHistory, podcastIndexSubscriptionIds)
     }
 
+    suspend fun getContentCatalog(
+        forceRefresh: Boolean = false,
+    ): cx.aswin.boxcast.core.data.content.ContentCatalogSnapshot? = withContext(Dispatchers.IO) {
+        val now = System.currentTimeMillis()
+        val cached = readCachedContentCatalog(now)
+        if (!forceRefresh && cached?.isSupported(now) == true) return@withContext cached
+        try {
+            val etag = contentCatalogPreferences.getString(CONTENT_CATALOG_ETAG, null)
+            val response = api.getContentCatalog(publicKey, etag).execute()
+            if (response.code() == 304) {
+                contentCatalogPreferences.edit()
+                    .putLong(CONTENT_CATALOG_FETCHED_AT, now)
+                    .apply()
+                return@withContext readCachedContentCatalog(now)
+            }
+            val body = response.body()
+            if (!response.isSuccessful || body == null) return@withContext cached
+            val snapshot = body.toContentCatalogSnapshot(now)
+            if (!snapshot.isSupported(now)) return@withContext cached
+            contentCatalogPreferences.edit()
+                .putString(CONTENT_CATALOG_JSON, Gson().toJson(body))
+                .putString(CONTENT_CATALOG_ETAG, response.headers()["ETag"])
+                .putLong(CONTENT_CATALOG_FETCHED_AT, now)
+                .apply()
+            snapshot
+        } catch (error: Exception) {
+            android.util.Log.w("PodcastRepository", "Content catalog refresh failed", error)
+            cached
+        }
+    }
+
+    private fun readCachedContentCatalog(
+        now: Long,
+    ): cx.aswin.boxcast.core.data.content.ContentCatalogSnapshot? {
+        val json = contentCatalogPreferences.getString(CONTENT_CATALOG_JSON, null) ?: return null
+        val fetchedAt = contentCatalogPreferences.getLong(CONTENT_CATALOG_FETCHED_AT, 0L)
+        return runCatching {
+            Gson().fromJson(
+                json,
+                cx.aswin.boxcast.core.network.model.ContentCatalogResponse::class.java,
+            ).toContentCatalogSnapshot(fetchedAt.takeIf { it > 0L } ?: now)
+        }.getOrNull()
+    }
+
     suspend fun getPersonalizedRecommendations(
         history: List<cx.aswin.boxcast.core.network.model.HistoryItem>,
         interests: List<String> = emptyList(),
@@ -633,26 +681,138 @@ class PodcastRepository(
             android.util.Log.d("PodcastRepository", "Cache HIT for getPersonalizedRecommendations: key=$cacheKey")
             return@withContext cached.first
         }
-        android.util.Log.d("PodcastRepository", "Cache MISS for getPersonalizedRecommendations. Fetching from network. Key: $cacheKey")
+        android.util.Log.d("PodcastRepository", "Recommendation cache miss; fetching candidates")
 
         try {
-            val request = cx.aswin.boxcast.core.network.model.RecommendationsRequest(
+            val results = fetchRecommendationV2(
                 history = podcastIndexHistory,
                 interests = interests,
                 country = country,
                 subscribedPodcastIds = podcastIndexSubscriptionIds,
-                subscribedGenres = subscribedGenres
+            ) ?: fetchLegacyRecommendations(
+                history = podcastIndexHistory,
+                interests = interests,
+                country = country,
+                subscribedPodcastIds = podcastIndexSubscriptionIds,
+                subscribedGenres = subscribedGenres,
             )
-            val response = api.getPersonalizedRecommendations(publicKey, getOrCreateDeviceUuid(), request).execute()
-            if (response.isSuccessful && response.body() != null) {
-                val results = response.body()!!.items.mapNotNull { mapToEpisode(it) }
-                recommendationsCache[cacheKey] = Pair(results, now)
-                results
-            } else {
-                emptyList()
-            }
+            recommendationsCache[cacheKey] = Pair(results, now)
+            results
         } catch (e: Exception) {
             android.util.Log.e("BoxCastRepo", "Personalized Recommendations Error", e)
+            emptyList()
+        }
+    }
+
+    private fun fetchRecommendationV2(
+        history: List<cx.aswin.boxcast.core.network.model.HistoryItem>,
+        interests: List<String>,
+        country: String?,
+        subscribedPodcastIds: List<String>,
+    ): List<Episode>? {
+        val seeds = buildRecommendationSeeds(history, subscribedPodcastIds)
+        val boundedInterests = interests.map(String::trim).filter(String::isNotEmpty).distinct().take(12)
+        if (seeds.isEmpty() && boundedInterests.isEmpty()) return null
+        val request = cx.aswin.boxcast.core.network.model.RecommendationsV2Request(
+            country = country?.lowercase()?.takeIf { it.length in 2..3 } ?: "us",
+            languages = listOf("en"),
+            seeds = seeds,
+            interests = boundedInterests,
+            subscribedPodcastIds = subscribedPodcastIds.mapNotNull(String::toLongOrNull)
+                .filter { it > 0L }
+                .distinct()
+                .take(250),
+            excludedEpisodeIds = history.mapNotNull { it.episodeId?.toLongOrNull() }
+                .filter { it > 0L }
+                .distinct()
+                .take(250),
+        )
+        val response = api.getPersonalizedRecommendationsV2(
+            publicKey,
+            getOrCreateDeviceUuid(),
+            request,
+        ).execute()
+        val body = response.body()
+        if (!response.isSuccessful ||
+            body?.status != "true" ||
+            body.contractVersion != 2 ||
+            body.algorithmVersion.isNullOrBlank()
+        ) {
+            return null
+        }
+        return body.items.mapNotNull { mapToEpisode(it) }.takeIf { it.isNotEmpty() }
+    }
+
+    private fun buildRecommendationSeeds(
+        history: List<cx.aswin.boxcast.core.network.model.HistoryItem>,
+        subscribedPodcastIds: List<String>,
+    ): List<cx.aswin.boxcast.core.network.model.RecommendationSeedV2> {
+        val episodeSeeds = history.mapNotNull { item ->
+            val id = item.episodeId?.toLongOrNull()?.takeIf { it > 0L } ?: return@mapNotNull null
+            val durationMs = item.durationMs ?: 0L
+            val progressRatio = if (durationMs > 0L) {
+                (item.progressMs ?: 0L).toDouble() / durationMs
+            } else {
+                0.0
+            }
+            val weight = when {
+                item.isLiked == true -> 1.0
+                item.isCompleted == true -> 0.9
+                progressRatio >= 0.5 -> 0.75
+                progressRatio >= 0.2 -> 0.55
+                else -> 0.35
+            }
+            cx.aswin.boxcast.core.network.model.RecommendationSeedV2(
+                kind = "episode",
+                id = id,
+                weight = weight,
+                fallback = cx.aswin.boxcast.core.network.model.RecommendationSemanticFallback(
+                    episodeTitle = item.episodeTitle.take(180),
+                    podcastTitle = item.podcastTitle.take(180),
+                    genre = item.genre?.take(120),
+                    description = item.episodeDescription.toSemanticFallback(),
+                ),
+            )
+        }.distinctBy { it.id }.sortedByDescending { it.weight }
+        if (episodeSeeds.size >= 12) return episodeSeeds.take(12)
+        val podcastSeeds = subscribedPodcastIds.asSequence()
+            .mapNotNull(String::toLongOrNull)
+            .filter { it > 0L }
+            .distinct()
+            .map { id ->
+                cx.aswin.boxcast.core.network.model.RecommendationSeedV2(
+                    kind = "podcast",
+                    id = id,
+                    weight = 0.35,
+                )
+            }
+            .take(12 - episodeSeeds.size)
+            .toList()
+        return episodeSeeds.take(12) + podcastSeeds
+    }
+
+    private fun fetchLegacyRecommendations(
+        history: List<cx.aswin.boxcast.core.network.model.HistoryItem>,
+        interests: List<String>,
+        country: String?,
+        subscribedPodcastIds: List<String>,
+        subscribedGenres: List<String>,
+    ): List<Episode> {
+        val request = cx.aswin.boxcast.core.network.model.RecommendationsRequest(
+            history = history,
+            interests = interests,
+            country = country,
+            subscribedPodcastIds = subscribedPodcastIds,
+            subscribedGenres = subscribedGenres,
+        )
+        val response = api.getPersonalizedRecommendations(
+            publicKey,
+            getOrCreateDeviceUuid(),
+            request,
+        ).execute()
+        return if (response.isSuccessful) {
+            response.body()?.items.orEmpty().mapNotNull { mapToEpisode(it) }
+        } else {
             emptyList()
         }
     }
@@ -782,7 +942,14 @@ class PodcastRepository(
             seasonNumber = item.season,
             episodeNumber = item.episodeNumber,
             episodeType = item.episodeType,
-            enclosureType = item.enclosureType
+            enclosureType = item.enclosureType,
+            retrievalScore = item.retrievalScore,
+            semanticScore = item.semanticScore,
+            recommendationSource = item.recommendationSource,
+            recommendationReason = item.recommendationReason,
+            serverRank = item.serverRank,
+            recommendationAlgorithmVersion = item.algorithmVersion,
+            language = item.language,
         )
     }
     suspend fun getPodcastType(feedId: String): String = withContext(Dispatchers.IO) {
@@ -1000,10 +1167,93 @@ class PodcastRepository(
         private const val FEED_PREFIX_URL = "url:"
         private const val FEED_PREFIX_GUID = "guid:"
         private const val FEED_PREFIX_ITUNES = "itunes:"
+        private const val CONTENT_CATALOG_JSON = "catalog_json"
+        private const val CONTENT_CATALOG_ETAG = "catalog_etag"
+        private const val CONTENT_CATALOG_FETCHED_AT = "catalog_fetched_at"
 
         private val episodesCache = java.util.concurrent.ConcurrentHashMap<String, Pair<EpisodePage, Long>>()
         private val recommendationsCache = java.util.concurrent.ConcurrentHashMap<String, Pair<List<Episode>, Long>>()
         private val becauseYouLikeCache = java.util.concurrent.ConcurrentHashMap<String, Pair<BecauseYouLikeData, Long>>()
+    }
+}
+
+private val semanticMarkupPattern = Regex("<[^>]+>")
+private val semanticUrlPattern = Regex("""https?://\S+""", RegexOption.IGNORE_CASE)
+private val semanticWhitespacePattern = Regex("\\s+")
+
+private fun String?.toSemanticFallback(): String? {
+    return this
+        ?.replace(semanticMarkupPattern, " ")
+        ?.replace(semanticUrlPattern, " ")
+        ?.replace(semanticWhitespacePattern, " ")
+        ?.trim()
+        ?.take(800)
+        ?.takeIf(String::isNotEmpty)
+}
+
+private fun cx.aswin.boxcast.core.network.model.ContentCatalogResponse.toContentCatalogSnapshot(
+    fetchedAt: Long,
+): cx.aswin.boxcast.core.data.content.ContentCatalogSnapshot {
+    val validDurationMillis = validForSeconds
+        .coerceIn(60L, 7L * 24L * 60L * 60L)
+        .times(1_000L)
+    val mappedIntents = intents.mapNotNull { intent ->
+        val surfaces = intent.surfaces.mapNotNull(String::toRankingSurface).toSet()
+        val dayparts = intent.dayparts.mapNotNull(String::toContentDaypart).toSet()
+        val layout = intent.layout.toContentLayout() ?: return@mapNotNull null
+        if (surfaces.isEmpty() || dayparts.isEmpty()) return@mapNotNull null
+        runCatching {
+            cx.aswin.boxcast.core.data.content.ContentIntent(
+                id = intent.id,
+                objective = cx.aswin.boxcast.core.data.ranking.RankingObjective.DISCOVERY,
+                eligibleSurfaces = surfaces,
+                eligibleDayparts = dayparts,
+                title = intent.titleFallback,
+                subtitle = intent.subtitleFallback,
+                providerQueryRef = intent.providerQueryRef,
+                layout = layout,
+                refreshPolicy = cx.aswin.boxcast.core.data.content.ContentRefreshPolicy.SESSION,
+                minimumItems = intent.minCandidates,
+                maximumItems = intent.maxCandidates,
+                protected = intent.layout == "protected_card",
+            )
+        }.getOrNull()
+    }
+    return cx.aswin.boxcast.core.data.content.ContentCatalogSnapshot(
+        schemaVersion = schemaVersion,
+        catalogVersion = catalogVersion.toString(),
+        validUntil = fetchedAt + validDurationMillis,
+        intents = mappedIntents,
+    )
+}
+
+private fun String.toRankingSurface(): cx.aswin.boxcast.core.data.ranking.RankingSurface? {
+    return when (lowercase()) {
+        "home" -> cx.aswin.boxcast.core.data.ranking.RankingSurface.HOME
+        "explore" -> cx.aswin.boxcast.core.data.ranking.RankingSurface.EXPLORE
+        "auto" -> cx.aswin.boxcast.core.data.ranking.RankingSurface.ANDROID_AUTO
+        else -> null
+    }
+}
+
+private fun String.toContentDaypart(): cx.aswin.boxcast.core.data.content.ContentDaypart? {
+    return when (lowercase()) {
+        "early_morning", "morning", "commute" ->
+            cx.aswin.boxcast.core.data.content.ContentDaypart.MORNING
+        "afternoon" -> cx.aswin.boxcast.core.data.content.ContentDaypart.AFTERNOON
+        "evening" -> cx.aswin.boxcast.core.data.content.ContentDaypart.EVENING
+        "late_night" -> cx.aswin.boxcast.core.data.content.ContentDaypart.LATE_NIGHT
+        else -> null
+    }
+}
+
+private fun String.toContentLayout(): cx.aswin.boxcast.core.data.content.ContentLayout? {
+    return when (lowercase()) {
+        "episode_rail" -> cx.aswin.boxcast.core.data.content.ContentLayout.EPISODE_RAIL
+        "podcast_rail" -> cx.aswin.boxcast.core.data.content.ContentLayout.PODCAST_RAIL
+        "compact_list" -> cx.aswin.boxcast.core.data.content.ContentLayout.COMPACT_LIST
+        "protected_card" -> cx.aswin.boxcast.core.data.content.ContentLayout.PROTECTED_CARD
+        else -> null
     }
 }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/QueueRepository.kt
@@ -6,6 +6,10 @@ import cx.aswin.boxcast.core.data.database.entities.QueueItem
 import cx.aswin.boxcast.core.network.model.EpisodeItem
 import cx.aswin.boxcast.core.model.Person
 import cx.aswin.boxcast.core.model.Transcript
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.FeedbackTarget
+import cx.aswin.boxcast.core.data.ranking.RankingAction
+import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import org.json.JSONArray
@@ -88,6 +92,21 @@ class QueueRepository @Inject constructor(
         )
         android.util.Log.d(TAG, "addToQueue: Inserting newItem at position ${maxPos + 1}")
         queueDao.insertQueueItem(newItem)
+        if (newItem.contextType == "MANUAL" || newItem.contextType == QueueMath.CONTEXT_TYPE_LORE) {
+            RankingFeedbackRepository.getIfInitialized()?.recordAction(
+                target = FeedbackTarget(
+                    episodeId = newItem.episodeId,
+                    podcastId = newItem.podcastId,
+                    genre = newItem.podcastGenre,
+                    source = if (newItem.contextType == QueueMath.CONTEXT_TYPE_LORE) {
+                        CandidateSource.CURATED_INTENT
+                    } else {
+                        null
+                    },
+                ),
+                action = RankingAction.EXPLICIT_QUEUE,
+            )
+        }
     }
 
     suspend fun clearQueue() {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -15,6 +15,7 @@ import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
 import cx.aswin.boxcast.core.data.ranking.CandidateSource
 import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
 import kotlinx.coroutines.flow.first
@@ -537,6 +538,7 @@ class SmartDownloadManager(
                 podcasts = subs.map { it.toScorable() },
                 history = allHistory,
                 objective = RankingObjective.OFFLINE,
+                surface = RankingSurface.DOWNLOADS,
                 includeAutoDownloadBoost = false,
             )
 
@@ -563,6 +565,7 @@ class SmartDownloadManager(
                 },
                 history = allHistory,
                 objective = RankingObjective.OFFLINE,
+                surface = RankingSurface.DOWNLOADS,
             )
             val orderedCandidates = initialCandidates
                 .map { candidate ->

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -540,13 +540,24 @@ class SmartDownloadManager(
             val resolvedSerial = resolveOldestSerialNextEpisodes(subs, allHistory, completedEpisodeIds)
 
             val historyByEpisode = allHistory.associateBy { it.episodeId }
-            val podScoresMap = adaptiveScorer.scorePodcasts(
-                podcasts = subs.map { it.toScorable() },
-                history = allHistory,
-                objective = RankingObjective.OFFLINE,
-                surface = RankingSurface.DOWNLOADS,
-                includeAutoDownloadBoost = false,
-            )
+            val podScoresMap = try {
+                adaptiveScorer.scorePodcasts(
+                    podcasts = subs.map { it.toScorable() },
+                    history = allHistory,
+                    objective = RankingObjective.OFFLINE,
+                    surface = RankingSurface.DOWNLOADS,
+                    includeAutoDownloadBoost = false,
+                )
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                Log.w("SmartDownloadManager", "Adaptive podcast scoring failed", error)
+                PodcastScoring.calculateScores(
+                    podcasts = subs.map { it.toScorable() },
+                    allHistory = allHistory,
+                    includeAutoDownloadBoost = false,
+                )
+            }
 
             val initialCandidates = generateMixtapeCandidates(
                 subs,
@@ -555,24 +566,31 @@ class SmartDownloadManager(
                 resolvedSerial,
                 podScoresMap,
             )
-            val adaptiveScores = adaptiveScorer.scoreEpisodes(
-                inputs = initialCandidates.map { candidate ->
-                    EpisodeRankingInput(
-                        episode = candidate.episode,
-                        podcast = candidate.podcast,
-                        priorScore = candidate.score,
-                        source = if (candidate.isProgress) {
-                            CandidateSource.LOCAL_HISTORY
-                        } else {
-                            CandidateSource.SUBSCRIPTION
-                        },
-                        online = false,
-                    )
-                },
-                history = allHistory,
-                objective = RankingObjective.OFFLINE,
-                surface = RankingSurface.DOWNLOADS,
-            )
+            val adaptiveScores = try {
+                adaptiveScorer.scoreEpisodes(
+                    inputs = initialCandidates.map { candidate ->
+                        EpisodeRankingInput(
+                            episode = candidate.episode,
+                            podcast = candidate.podcast,
+                            priorScore = candidate.score,
+                            source = if (candidate.isProgress) {
+                                CandidateSource.LOCAL_HISTORY
+                            } else {
+                                CandidateSource.SUBSCRIPTION
+                            },
+                            online = false,
+                        )
+                    },
+                    history = allHistory,
+                    objective = RankingObjective.OFFLINE,
+                    surface = RankingSurface.DOWNLOADS,
+                )
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                Log.w("SmartDownloadManager", "Adaptive episode scoring failed", error)
+                initialCandidates.associate { it.episodeId to it.score }
+            }
             val orderedCandidates = initialCandidates
                 .map { candidate ->
                     candidate.copy(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -239,9 +239,15 @@ class SmartDownloadManager(
         } else {
             pod.latestEpisode
         }
-        if (resolvedEpisode == null) return null
-        val ep = resolvedEpisode
+        return buildUnplayedDropCandidate(pod, resolvedEpisode, historyByEpisode)
+    }
 
+    private fun buildUnplayedDropCandidate(
+        pod: PodcastEntity,
+        episode: Episode?,
+        historyByEpisode: Map<String, ListeningHistoryEntity>,
+    ): Pair<PodcastEntity, Episode>? {
+        val ep = episode ?: return null
         val history = historyByEpisode[ep.id]
         val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)
         return if (isUnplayed) {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -11,6 +11,10 @@ import cx.aswin.boxcast.core.data.database.BoxLoreDatabase
 import cx.aswin.boxcast.core.data.database.DownloadedEpisodeEntity
 import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
 import cx.aswin.boxcast.core.data.database.PodcastEntity
+import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
 import kotlinx.coroutines.flow.first
@@ -59,6 +63,7 @@ class SmartDownloadManager(
     private val subscriptionRepository: SubscriptionRepository,
     private val userPrefs: UserPreferencesRepository
 ) {
+    private val adaptiveScorer = AdaptiveCandidateScorer.getInstance(context)
 
     private data class MixtapeCandidate(
         val episodeId: String,
@@ -526,13 +531,44 @@ class SmartDownloadManager(
             val resolvedSerial = resolveOldestSerialNextEpisodes(subs, allHistory, completedEpisodeIds)
 
             val historyByEpisode = allHistory.associateBy { it.episodeId }
-            val podScoresMap = PodcastScoring.calculateScores(
+            val podScoresMap = adaptiveScorer.scorePodcasts(
                 podcasts = subs.map { it.toScorable() },
-                allHistory = allHistory,
-                includeAutoDownloadBoost = false
+                history = allHistory,
+                objective = RankingObjective.OFFLINE,
+                includeAutoDownloadBoost = false,
             )
 
-            val orderedCandidates = generateMixtapeCandidates(subs, allHistory, historyByEpisode, resolvedSerial, podScoresMap)
+            val initialCandidates = generateMixtapeCandidates(
+                subs,
+                allHistory,
+                historyByEpisode,
+                resolvedSerial,
+                podScoresMap,
+            )
+            val adaptiveScores = adaptiveScorer.scoreEpisodes(
+                inputs = initialCandidates.map { candidate ->
+                    EpisodeRankingInput(
+                        episode = candidate.episode,
+                        podcast = candidate.podcast,
+                        priorScore = candidate.score,
+                        source = if (candidate.isProgress) {
+                            CandidateSource.LOCAL_HISTORY
+                        } else {
+                            CandidateSource.SUBSCRIPTION
+                        },
+                        online = false,
+                    )
+                },
+                history = allHistory,
+                objective = RankingObjective.OFFLINE,
+            )
+            val orderedCandidates = initialCandidates
+                .map { candidate ->
+                    candidate.copy(
+                        score = adaptiveScores[candidate.episodeId] ?: candidate.score,
+                    )
+                }
+                .sortedByDescending(MixtapeCandidate::score)
 
             val maxCount = userPrefs.smartDownloadsMaxEpisodesStream.first()
             val storageBudgetMb = userPrefs.smartDownloadsStorageBudgetStream.first()

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartDownloadManager.kt
@@ -233,11 +233,13 @@ class SmartDownloadManager(
         historyByEpisode: Map<String, ListeningHistoryEntity>
     ): Pair<PodcastEntity, Episode>? {
         val sort = pod.preferredSort ?: "newest"
-        val ep = if (sort == "oldest") {
+        val resolvedEpisode = if (sort == "oldest") {
             resolvedSerial[pod.podcastId] ?: pod.latestEpisode
         } else {
             pod.latestEpisode
-        } ?: return null
+        }
+        if (resolvedEpisode == null) return null
+        val ep = resolvedEpisode
 
         val history = historyByEpisode[ep.id]
         val isUnplayed = history == null || (history.progressMs == 0L && !history.isCompleted)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
@@ -9,6 +9,7 @@ import cx.aswin.boxcast.core.data.ranking.CandidateSource
 import cx.aswin.boxcast.core.data.ranking.DiversityPolicy
 import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import kotlinx.coroutines.CancellationException
 
 private suspend inline fun <T> runSuspendCatching(crossinline block: suspend () -> T): Result<T> =
@@ -271,6 +272,7 @@ class DefaultSmartQueueEngine(
             },
             history = history,
             objective = RankingObjective.CONTINUATION,
+            surface = RankingSurface.QUEUE,
             diversityPolicy = DiversityPolicy(
                 limit = fallback.size,
                 maxPerShow = 2,
@@ -494,6 +496,7 @@ class DefaultSmartQueueEngine(
                 podcasts = validSubs.map { it.toScorable() },
                 history = history,
                 objective = RankingObjective.CONTINUATION,
+                surface = RankingSurface.QUEUE,
             ) ?: PodcastScoring.calculateScores(validSubs.map { it.toScorable() }, history)
         }.getOrElse {
             android.util.Log.e(LOG_TAG, "Tier 2 subscription scoring failed", it)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
@@ -5,6 +5,9 @@ import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.network.model.EpisodeItem
 import cx.aswin.boxcast.core.network.model.HistoryItem
 import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.DiversityPolicy
+import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
 import kotlinx.coroutines.CancellationException
 
@@ -218,7 +221,9 @@ class DefaultSmartQueueEngine(
             )
         }
 
-        if (existingBatchSize + fallback.size >= MIN_ITEMS_BEFORE_NETWORK) return fallback
+        if (existingBatchSize + fallback.size >= MIN_ITEMS_BEFORE_NETWORK) {
+            return rankFallbackEntries(fallback, recentPodcasts)
+        }
 
         val region = sources.getRegion()
         val tier3 = networkTier3(
@@ -245,7 +250,36 @@ class DefaultSmartQueueEngine(
                 needed = FALLBACK_BATCH_TARGET - existingBatchSize - fallback.size
             )
         }
-        return fallback
+        return rankFallbackEntries(fallback, recentPodcasts)
+    }
+
+    private suspend fun rankFallbackEntries(
+        fallback: List<QueueEntry>,
+        recentPodcastIds: Set<String>,
+    ): List<QueueEntry> {
+        val scorer = adaptiveScorer ?: return fallback
+        val history = runSuspendCatching { sources.getRecentHistory(300) }.getOrDefault(emptyList())
+        val rankedEpisodes = scorer.rankEpisodes(
+            inputs = fallback.mapIndexed { index, entry ->
+                EpisodeRankingInput(
+                    episode = entry.toRankingEpisode(),
+                    podcast = entry.podcast,
+                    priorScore = (fallback.size - index).toDouble(),
+                    source = entry.source.toCandidateSource(),
+                    isNovel = entry.podcast.id !in recentPodcastIds,
+                )
+            },
+            history = history,
+            objective = RankingObjective.CONTINUATION,
+            diversityPolicy = DiversityPolicy(
+                limit = fallback.size,
+                maxPerShow = 2,
+                recentPodcastIds = recentPodcastIds,
+                reserveNovelSlot = true,
+            ),
+        )
+        val entryByEpisode = fallback.associateBy { it.episode.id.toString() }
+        return rankedEpisodes.mapNotNull { entryByEpisode[it.id] }
     }
 
     private fun sortBriefingFallback(fallback: List<QueueEntry>): List<QueueEntry> =
@@ -741,5 +775,31 @@ class DefaultSmartQueueEngine(
             transcriptUrl = this.transcriptUrl
         )
         return QueueEntry(episode = episodeItem, podcast = podcast, source = source)
+    }
+
+    private fun QueueEntry.toRankingEpisode(): Episode = Episode(
+        id = episode.id.toString(),
+        title = episode.title,
+        description = episode.description.orEmpty(),
+        audioUrl = episode.enclosureUrl.orEmpty(),
+        imageUrl = episode.image,
+        podcastImageUrl = episode.feedImage ?: podcast.imageUrl,
+        podcastTitle = podcast.title,
+        podcastId = podcast.id,
+        podcastGenre = podcast.genre,
+        podcastArtist = podcast.artist,
+        duration = episode.duration ?: 0,
+        publishedDate = episode.datePublished ?: 0L,
+        episodeType = episode.episodeType,
+        enclosureType = episode.enclosureType,
+    )
+
+    private fun String.toCandidateSource(): CandidateSource = when (this) {
+        SmartQueueEngine.SOURCE_RESUME -> CandidateSource.LOCAL_HISTORY
+        SmartQueueEngine.SOURCE_SUBSCRIPTION,
+        SmartQueueEngine.SOURCE_SAME_PODCAST,
+        -> CandidateSource.SUBSCRIPTION
+        SmartQueueEngine.SOURCE_TRENDING -> CandidateSource.TRENDING
+        else -> CandidateSource.SERVER_RECOMMENDATION
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
@@ -260,26 +260,31 @@ class DefaultSmartQueueEngine(
     ): List<QueueEntry> {
         val scorer = adaptiveScorer ?: return fallback
         val history = runSuspendCatching { sources.getRecentHistory(300) }.getOrDefault(emptyList())
-        val rankedEpisodes = scorer.rankEpisodes(
-            inputs = fallback.mapIndexed { index, entry ->
-                EpisodeRankingInput(
-                    episode = entry.toRankingEpisode(),
-                    podcast = entry.podcast,
-                    priorScore = (fallback.size - index).toDouble(),
-                    source = entry.source.toCandidateSource(),
-                    isNovel = entry.podcast.id !in recentPodcastIds,
-                )
-            },
-            history = history,
-            objective = RankingObjective.CONTINUATION,
-            surface = RankingSurface.QUEUE,
-            diversityPolicy = DiversityPolicy(
-                limit = fallback.size,
-                maxPerShow = 2,
-                recentPodcastIds = recentPodcastIds,
-                reserveNovelSlot = true,
-            ),
-        )
+        val rankedEpisodes = runSuspendCatching {
+            scorer.rankEpisodes(
+                inputs = fallback.mapIndexed { index, entry ->
+                    EpisodeRankingInput(
+                        episode = entry.toRankingEpisode(),
+                        podcast = entry.podcast,
+                        priorScore = (fallback.size - index).toDouble(),
+                        source = entry.source.toCandidateSource(),
+                        isNovel = entry.podcast.id !in recentPodcastIds,
+                    )
+                },
+                history = history,
+                objective = RankingObjective.CONTINUATION,
+                surface = RankingSurface.QUEUE,
+                diversityPolicy = DiversityPolicy(
+                    limit = fallback.size,
+                    maxPerShow = 2,
+                    recentPodcastIds = recentPodcastIds,
+                    reserveNovelSlot = true,
+                ),
+            )
+        }.getOrElse {
+            android.util.Log.w(LOG_TAG, "Adaptive fallback ranking failed", it)
+            return fallback
+        }
         val entryByEpisode = fallback.associateBy { it.episode.id.toString() }
         return rankedEpisodes.mapNotNull { entryByEpisode[it.id] }
     }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SmartQueueEngine.kt
@@ -4,6 +4,8 @@ import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.network.model.EpisodeItem
 import cx.aswin.boxcast.core.network.model.HistoryItem
+import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
 import kotlinx.coroutines.CancellationException
 
 private suspend inline fun <T> runSuspendCatching(crossinline block: suspend () -> T): Result<T> =
@@ -101,7 +103,8 @@ interface SmartQueueEngine {
 class DefaultSmartQueueEngine(
     private val sources: SmartQueueSources,
     private val skipMemory: QueueSkipMemory? = null,
-    private val nowMs: () -> Long = { System.currentTimeMillis() }
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+    private val adaptiveScorer: AdaptiveCandidateScorer? = null,
 ) : SmartQueueEngine {
 
     companion object {
@@ -452,8 +455,12 @@ class DefaultSmartQueueEngine(
                 sub.id.isNotBlank() && sub.title.isNotBlank()
             }.getOrDefault(false)
         }
-        val scores = runCatching {
-            PodcastScoring.calculateScores(validSubs.map { it.toScorable() }, history)
+        val scores = runSuspendCatching {
+            adaptiveScorer?.scorePodcasts(
+                podcasts = validSubs.map { it.toScorable() },
+                history = history,
+                objective = RankingObjective.CONTINUATION,
+            ) ?: PodcastScoring.calculateScores(validSubs.map { it.toScorable() }, history)
         }.getOrElse {
             android.util.Log.e(LOG_TAG, "Tier 2 subscription scoring failed", it)
             emptyMap()

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/SubscriptionRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/SubscriptionRepository.kt
@@ -3,6 +3,9 @@ package cx.aswin.boxcast.core.data
 import cx.aswin.boxcast.core.data.database.PodcastDao
 import cx.aswin.boxcast.core.data.database.PodcastEntity
 import cx.aswin.boxcast.core.model.Podcast
+import cx.aswin.boxcast.core.data.ranking.FeedbackTarget
+import cx.aswin.boxcast.core.data.ranking.RankingAction
+import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -79,6 +82,14 @@ class SubscriptionRepository(
             if (!podcast.isRss) {
                 updateFirebaseSubscription(podcast.id, podcast.title, podcast.imageUrl, false)
             }
+            RankingFeedbackRepository.getIfInitialized()?.recordAction(
+                target = FeedbackTarget(
+                    episodeId = podcast.latestEpisode?.id ?: "podcast:${podcast.id}",
+                    podcastId = podcast.id,
+                    genre = podcast.genre,
+                ),
+                action = RankingAction.UNSUBSCRIBE,
+            )
         } else {
             // Subscribe (Upsert to ensure we have data for offline/Jump Back In)
             val entity = PodcastEntity(
@@ -122,6 +133,14 @@ class SubscriptionRepository(
                 linkedPodcastIndexId = podcast.linkedPodcastIndexId,
             )
             podcastDao.upsert(entity)
+            RankingFeedbackRepository.getIfInitialized()?.recordAction(
+                target = FeedbackTarget(
+                    episodeId = podcast.latestEpisode?.id ?: "podcast:${podcast.id}",
+                    podcastId = podcast.id,
+                    genre = podcast.genre,
+                ),
+                action = RankingAction.SUBSCRIBE,
+            )
         }
     }
 
@@ -135,6 +154,7 @@ class SubscriptionRepository(
             return
         }
         val existing = podcastDao.getPodcast(podcast.id)
+        val isNewSubscription = existing?.isSubscribed != true
         val preferredSortVal = existing?.preferredSort ?: if (podcast.type == "serial") "oldest" else "newest"
         val typeVal = if (preferredSortVal == "oldest" || podcast.type == "serial") "serial" else "episodic"
         val entity = PodcastEntity(
@@ -184,6 +204,16 @@ class SubscriptionRepository(
                 ?: podcast.linkedPodcastIndexId,
         )
         podcastDao.upsert(entity)
+        if (isNewSubscription) {
+            RankingFeedbackRepository.getIfInitialized()?.recordAction(
+                target = FeedbackTarget(
+                    episodeId = podcast.latestEpisode?.id ?: "podcast:${podcast.id}",
+                    podcastId = podcast.id,
+                    genre = podcast.genre,
+                ),
+                action = RankingAction.SUBSCRIBE,
+            )
+        }
     }
 
     suspend fun setNotificationsEnabled(podcast: Podcast, enabled: Boolean) {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -1536,6 +1536,10 @@ object AnalyticsHelper {
             properties = mapOf(
                 "ranker_version" to statuses.maxOf(RankingAggregateTelemetry::rankerVersion),
                 "objectives" to statuses.map(RankingAggregateTelemetry::objective),
+                "ranker_versions" to statuses.map(RankingAggregateTelemetry::rankerVersion),
+                "ranker_versions_by_objective" to statuses.associate {
+                    it.objective to it.rankerVersion
+                },
                 "learning_stages" to statuses.map(RankingAggregateTelemetry::learningStage),
                 "outcome_count_buckets" to statuses.map(
                     RankingAggregateTelemetry::outcomeCountBucket,

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/analytics/AnalyticsHelper.kt
@@ -2,6 +2,7 @@ package cx.aswin.boxcast.core.data.analytics
 
 import android.content.Context
 import com.posthog.PostHog
+import cx.aswin.boxcast.core.data.ranking.RankingAggregateTelemetry
 import java.time.Instant
 
 object AnalyticsHelper {
@@ -1525,6 +1526,24 @@ object AnalyticsHelper {
                 "podcasts_clicked_count" to podcastsClickedCount,
                 "infos_clicked_count" to infosClickedCount
             )
+        )
+    }
+
+    fun trackAdaptiveRankingStatus(statuses: List<RankingAggregateTelemetry>) {
+        if (statuses.isEmpty()) return
+        PostHog.capture(
+            event = "adaptive_ranking_status",
+            properties = mapOf(
+                "ranker_version" to statuses.maxOf(RankingAggregateTelemetry::rankerVersion),
+                "objectives" to statuses.map(RankingAggregateTelemetry::objective),
+                "learning_stages" to statuses.map(RankingAggregateTelemetry::learningStage),
+                "outcome_count_buckets" to statuses.map(
+                    RankingAggregateTelemetry::outcomeCountBucket,
+                ),
+                "exploration_eligible" to statuses.map(
+                    RankingAggregateTelemetry::explorationEligible,
+                ),
+            ),
         )
     }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/backup/LibraryBackupManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/backup/LibraryBackupManager.kt
@@ -61,8 +61,9 @@ class LibraryBackupManager(
     private val playbackRepository: PlaybackRepository,
     private val podcastRepository: PodcastRepository,
     private val userPrefs: cx.aswin.boxcast.core.data.UserPreferencesRepository? = null,
-    private val context: android.content.Context? = null
+    context: android.content.Context,
 ) {
+    private val context = context.applicationContext
     private val gson: Gson = GsonBuilder()
         .setPrettyPrinting()
         .create()
@@ -101,10 +102,7 @@ class LibraryBackupManager(
             )
         } else null
 
-        val appContext = requireNotNull(context) {
-            "A context is required to export a complete JSON backup"
-        }
-        val rankingBackup = AdaptiveRankingRepository.getInstance(appContext).exportBackup()
+        val rankingBackup = AdaptiveRankingRepository.getInstance(context).exportBackup()
         val backup = BoxCastBackup(
             version = 5,
             subscriptions = subscriptions,
@@ -172,14 +170,12 @@ class LibraryBackupManager(
                     prefs.hideCompletedInSubs?.let { up.setHideCompletedInSubs(it) }
                     prefs.smartDownloadsEnabled?.let { enabled ->
                         up.setSmartDownloadsEnabled(enabled)
-                        if (context != null) {
-                            if (enabled) {
-                                val wifiOnly = prefs.smartDownloadsWifiOnly ?: true
-                                val chargingOnly = prefs.smartDownloadsChargingOnly ?: false
-                                cx.aswin.boxcast.core.data.SmartDownloadManager.schedulePeriodicSync(context, wifiOnly, chargingOnly)
-                            } else {
-                                cx.aswin.boxcast.core.data.SmartDownloadManager.cancelPeriodicSync(context)
-                            }
+                        if (enabled) {
+                            val wifiOnly = prefs.smartDownloadsWifiOnly ?: true
+                            val chargingOnly = prefs.smartDownloadsChargingOnly ?: false
+                            cx.aswin.boxcast.core.data.SmartDownloadManager.schedulePeriodicSync(context, wifiOnly, chargingOnly)
+                        } else {
+                            cx.aswin.boxcast.core.data.SmartDownloadManager.cancelPeriodicSync(context)
                         }
                     }
                     prefs.smartDownloadsMaxEpisodes?.let { up.setSmartDownloadsMaxEpisodes(it) }
@@ -327,10 +323,7 @@ class LibraryBackupManager(
             // 3. Restore the complete on-device learning state when present. Older backups
             // remain compatible because this versioned field is optional.
             backup.adaptiveRanking?.let { rankingBackup ->
-                val appContext = requireNotNull(context) {
-                    "A context is required to restore adaptive ranking"
-                }
-                AdaptiveRankingRepository.getInstance(appContext).restoreBackup(rankingBackup)
+                AdaptiveRankingRepository.getInstance(context).restoreBackup(rankingBackup)
             }
             
             // 4. Trigger check for new episodes

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/backup/LibraryBackupManager.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/backup/LibraryBackupManager.kt
@@ -5,6 +5,8 @@ import cx.aswin.boxcast.core.data.SubscriptionRepository
 import cx.aswin.boxcast.core.data.PlaybackRepository
 import cx.aswin.boxcast.core.data.database.PodcastEntity
 import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
+import cx.aswin.boxcast.core.data.ranking.AdaptiveRankingBackup
+import cx.aswin.boxcast.core.data.ranking.AdaptiveRankingRepository
 import kotlinx.coroutines.flow.first
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -42,10 +44,11 @@ data class GlobalPreferencesBackup(
 )
 
 data class BoxCastBackup(
-    val version: Int = 4,
+    val version: Int = 5,
     val subscriptions: List<PodcastEntity>,
     val history: List<ListeningHistoryEntity>,
-    val globalPreferences: GlobalPreferencesBackup? = null
+    val globalPreferences: GlobalPreferencesBackup? = null,
+    val adaptiveRanking: AdaptiveRankingBackup? = null,
 )
 
 data class OpmlFeed(
@@ -98,11 +101,16 @@ class LibraryBackupManager(
             )
         } else null
 
+        val appContext = requireNotNull(context) {
+            "A context is required to export a complete JSON backup"
+        }
+        val rankingBackup = AdaptiveRankingRepository.getInstance(appContext).exportBackup()
         val backup = BoxCastBackup(
-            version = 4,
+            version = 5,
             subscriptions = subscriptions,
             history = allHistory,
-            globalPreferences = globalPrefs
+            globalPreferences = globalPrefs,
+            adaptiveRanking = rankingBackup,
         )
         return gson.toJson(backup)
     }
@@ -315,8 +323,17 @@ class LibraryBackupManager(
                 )
                 playbackRepository.upsertHistoryEntity(safeEntity)
             }
+
+            // 3. Restore the complete on-device learning state when present. Older backups
+            // remain compatible because this versioned field is optional.
+            backup.adaptiveRanking?.let { rankingBackup ->
+                val appContext = requireNotNull(context) {
+                    "A context is required to restore adaptive ranking"
+                }
+                AdaptiveRankingRepository.getInstance(appContext).restoreBackup(rankingBackup)
+            }
             
-            // 3. Trigger check for new episodes
+            // 4. Trigger check for new episodes
             if (importedIds.isNotEmpty()) {
                 try {
                     val syncedMap = podcastRepository.syncSubscriptions(importedIds)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentCandidateProviders.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentCandidateProviders.kt
@@ -8,6 +8,7 @@ import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
 import cx.aswin.boxcast.core.data.ranking.PodcastRankingInput
 import cx.aswin.boxcast.core.model.Episode
 import cx.aswin.boxcast.core.model.Podcast
+import kotlinx.coroutines.CancellationException
 
 class PodcastCandidateProvider(
     override val source: CandidateSource,
@@ -84,6 +85,23 @@ class AdaptiveContentCandidateRanker(
     private val historyProvider: suspend () -> List<ListeningHistoryEntity>,
 ) : ContentCandidateRanker {
     override suspend fun rank(
+        candidates: List<ContentCandidate>,
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate> {
+        return try {
+            rankAdaptively(candidates, intent, context)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            candidates.sortedWith(
+                compareByDescending(ContentCandidate::retrievalScore)
+                    .thenBy(ContentCandidate::id),
+            )
+        }
+    }
+
+    private suspend fun rankAdaptively(
         candidates: List<ContentCandidate>,
         intent: ContentIntent,
         context: ContentContext,

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentCandidateProviders.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentCandidateProviders.kt
@@ -104,6 +104,7 @@ class AdaptiveContentCandidateRanker(
             },
             history = history,
             objective = intent.objective,
+            surface = context.surface,
         )
         val podcastCandidates = candidates.filter { it.episode == null }
         val rankedPodcasts = scorer.rankPodcasts(
@@ -118,6 +119,7 @@ class AdaptiveContentCandidateRanker(
             },
             history = history,
             objective = intent.objective,
+            surface = context.surface,
         )
         val podcastScores = rankedPodcasts.mapIndexed { index, podcast ->
             podcast.id to reciprocalRank(index)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentCandidateProviders.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentCandidateProviders.kt
@@ -1,0 +1,138 @@
+package cx.aswin.boxcast.core.data.content
+
+import cx.aswin.boxcast.core.data.PodcastRepository
+import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
+import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
+import cx.aswin.boxcast.core.data.ranking.PodcastRankingInput
+import cx.aswin.boxcast.core.model.Episode
+import cx.aswin.boxcast.core.model.Podcast
+
+class PodcastCandidateProvider(
+    override val source: CandidateSource,
+    private val loader: suspend (ContentIntent, ContentContext) -> List<Podcast>,
+) : CandidateProvider {
+    override suspend fun candidates(
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate> {
+        return loader(intent, context).mapIndexed { index, podcast ->
+            ContentCandidate(
+                id = podcast.latestEpisode?.id ?: "podcast:${podcast.id}",
+                episode = podcast.latestEpisode,
+                podcast = podcast,
+                source = source,
+                intentId = intent.id,
+                retrievalScore = reciprocalRank(index),
+                isNovel = podcast.subscribedAt <= 0L,
+            )
+        }
+    }
+}
+
+class EpisodeCandidateProvider(
+    override val source: CandidateSource,
+    private val loader: suspend (ContentIntent, ContentContext) -> List<Pair<Episode, Podcast>>,
+) : CandidateProvider {
+    override suspend fun candidates(
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate> {
+        return loader(intent, context).mapIndexed { index, (episode, podcast) ->
+            ContentCandidate(
+                id = episode.id,
+                episode = episode,
+                podcast = podcast,
+                source = source,
+                intentId = intent.id,
+                retrievalScore = episode.retrievalScore ?: reciprocalRank(index),
+                isNovel = podcast.subscribedAt <= 0L,
+                explanationTokens = setOfNotNull(episode.recommendationReason),
+            )
+        }
+    }
+}
+
+class ServerIntentCandidateProvider(
+    private val podcastRepository: PodcastRepository,
+) : CandidateProvider {
+    override val source: CandidateSource = CandidateSource.CURATED_INTENT
+
+    override suspend fun candidates(
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate> {
+        val query = intent.providerQueryRef ?: return emptyList()
+        return podcastRepository.getCuratedPodcasts(query, context.region).mapIndexed { index, podcast ->
+            ContentCandidate(
+                id = podcast.latestEpisode?.id ?: "podcast:${podcast.id}",
+                episode = podcast.latestEpisode,
+                podcast = podcast,
+                source = source,
+                intentId = intent.id,
+                retrievalScore = reciprocalRank(index),
+                isNovel = podcast.subscribedAt <= 0L,
+                explanationTokens = setOf(intent.id),
+            )
+        }
+    }
+}
+
+class AdaptiveContentCandidateRanker(
+    private val scorer: AdaptiveCandidateScorer,
+    private val historyProvider: suspend () -> List<ListeningHistoryEntity>,
+) : ContentCandidateRanker {
+    override suspend fun rank(
+        candidates: List<ContentCandidate>,
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate> {
+        if (candidates.isEmpty()) return emptyList()
+        val history = historyProvider()
+        val episodeCandidates = candidates.filter { it.episode != null }
+        val episodeScores = scorer.scoreEpisodes(
+            inputs = episodeCandidates.map { candidate ->
+                EpisodeRankingInput(
+                    episode = requireNotNull(candidate.episode),
+                    podcast = candidate.podcast,
+                    priorScore = candidate.retrievalScore,
+                    source = candidate.source,
+                    isNovel = candidate.isNovel,
+                    online = context.isOnline,
+                )
+            },
+            history = history,
+            objective = intent.objective,
+        )
+        val podcastCandidates = candidates.filter { it.episode == null }
+        val rankedPodcasts = scorer.rankPodcasts(
+            inputs = podcastCandidates.map { candidate ->
+                PodcastRankingInput(
+                    podcast = candidate.podcast,
+                    priorScore = candidate.retrievalScore,
+                    source = candidate.source,
+                    isNovel = candidate.isNovel,
+                    timeContextMatch = if (intent.eligibleDayparts.contains(context.daypart)) 1.0 else 0.0,
+                )
+            },
+            history = history,
+            objective = intent.objective,
+        )
+        val podcastScores = rankedPodcasts.mapIndexed { index, podcast ->
+            podcast.id to reciprocalRank(index)
+        }.toMap()
+        return candidates.map { candidate ->
+            candidate.copy(
+                rankingScore = candidate.episode?.let { episodeScores[it.id] }
+                    ?: podcastScores[candidate.podcast.id]
+                    ?: candidate.retrievalScore,
+            )
+        }.sortedWith(
+            compareByDescending<ContentCandidate>(ContentCandidate::rankingScore)
+                .thenBy(ContentCandidate::id),
+        )
+    }
+}
+
+private fun reciprocalRank(index: Int): Double = 1.0 / (index + 1.0)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentContextEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentContextEngine.kt
@@ -52,37 +52,39 @@ data class ContentCatalogSnapshot(
 class ContentContextEngine(
     private val clock: Clock = Clock.systemDefaultZone(),
 ) {
-    fun create(
-        surface: RankingSurface,
-        region: String,
-        isDriving: Boolean,
-        isOnline: Boolean,
-        availableMinutes: Int?,
-        currentEpisodeId: String?,
-        currentPodcastId: String?,
-        historyMaturity: Int,
-        subscriptionCount: Int,
-        sessionId: String,
-    ): ContentContext {
+    fun create(input: ContentContextInput): ContentContext {
         val local = ZonedDateTime.now(clock)
         val minuteOfDay = local.hour * 60 + local.minute
         return ContentContext(
-            surface = surface,
+            surface = input.surface,
             localMinuteOfDay = minuteOfDay,
             weekday = local.dayOfWeek.value,
             daypart = minuteOfDay.toDaypart(),
-            region = region.ifBlank { "us" },
-            isDriving = isDriving,
-            isOnline = isOnline,
-            availableMinutes = availableMinutes?.coerceAtLeast(0),
-            currentEpisodeId = currentEpisodeId,
-            currentPodcastId = currentPodcastId,
-            historyMaturity = historyMaturity,
-            subscriptionCount = subscriptionCount,
-            sessionId = sessionId,
+            region = input.region.ifBlank { "us" },
+            isDriving = input.isDriving,
+            isOnline = input.isOnline,
+            availableMinutes = input.availableMinutes?.coerceAtLeast(0),
+            currentEpisodeId = input.currentEpisodeId,
+            currentPodcastId = input.currentPodcastId,
+            historyMaturity = input.historyMaturity,
+            subscriptionCount = input.subscriptionCount,
+            sessionId = input.sessionId,
         )
     }
 }
+
+data class ContentContextInput(
+    val surface: RankingSurface,
+    val region: String,
+    val isDriving: Boolean,
+    val isOnline: Boolean,
+    val availableMinutes: Int?,
+    val currentEpisodeId: String?,
+    val currentPodcastId: String?,
+    val historyMaturity: Int,
+    val subscriptionCount: Int,
+    val sessionId: String,
+)
 
 class ContentIntentResolver {
     fun resolve(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentContextEngine.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentContextEngine.kt
@@ -1,0 +1,107 @@
+package cx.aswin.boxcast.core.data.content
+
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
+import java.time.Clock
+import java.time.ZonedDateTime
+
+data class ContentCatalogSnapshot(
+    val schemaVersion: Int,
+    val catalogVersion: String,
+    val validUntil: Long,
+    val intents: List<ContentIntent>,
+) {
+    fun isSupported(now: Long): Boolean {
+        return schemaVersion == SUPPORTED_SCHEMA_VERSION &&
+            catalogVersion.isNotBlank() &&
+            validUntil > now &&
+            intents.isNotEmpty() &&
+            intents.map(ContentIntent::id).distinct().size == intents.size
+    }
+
+    companion object {
+        const val SUPPORTED_SCHEMA_VERSION = 1
+
+        fun anytimeFallback(now: Long): ContentCatalogSnapshot {
+            return ContentCatalogSnapshot(
+                schemaVersion = SUPPORTED_SCHEMA_VERSION,
+                catalogVersion = "embedded-anytime-v1",
+                validUntil = Long.MAX_VALUE,
+                intents = listOf(
+                    ContentIntent(
+                        id = "anytime",
+                        objective = RankingObjective.DISCOVERY,
+                        eligibleSurfaces = setOf(
+                            RankingSurface.HOME,
+                            RankingSurface.EXPLORE,
+                            RankingSurface.ANDROID_AUTO,
+                        ),
+                        title = "Anytime picks",
+                        subtitle = "A balanced mix for whenever you’re listening.",
+                        layout = ContentLayout.PODCAST_RAIL,
+                        refreshPolicy = ContentRefreshPolicy.SESSION,
+                        minimumItems = 1,
+                        maximumItems = 10,
+                    ),
+                ),
+            )
+        }
+    }
+}
+
+class ContentContextEngine(
+    private val clock: Clock = Clock.systemDefaultZone(),
+) {
+    fun create(
+        surface: RankingSurface,
+        region: String,
+        isDriving: Boolean,
+        isOnline: Boolean,
+        availableMinutes: Int?,
+        currentEpisodeId: String?,
+        currentPodcastId: String?,
+        historyMaturity: Int,
+        subscriptionCount: Int,
+        sessionId: String,
+    ): ContentContext {
+        val local = ZonedDateTime.now(clock)
+        val minuteOfDay = local.hour * 60 + local.minute
+        return ContentContext(
+            surface = surface,
+            localMinuteOfDay = minuteOfDay,
+            weekday = local.dayOfWeek.value,
+            daypart = minuteOfDay.toDaypart(),
+            region = region.ifBlank { "us" },
+            isDriving = isDriving,
+            isOnline = isOnline,
+            availableMinutes = availableMinutes?.coerceAtLeast(0),
+            currentEpisodeId = currentEpisodeId,
+            currentPodcastId = currentPodcastId,
+            historyMaturity = historyMaturity,
+            subscriptionCount = subscriptionCount,
+            sessionId = sessionId,
+        )
+    }
+}
+
+class ContentIntentResolver {
+    fun resolve(
+        catalog: ContentCatalogSnapshot?,
+        context: ContentContext,
+        now: Long = System.currentTimeMillis(),
+    ): Pair<String, List<ContentIntent>> {
+        val effectiveCatalog = catalog
+            ?.takeIf { it.isSupported(now) }
+            ?: ContentCatalogSnapshot.anytimeFallback(now)
+        return effectiveCatalog.catalogVersion to effectiveCatalog.intents.filter {
+            it.isEligible(context)
+        }
+    }
+}
+
+private fun Int.toDaypart(): ContentDaypart = when (this) {
+    in 5 * 60 until 12 * 60 -> ContentDaypart.MORNING
+    in 12 * 60 until 17 * 60 -> ContentDaypart.AFTERNOON
+    in 17 * 60 until 23 * 60 -> ContentDaypart.EVENING
+    else -> ContentDaypart.LATE_NIGHT
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentContracts.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentContracts.kt
@@ -112,6 +112,7 @@ data class ContentSection(
 ) {
     init {
         require(stableId.isNotBlank())
+        require(items.isNotEmpty())
         require(utility.isFinite())
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentContracts.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentContracts.kt
@@ -1,0 +1,142 @@
+package cx.aswin.boxcast.core.data.content
+
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
+import cx.aswin.boxcast.core.model.Episode
+import cx.aswin.boxcast.core.model.Podcast
+
+enum class ContentDaypart {
+    MORNING,
+    AFTERNOON,
+    EVENING,
+    LATE_NIGHT,
+}
+
+enum class ContentLayout {
+    HERO_CAROUSEL,
+    EPISODE_RAIL,
+    PODCAST_RAIL,
+    MIXED_MASONRY,
+    COMPACT_LIST,
+    PROTECTED_CARD,
+}
+
+enum class ContentRefreshPolicy {
+    SESSION,
+    MANUAL,
+    DAYPART,
+    DAILY,
+}
+
+data class ContentContext(
+    val surface: RankingSurface,
+    val localMinuteOfDay: Int,
+    val weekday: Int,
+    val daypart: ContentDaypart,
+    val region: String,
+    val isDriving: Boolean,
+    val isOnline: Boolean,
+    val availableMinutes: Int?,
+    val currentEpisodeId: String?,
+    val currentPodcastId: String?,
+    val historyMaturity: Int,
+    val subscriptionCount: Int,
+    val sessionId: String,
+) {
+    init {
+        require(localMinuteOfDay in 0 until MINUTES_PER_DAY)
+        require(weekday in 1..7)
+        require(region.isNotBlank())
+        require(historyMaturity >= 0)
+        require(subscriptionCount >= 0)
+        require(sessionId.isNotBlank())
+    }
+
+    companion object {
+        private const val MINUTES_PER_DAY = 24 * 60
+    }
+}
+
+data class ContentIntent(
+    val id: String,
+    val objective: RankingObjective,
+    val eligibleSurfaces: Set<RankingSurface>,
+    val eligibleDayparts: Set<ContentDaypart> = ContentDaypart.entries.toSet(),
+    val title: String,
+    val subtitle: String? = null,
+    val providerQueryRef: String? = null,
+    val layout: ContentLayout,
+    val refreshPolicy: ContentRefreshPolicy = ContentRefreshPolicy.SESSION,
+    val minimumItems: Int = 1,
+    val maximumItems: Int = 10,
+    val protected: Boolean = false,
+) {
+    init {
+        require(id.isNotBlank())
+        require(title.isNotBlank())
+        require(minimumItems >= 0)
+        require(maximumItems >= minimumItems)
+    }
+
+    fun isEligible(context: ContentContext): Boolean {
+        return context.surface in eligibleSurfaces && context.daypart in eligibleDayparts
+    }
+}
+
+data class ContentCandidate(
+    val id: String,
+    val episode: Episode?,
+    val podcast: Podcast,
+    val source: CandidateSource,
+    val intentId: String,
+    val retrievalScore: Double,
+    val rankingScore: Double = retrievalScore,
+    val isNovel: Boolean = false,
+    val explanationTokens: Set<String> = emptySet(),
+) {
+    init {
+        require(id.isNotBlank())
+        require(intentId.isNotBlank())
+        require(retrievalScore.isFinite())
+        require(rankingScore.isFinite())
+    }
+}
+
+data class ContentSection(
+    val stableId: String,
+    val intent: ContentIntent,
+    val items: List<ContentCandidate>,
+    val utility: Double,
+    val explanation: String? = null,
+) {
+    init {
+        require(stableId.isNotBlank())
+        require(utility.isFinite())
+    }
+}
+
+data class ContentSlate(
+    val surface: RankingSurface,
+    val sessionId: String,
+    val sections: List<ContentSection>,
+    val generatedAt: Long,
+    val catalogVersion: String,
+)
+
+interface CandidateProvider {
+    val source: CandidateSource
+
+    suspend fun candidates(
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate>
+}
+
+fun interface ContentCandidateRanker {
+    suspend fun rank(
+        candidates: List<ContentCandidate>,
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate>
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentOrchestrator.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentOrchestrator.kt
@@ -150,25 +150,7 @@ class ContentOrchestrator(
         if (!forceRefresh) sessionCache[cacheKey]?.let { return it }
         val rankedByIntent = supervisorScope {
             intents.map { intent ->
-                async {
-                    val candidates = providers.flatMap { provider ->
-                        try {
-                            provider.candidates(intent, context)
-                        } catch (error: CancellationException) {
-                            throw error
-                        } catch (_: Exception) {
-                            emptyList()
-                        }
-                    }.distinctBy(ContentCandidate::id)
-                    val ranked = try {
-                        ranker.rank(candidates, intent, context)
-                    } catch (error: CancellationException) {
-                        throw error
-                    } catch (_: Exception) {
-                        candidates.sortedByDescending(ContentCandidate::retrievalScore)
-                    }
-                    intent to ranked
-                }
+                async { intent to rankIntent(intent, context) }
             }.map { it.await() }
         }
         return slateComposer.compose(
@@ -178,6 +160,36 @@ class ContentOrchestrator(
             exposureBudget = exposureBudget,
             now = now,
         ).also { sessionCache[cacheKey] = it }
+    }
+
+    private suspend fun rankIntent(
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate> {
+        val candidates = providers.flatMap { provider ->
+            providerCandidates(provider, intent, context)
+        }.distinctBy(ContentCandidate::id)
+        return try {
+            ranker.rank(candidates, intent, context)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            candidates.sortedByDescending(ContentCandidate::retrievalScore)
+        }
+    }
+
+    private suspend fun providerCandidates(
+        provider: CandidateProvider,
+        intent: ContentIntent,
+        context: ContentContext,
+    ): List<ContentCandidate> {
+        return try {
+            provider.candidates(intent, context)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            emptyList()
+        }
     }
 
     fun clearSession(sessionId: String) {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentOrchestrator.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentOrchestrator.kt
@@ -1,6 +1,7 @@
 package cx.aswin.boxcast.core.data.content
 
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
 
@@ -45,6 +46,9 @@ class SharedExposureBudget(
         exposedItems.clear()
         showCounts.clear()
     }
+
+    @Synchronized
+    fun <T> atomically(block: () -> T): T = block()
 }
 
 class SlateComposer {
@@ -54,7 +58,7 @@ class SlateComposer {
         rankedByIntent: List<Pair<ContentIntent, List<ContentCandidate>>>,
         exposureBudget: SharedExposureBudget,
         now: Long = System.currentTimeMillis(),
-    ): ContentSlate {
+    ): ContentSlate = exposureBudget.atomically {
         val proposed = rankedByIntent.mapNotNull { (intent, candidates) ->
             val eligible = candidates
                 .asSequence()
@@ -62,7 +66,7 @@ class SlateComposer {
                 .filter(exposureBudget::allows)
                 .take(intent.maximumItems)
                 .toList()
-            eligible.takeIf { it.size >= intent.minimumItems }?.let {
+            eligible.takeIf { it.isNotEmpty() && it.size >= intent.minimumItems }?.let {
                 ContentSection(
                     stableId = "${context.surface.name.lowercase()}:${intent.id}",
                     intent = intent,
@@ -80,7 +84,7 @@ class SlateComposer {
             )
         val sections = enforceCrossSectionConstraints(protected + optional)
         sections.forEach { exposureBudget.record(it.items) }
-        return ContentSlate(
+        ContentSlate(
             surface = context.surface,
             sessionId = context.sessionId,
             sections = sections,
@@ -139,18 +143,31 @@ class ContentOrchestrator(
         context: ContentContext,
         catalog: ContentCatalogSnapshot?,
         forceRefresh: Boolean = false,
+        now: Long = System.currentTimeMillis(),
     ): ContentSlate {
-        val cacheKey = "${context.sessionId}:${context.surface.name}"
-        if (!forceRefresh) sessionCache[cacheKey]?.let { return it }
         val (catalogVersion, intents) = intentResolver.resolve(catalog, context)
+        val cacheKey = cacheKey(context, catalogVersion, intents, now)
+        if (!forceRefresh) sessionCache[cacheKey]?.let { return it }
         val rankedByIntent = supervisorScope {
             intents.map { intent ->
                 async {
                     val candidates = providers.flatMap { provider ->
-                        runCatching { provider.candidates(intent, context) }
-                            .getOrDefault(emptyList())
+                        try {
+                            provider.candidates(intent, context)
+                        } catch (error: CancellationException) {
+                            throw error
+                        } catch (_: Exception) {
+                            emptyList()
+                        }
                     }.distinctBy(ContentCandidate::id)
-                    intent to ranker.rank(candidates, intent, context)
+                    val ranked = try {
+                        ranker.rank(candidates, intent, context)
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (_: Exception) {
+                        candidates.sortedByDescending(ContentCandidate::retrievalScore)
+                    }
+                    intent to ranked
                 }
             }.map { it.await() }
         }
@@ -159,6 +176,7 @@ class ContentOrchestrator(
             catalogVersion = catalogVersion,
             rankedByIntent = rankedByIntent,
             exposureBudget = exposureBudget,
+            now = now,
         ).also { sessionCache[cacheKey] = it }
     }
 
@@ -169,6 +187,37 @@ class ContentOrchestrator(
     fun clearAll() {
         sessionCache.clear()
         exposureBudget.reset()
+    }
+
+    private fun cacheKey(
+        context: ContentContext,
+        catalogVersion: String,
+        intents: List<ContentIntent>,
+        now: Long,
+    ): String {
+        val refreshFingerprint = intents.joinToString(",") { intent ->
+            val token = when (intent.refreshPolicy) {
+                ContentRefreshPolicy.SESSION -> context.sessionId
+                ContentRefreshPolicy.MANUAL -> "manual"
+                ContentRefreshPolicy.DAYPART -> context.daypart.name
+                ContentRefreshPolicy.DAILY -> (now / DAY_MILLIS).toString()
+            }
+            "${intent.id}:${intent.refreshPolicy.name}:$token"
+        }
+        return listOf(
+            context.sessionId,
+            context.surface.name,
+            catalogVersion,
+            context.region,
+            context.subscriptionCount,
+            context.historyMaturity,
+            context.currentEpisodeId.orEmpty(),
+            refreshFingerprint,
+        ).joinToString(":")
+    }
+
+    companion object {
+        private const val DAY_MILLIS = 24L * 60L * 60L * 1_000L
     }
 }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentOrchestrator.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/content/ContentOrchestrator.kt
@@ -1,0 +1,175 @@
+package cx.aswin.boxcast.core.data.content
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.async
+import kotlinx.coroutines.supervisorScope
+
+class SharedExposureBudget(
+    private val maximumRememberedItems: Int = 200,
+    private val maximumItemsPerShow: Int = 2,
+) {
+    private val exposedItems = linkedMapOf<String, String>()
+    private val showCounts = mutableMapOf<String, Int>()
+
+    init {
+        require(maximumRememberedItems > 0)
+        require(maximumItemsPerShow > 0)
+    }
+
+    @Synchronized
+    fun allows(candidate: ContentCandidate): Boolean {
+        return candidate.id !in exposedItems &&
+            (showCounts[candidate.podcast.id] ?: 0) < maximumItemsPerShow
+    }
+
+    @Synchronized
+    fun record(candidates: Collection<ContentCandidate>) {
+        candidates.forEach { candidate ->
+            if (candidate.id !in exposedItems) {
+                exposedItems[candidate.id] = candidate.podcast.id
+                showCounts[candidate.podcast.id] =
+                    (showCounts[candidate.podcast.id] ?: 0) + 1
+            }
+        }
+        while (exposedItems.size > maximumRememberedItems) {
+            val oldest = exposedItems.entries.first()
+            exposedItems.remove(oldest.key)
+            val remainingCount = (showCounts[oldest.value] ?: 1) - 1
+            if (remainingCount <= 0) showCounts.remove(oldest.value)
+            else showCounts[oldest.value] = remainingCount
+        }
+    }
+
+    @Synchronized
+    fun reset() {
+        exposedItems.clear()
+        showCounts.clear()
+    }
+}
+
+class SlateComposer {
+    fun compose(
+        context: ContentContext,
+        catalogVersion: String,
+        rankedByIntent: List<Pair<ContentIntent, List<ContentCandidate>>>,
+        exposureBudget: SharedExposureBudget,
+        now: Long = System.currentTimeMillis(),
+    ): ContentSlate {
+        val proposed = rankedByIntent.mapNotNull { (intent, candidates) ->
+            val eligible = candidates
+                .asSequence()
+                .distinctBy(ContentCandidate::id)
+                .filter(exposureBudget::allows)
+                .take(intent.maximumItems)
+                .toList()
+            eligible.takeIf { it.size >= intent.minimumItems }?.let {
+                ContentSection(
+                    stableId = "${context.surface.name.lowercase()}:${intent.id}",
+                    intent = intent,
+                    items = it,
+                    utility = sectionUtility(it, context),
+                    explanation = it.firstOrNull()?.explanationTokens?.firstOrNull(),
+                )
+            }
+        }
+        val protected = proposed.filter { it.intent.protected }
+        val optional = proposed.filterNot { it.intent.protected }
+            .sortedWith(
+                compareByDescending<ContentSection>(ContentSection::utility)
+                    .thenBy(ContentSection::stableId),
+            )
+        val sections = enforceCrossSectionConstraints(protected + optional)
+        sections.forEach { exposureBudget.record(it.items) }
+        return ContentSlate(
+            surface = context.surface,
+            sessionId = context.sessionId,
+            sections = sections,
+            generatedAt = now,
+            catalogVersion = catalogVersion,
+        )
+    }
+
+    private fun enforceCrossSectionConstraints(
+        sections: List<ContentSection>,
+    ): List<ContentSection> {
+        val seenItems = mutableSetOf<String>()
+        val showCounts = mutableMapOf<String, Int>()
+        return sections.mapNotNull { section ->
+            val constrained = section.items.filter { candidate ->
+                candidate.id !in seenItems &&
+                    (showCounts[candidate.podcast.id] ?: 0) < MAX_ITEMS_PER_SHOW_IN_SLATE
+            }.onEach { candidate ->
+                seenItems += candidate.id
+                showCounts[candidate.podcast.id] =
+                    (showCounts[candidate.podcast.id] ?: 0) + 1
+            }
+            constrained.takeIf { it.size >= section.intent.minimumItems }?.let {
+                section.copy(items = it)
+            }
+        }
+    }
+
+    private fun sectionUtility(
+        items: List<ContentCandidate>,
+        context: ContentContext,
+    ): Double {
+        val topQuality = items.take(3).map(ContentCandidate::rankingScore).averageOrZero()
+        val novelty = items.count(ContentCandidate::isNovel).toDouble() / items.size
+        val onlineFit = if (context.isOnline) 1.0 else {
+            items.count { it.source.name == "DOWNLOADED" }.toDouble() / items.size
+        }
+        return (topQuality * 0.7 + novelty * 0.2 + onlineFit * 0.1).coerceIn(-1.0, 1.0)
+    }
+
+    companion object {
+        private const val MAX_ITEMS_PER_SHOW_IN_SLATE = 2
+    }
+}
+
+class ContentOrchestrator(
+    private val providers: List<CandidateProvider>,
+    private val ranker: ContentCandidateRanker,
+    private val intentResolver: ContentIntentResolver = ContentIntentResolver(),
+    private val slateComposer: SlateComposer = SlateComposer(),
+    private val exposureBudget: SharedExposureBudget = SharedExposureBudget(),
+) {
+    private val sessionCache = ConcurrentHashMap<String, ContentSlate>()
+
+    suspend fun compose(
+        context: ContentContext,
+        catalog: ContentCatalogSnapshot?,
+        forceRefresh: Boolean = false,
+    ): ContentSlate {
+        val cacheKey = "${context.sessionId}:${context.surface.name}"
+        if (!forceRefresh) sessionCache[cacheKey]?.let { return it }
+        val (catalogVersion, intents) = intentResolver.resolve(catalog, context)
+        val rankedByIntent = supervisorScope {
+            intents.map { intent ->
+                async {
+                    val candidates = providers.flatMap { provider ->
+                        runCatching { provider.candidates(intent, context) }
+                            .getOrDefault(emptyList())
+                    }.distinctBy(ContentCandidate::id)
+                    intent to ranker.rank(candidates, intent, context)
+                }
+            }.map { it.await() }
+        }
+        return slateComposer.compose(
+            context = context,
+            catalogVersion = catalogVersion,
+            rankedByIntent = rankedByIntent,
+            exposureBudget = exposureBudget,
+        ).also { sessionCache[cacheKey] = it }
+    }
+
+    fun clearSession(sessionId: String) {
+        sessionCache.keys.removeIf { it.startsWith("$sessionId:") }
+    }
+
+    fun clearAll() {
+        sessionCache.clear()
+        exposureBudget.reset()
+    }
+}
+
+private fun List<Double>.averageOrZero(): Double = if (isEmpty()) 0.0 else average()

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
@@ -33,6 +33,7 @@ class AdaptiveCandidateScorer private constructor(
         podcasts: List<ScorablePodcast>,
         history: List<ListeningHistoryEntity>,
         objective: RankingObjective,
+        surface: RankingSurface,
         includeAutoDownloadBoost: Boolean = true,
         nowMs: Long = System.currentTimeMillis(),
     ): Map<String, Double> {
@@ -42,7 +43,7 @@ class AdaptiveCandidateScorer private constructor(
             allHistory = history,
             includeAutoDownloadBoost = includeAutoDownloadBoost,
         )
-        if (!runtimeControls.isAdaptiveEnabled(objective)) return legacy
+        if (!runtimeControls.isAdaptiveEnabled(objective, surface)) return legacy
         val normalizedPriors = normalizePriors(legacy)
         val historyByPodcast = history.groupBy(ListeningHistoryEntity::podcastId)
         val adaptive = podcasts.associate { podcast ->
@@ -91,11 +92,12 @@ class AdaptiveCandidateScorer private constructor(
         inputs: List<EpisodeRankingInput>,
         history: List<ListeningHistoryEntity>,
         objective: RankingObjective,
+        surface: RankingSurface,
         nowMs: Long = System.currentTimeMillis(),
     ): Map<String, Double> {
         if (inputs.isEmpty()) return emptyMap()
         val normalizedPriors = normalizePriors(inputs.associate { it.episode.id to it.priorScore })
-        if (!runtimeControls.isAdaptiveEnabled(objective)) return normalizedPriors
+        if (!runtimeControls.isAdaptiveEnabled(objective, surface)) return normalizedPriors
         val historyByEpisode = history.associateBy(ListeningHistoryEntity::episodeId)
         val adaptive = inputs.associate { input ->
             val episodeHistory = historyByEpisode[input.episode.id]
@@ -160,10 +162,11 @@ class AdaptiveCandidateScorer private constructor(
         inputs: List<EpisodeRankingInput>,
         history: List<ListeningHistoryEntity>,
         objective: RankingObjective,
+        surface: RankingSurface,
         diversityPolicy: DiversityPolicy,
         nowMs: Long = System.currentTimeMillis(),
     ): List<Episode> {
-        val scores = scoreEpisodes(inputs, history, objective, nowMs)
+        val scores = scoreEpisodes(inputs, history, objective, surface, nowMs)
         val candidates = inputs.map { input ->
             RankedCandidate(
                 value = input.episode,
@@ -191,6 +194,7 @@ class AdaptiveCandidateScorer private constructor(
         inputs: List<PodcastRankingInput>,
         history: List<ListeningHistoryEntity>,
         objective: RankingObjective,
+        surface: RankingSurface,
         diversityPolicy: DiversityPolicy? = null,
         nowMs: Long = System.currentTimeMillis(),
     ): List<Podcast> {
@@ -243,7 +247,7 @@ class AdaptiveCandidateScorer private constructor(
                 ),
             )
             val priorScore = normalizedPriors[podcast.id] ?: 0.0
-            val finalScore = if (runtimeControls.isAdaptiveEnabled(objective)) {
+            val finalScore = if (runtimeControls.isAdaptiveEnabled(objective, surface)) {
                 rankingRepository.score(
                     objective = objective,
                     features = features,

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
@@ -1,0 +1,183 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import android.content.Context
+import cx.aswin.boxcast.core.data.PodcastScoring
+import cx.aswin.boxcast.core.data.ScorablePodcast
+import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
+import cx.aswin.boxcast.core.model.Episode
+import cx.aswin.boxcast.core.model.Podcast
+import kotlin.math.ln
+
+data class EpisodeRankingInput(
+    val episode: Episode,
+    val podcast: Podcast,
+    val priorScore: Double,
+    val source: CandidateSource,
+    val isNovel: Boolean = false,
+    val online: Boolean = true,
+)
+
+class AdaptiveCandidateScorer private constructor(
+    private val rankingRepository: AdaptiveRankingRepository,
+) {
+    suspend fun scorePodcasts(
+        podcasts: List<ScorablePodcast>,
+        history: List<ListeningHistoryEntity>,
+        objective: RankingObjective,
+        includeAutoDownloadBoost: Boolean = true,
+        nowMs: Long = System.currentTimeMillis(),
+    ): Map<String, Double> {
+        if (podcasts.isEmpty()) return emptyMap()
+        val legacy = PodcastScoring.calculateScores(
+            podcasts = podcasts,
+            allHistory = history,
+            includeAutoDownloadBoost = includeAutoDownloadBoost,
+        )
+        val normalizedPriors = normalizePriors(legacy)
+        val historyByPodcast = history.groupBy(ListeningHistoryEntity::podcastId)
+        return podcasts.associate { podcast ->
+            val podcastHistory = historyByPodcast[podcast.id].orEmpty()
+            val latestHistory = podcast.latestEpisode?.let { latest ->
+                podcastHistory.firstOrNull { it.episodeId == latest.id }
+            }
+            val showAffinity = rankingRepository.facetAffinity(
+                PreferenceFacetType.SHOW,
+                podcast.id,
+                nowMs,
+            )
+            val features = CandidateFeatureBuilder.build(
+                CandidateSignals(
+                    showAffinity = showAffinity.toUnitAffinity(),
+                    ageHours = podcast.latestEpisode?.let { episode ->
+                        (nowMs / 1_000.0 - episode.publishedDate).coerceAtLeast(0.0) / 3_600.0
+                    },
+                    isSubscribed = true,
+                    progressRatio = latestHistory.progressRatio(),
+                    isUnplayed = latestHistory == null ||
+                        (latestHistory.progressMs == 0L && !latestHistory.isCompleted),
+                    serialMatch = if (podcast.latestEpisode != null) 1.0 else 0.0,
+                    explicitPreference = when {
+                        podcast.autoDownloadEnabled && includeAutoDownloadBoost -> 1.0
+                        podcast.notificationsEnabled -> 0.7
+                        else -> 0.0
+                    },
+                    hoursSinceSubscription = podcast.subscribedAt
+                        .takeIf { it > 0L }
+                        ?.let { (nowMs - it).coerceAtLeast(0L) / 3_600_000.0 },
+                ),
+            )
+            val score = rankingRepository.score(
+                objective = objective,
+                features = features,
+                priorScore = normalizedPriors[podcast.id] ?: 0.0,
+            )
+            podcast.id to score.finalScore
+        }
+    }
+
+    suspend fun scoreEpisodes(
+        inputs: List<EpisodeRankingInput>,
+        history: List<ListeningHistoryEntity>,
+        objective: RankingObjective,
+        nowMs: Long = System.currentTimeMillis(),
+    ): Map<String, Double> {
+        if (inputs.isEmpty()) return emptyMap()
+        val normalizedPriors = normalizePriors(inputs.associate { it.episode.id to it.priorScore })
+        val historyByEpisode = history.associateBy(ListeningHistoryEntity::episodeId)
+        return inputs.associate { input ->
+            val episodeHistory = historyByEpisode[input.episode.id]
+            val showAffinity = rankingRepository.facetAffinity(
+                PreferenceFacetType.SHOW,
+                input.podcast.id,
+                nowMs,
+            )
+            val genreAffinity = input.podcast.genre
+                .split(",")
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .map { rankingRepository.facetAffinity(PreferenceFacetType.GENRE, it, nowMs) }
+                .averageOrNeutral()
+            val sourceAffinity = rankingRepository.facetAffinity(
+                PreferenceFacetType.SOURCE,
+                input.source.name,
+                nowMs,
+            )
+            val features = CandidateFeatureBuilder.build(
+                CandidateSignals(
+                    showAffinity = showAffinity.toUnitAffinity(),
+                    genreAffinity = genreAffinity.toUnitAffinity(),
+                    sourceAffinity = sourceAffinity.toUnitAffinity(),
+                    ageHours = (nowMs / 1_000.0 - input.episode.publishedDate)
+                        .coerceAtLeast(0.0) / 3_600.0,
+                    isUnseenShow = input.isNovel,
+                    durationFit = durationFit(input.episode.duration),
+                    isSubscribed = input.podcast.subscribedAt > 0L,
+                    progressRatio = episodeHistory.progressRatio(),
+                    isUnplayed = episodeHistory == null ||
+                        (episodeHistory.progressMs == 0L && !episodeHistory.isCompleted),
+                    serialMatch = if (input.podcast.preferredSort == "oldest") 1.0 else 0.5,
+                    serverRelevance = normalizedPriors[input.episode.id] ?: 0.0,
+                    offlineSuitability = if (input.online) {
+                        durationFit(input.episode.duration)
+                    } else {
+                        1.0
+                    },
+                    explicitPreference = when {
+                        input.podcast.autoDownloadEnabled -> 1.0
+                        input.podcast.notificationsEnabled -> 0.7
+                        else -> 0.0
+                    },
+                    hoursSinceSubscription = input.podcast.subscribedAt
+                        .takeIf { it > 0L }
+                        ?.let { (nowMs - it).coerceAtLeast(0L) / 3_600_000.0 },
+                ),
+            )
+            val score = rankingRepository.score(
+                objective = objective,
+                features = features,
+                priorScore = normalizedPriors[input.episode.id] ?: 0.0,
+            )
+            input.episode.id to score.finalScore
+        }
+    }
+
+    private fun normalizePriors(scores: Map<String, Double>): Map<String, Double> {
+        val finite = scores.filterValues { it.isFinite() && it >= 0.0 }
+        val max = finite.values.maxOrNull() ?: return scores.mapValues { 0.0 }
+        if (max <= 0.0) return scores.mapValues { 0.0 }
+        val denominator = ln(1.0 + max)
+        return scores.mapValues { (_, value) ->
+            if (!value.isFinite() || value <= 0.0) 0.0
+            else (ln(1.0 + value) / denominator).coerceIn(0.0, 1.0)
+        }
+    }
+
+    companion object {
+        @Volatile
+        private var instance: AdaptiveCandidateScorer? = null
+
+        fun getInstance(context: Context): AdaptiveCandidateScorer {
+            return instance ?: synchronized(this) {
+                instance ?: AdaptiveCandidateScorer(
+                    AdaptiveRankingRepository.getInstance(context.applicationContext),
+                ).also { instance = it }
+            }
+        }
+    }
+}
+
+private fun Double.toUnitAffinity(): Double = ((coerceIn(-1.0, 1.0) + 1.0) / 2.0)
+
+private fun ListeningHistoryEntity?.progressRatio(): Double {
+    if (this == null || durationMs <= 0L) return 0.0
+    return (progressMs.toDouble() / durationMs).coerceIn(0.0, 1.0)
+}
+
+private fun List<Double>.averageOrNeutral(): Double = if (isEmpty()) 0.0 else average()
+
+private fun durationFit(durationSeconds: Int): Double {
+    if (durationSeconds <= 0) return 0.5
+    val idealSeconds = 45.0 * 60.0
+    return (1.0 - kotlin.math.abs(durationSeconds - idealSeconds) / idealSeconds)
+        .coerceIn(0.0, 1.0)
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
@@ -46,16 +46,19 @@ class AdaptiveCandidateScorer private constructor(
         if (!runtimeControls.isAdaptiveEnabled(objective, surface)) return legacy
         val normalizedPriors = normalizePriors(legacy)
         val historyByPodcast = history.groupBy(ListeningHistoryEntity::podcastId)
-        val adaptive = podcasts.associate { podcast ->
+        val affinities = rankingRepository.facetAffinities(
+            podcasts.mapTo(mutableSetOf()) { podcast ->
+                PreferenceFacetKey(PreferenceFacetType.SHOW, podcast.id)
+            },
+            nowMs,
+        )
+        val featuresByPodcast = podcasts.associate { podcast ->
             val podcastHistory = historyByPodcast[podcast.id].orEmpty()
             val latestHistory = podcast.latestEpisode?.let { latest ->
                 podcastHistory.firstOrNull { it.episodeId == latest.id }
             }
-            val showAffinity = rankingRepository.facetAffinity(
-                PreferenceFacetType.SHOW,
-                podcast.id,
-                nowMs,
-            )
+            val showAffinity =
+                affinities[PreferenceFacetKey(PreferenceFacetType.SHOW, podcast.id)] ?: 0.0
             val features = CandidateFeatureBuilder.build(
                 CandidateSignals(
                     showAffinity = showAffinity.toUnitAffinity(),
@@ -77,13 +80,20 @@ class AdaptiveCandidateScorer private constructor(
                         ?.let { (nowMs - it).coerceAtLeast(0L) / 3_600_000.0 },
                 ),
             )
-            val score = rankingRepository.score(
-                objective = objective,
-                features = features,
-                priorScore = normalizedPriors[podcast.id] ?: 0.0,
-            )
-            podcast.id to score.finalScore
+            podcast.id to features
         }
+        val scores = rankingRepository.scoreBatch(
+            objective = objective,
+            inputs = podcasts.map { podcast ->
+                RankingScoreInput(
+                    features = featuresByPodcast.getValue(podcast.id),
+                    priorScore = normalizedPriors[podcast.id] ?: 0.0,
+                )
+            },
+        )
+        val adaptive = podcasts.mapIndexed { index, podcast ->
+            podcast.id to scores[index].finalScore
+        }.toMap()
         recordShadowComparison(objective, legacy, adaptive)
         return adaptive
     }
@@ -99,24 +109,27 @@ class AdaptiveCandidateScorer private constructor(
         val normalizedPriors = normalizePriors(inputs.associate { it.episode.id to it.priorScore })
         if (!runtimeControls.isAdaptiveEnabled(objective, surface)) return normalizedPriors
         val historyByEpisode = history.associateBy(ListeningHistoryEntity::episodeId)
-        val adaptive = inputs.associate { input ->
+        val facetKeys = buildSet {
+            inputs.forEach { input ->
+                add(PreferenceFacetKey(PreferenceFacetType.SHOW, input.podcast.id))
+                add(PreferenceFacetKey(PreferenceFacetType.SOURCE, input.source.name))
+                input.podcast.rankingGenres().forEach { genre ->
+                    add(PreferenceFacetKey(PreferenceFacetType.GENRE, genre))
+                }
+            }
+        }
+        val affinities = rankingRepository.facetAffinities(facetKeys, nowMs)
+        val featuresByEpisode = inputs.associate { input ->
             val episodeHistory = historyByEpisode[input.episode.id]
-            val showAffinity = rankingRepository.facetAffinity(
-                PreferenceFacetType.SHOW,
-                input.podcast.id,
-                nowMs,
-            )
-            val genreAffinity = input.podcast.genre
-                .split(",")
-                .map(String::trim)
-                .filter(String::isNotEmpty)
-                .map { rankingRepository.facetAffinity(PreferenceFacetType.GENRE, it, nowMs) }
+            val showAffinity =
+                affinities[PreferenceFacetKey(PreferenceFacetType.SHOW, input.podcast.id)] ?: 0.0
+            val genreAffinity = input.podcast.rankingGenres()
+                .map { genre ->
+                    affinities[PreferenceFacetKey(PreferenceFacetType.GENRE, genre)] ?: 0.0
+                }
                 .averageOrNeutral()
-            val sourceAffinity = rankingRepository.facetAffinity(
-                PreferenceFacetType.SOURCE,
-                input.source.name,
-                nowMs,
-            )
+            val sourceAffinity =
+                affinities[PreferenceFacetKey(PreferenceFacetType.SOURCE, input.source.name)] ?: 0.0
             val features = CandidateFeatureBuilder.build(
                 CandidateSignals(
                     showAffinity = showAffinity.toUnitAffinity(),
@@ -147,13 +160,20 @@ class AdaptiveCandidateScorer private constructor(
                         ?.let { (nowMs - it).coerceAtLeast(0L) / 3_600_000.0 },
                 ),
             )
-            val score = rankingRepository.score(
-                objective = objective,
-                features = features,
-                priorScore = normalizedPriors[input.episode.id] ?: 0.0,
-            )
-            input.episode.id to score.finalScore
+            input.episode.id to features
         }
+        val scores = rankingRepository.scoreBatch(
+            objective = objective,
+            inputs = inputs.map { input ->
+                RankingScoreInput(
+                    features = featuresByEpisode.getValue(input.episode.id),
+                    priorScore = normalizedPriors[input.episode.id] ?: 0.0,
+                )
+            },
+        )
+        val adaptive = inputs.mapIndexed { index, input ->
+            input.episode.id to scores[index].finalScore
+        }.toMap()
         recordShadowComparison(objective, normalizedPriors, adaptive)
         return adaptive
     }
@@ -179,7 +199,9 @@ class AdaptiveCandidateScorer private constructor(
         }
         val ranked = DiversityReranker.rerank(candidates, diversityPolicy)
             .map(RankedCandidate<Episode>::value)
-        if (runtimeControls.isShadowDiagnosticsEnabled()) {
+        if (runtimeControls.isShadowDiagnosticsEnabled() &&
+            runtimeControls.isAdaptiveEnabled(objective, surface)
+        ) {
             RankingShadowDiagnostics.record(
                 objective = objective,
                 priorOrder = inputs.sortedByDescending(EpisodeRankingInput::priorScore)
@@ -201,31 +223,41 @@ class AdaptiveCandidateScorer private constructor(
         if (inputs.isEmpty()) return emptyList()
         val normalizedPriors = normalizePriors(inputs.associate { it.podcast.id to it.priorScore })
         val historyByPodcast = history.groupBy(ListeningHistoryEntity::podcastId)
-        val scored = inputs.map { input ->
+        val adaptiveEnabled = runtimeControls.isAdaptiveEnabled(objective, surface)
+        val facetKeys = if (adaptiveEnabled) {
+            buildSet {
+                inputs.forEach { input ->
+                    add(PreferenceFacetKey(PreferenceFacetType.SHOW, input.podcast.id))
+                    add(PreferenceFacetKey(PreferenceFacetType.SOURCE, input.source.name))
+                    input.podcast.rankingGenres().forEach { genre ->
+                        add(PreferenceFacetKey(PreferenceFacetType.GENRE, genre))
+                    }
+                }
+            }
+        } else {
+            emptySet()
+        }
+        val affinities = rankingRepository.facetAffinities(facetKeys, nowMs)
+        val features = inputs.map { input ->
             val podcast = input.podcast
             val latestHistory = podcast.latestEpisode?.let { episode ->
                 historyByPodcast[podcast.id].orEmpty().firstOrNull { it.episodeId == episode.id }
             }
-            val showAffinity = rankingRepository.facetAffinity(
-                PreferenceFacetType.SHOW,
-                podcast.id,
-                nowMs,
-            )
-            val genreAffinity = podcast.genre
-                .split(",")
-                .map(String::trim)
-                .filter(String::isNotEmpty)
-                .map { rankingRepository.facetAffinity(PreferenceFacetType.GENRE, it, nowMs) }
+            val showAffinity =
+                affinities[PreferenceFacetKey(PreferenceFacetType.SHOW, podcast.id)] ?: 0.0
+            val genreAffinity = podcast.rankingGenres()
+                .map { genre ->
+                    affinities[PreferenceFacetKey(PreferenceFacetType.GENRE, genre)] ?: 0.0
+                }
                 .averageOrNeutral()
-            val features = CandidateFeatureBuilder.build(
+            CandidateFeatureBuilder.build(
                 CandidateSignals(
                     showAffinity = showAffinity.toUnitAffinity(),
                     genreAffinity = genreAffinity.toUnitAffinity(),
-                    sourceAffinity = rankingRepository.facetAffinity(
-                        PreferenceFacetType.SOURCE,
-                        input.source.name,
-                        nowMs,
-                    ).toUnitAffinity(),
+                    sourceAffinity = (
+                        affinities[PreferenceFacetKey(PreferenceFacetType.SOURCE, input.source.name)]
+                            ?: 0.0
+                        ).toUnitAffinity(),
                     ageHours = podcast.latestEpisode?.let { episode ->
                         (nowMs / 1_000.0 - episode.publishedDate).coerceAtLeast(0.0) / 3_600.0
                     },
@@ -246,16 +278,24 @@ class AdaptiveCandidateScorer private constructor(
                         ?.let { (nowMs - it).coerceAtLeast(0L) / 3_600_000.0 },
                 ),
             )
+        }
+        val adaptiveScores = if (adaptiveEnabled) {
+            rankingRepository.scoreBatch(
+                objective = objective,
+                inputs = inputs.mapIndexed { index, input ->
+                    RankingScoreInput(
+                        features = features[index],
+                        priorScore = normalizedPriors[input.podcast.id] ?: 0.0,
+                    )
+                },
+            )
+        } else {
+            emptyList()
+        }
+        val scored = inputs.mapIndexed { index, input ->
+            val podcast = input.podcast
             val priorScore = normalizedPriors[podcast.id] ?: 0.0
-            val finalScore = if (runtimeControls.isAdaptiveEnabled(objective, surface)) {
-                rankingRepository.score(
-                    objective = objective,
-                    features = features,
-                    priorScore = priorScore,
-                ).finalScore
-            } else {
-                priorScore
-            }
+            val finalScore = adaptiveScores.getOrNull(index)?.finalScore ?: priorScore
             RankedCandidate(
                 value = podcast,
                 episodeId = podcast.id,
@@ -272,7 +312,9 @@ class AdaptiveCandidateScorer private constructor(
             DiversityReranker.rerank(scored, diversityPolicy)
         }
         val ranked = ordered.map(RankedCandidate<Podcast>::value)
-        if (runtimeControls.isShadowDiagnosticsEnabled()) {
+        if (runtimeControls.isShadowDiagnosticsEnabled() &&
+            runtimeControls.isAdaptiveEnabled(objective, surface)
+        ) {
             RankingShadowDiagnostics.record(
                 objective = objective,
                 priorOrder = inputs.sortedByDescending(PodcastRankingInput::priorScore)
@@ -332,6 +374,11 @@ private fun ListeningHistoryEntity?.progressRatio(): Double {
 }
 
 private fun List<Double>.averageOrNeutral(): Double = if (isEmpty()) 0.0 else average()
+
+private fun Podcast.rankingGenres(): List<String> = genre
+    .split(",")
+    .map(String::trim)
+    .filter(String::isNotEmpty)
 
 private fun durationFit(durationSeconds: Int): Double {
     if (durationSeconds <= 0) return 0.5

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
@@ -17,6 +17,14 @@ data class EpisodeRankingInput(
     val online: Boolean = true,
 )
 
+data class PodcastRankingInput(
+    val podcast: Podcast,
+    val priorScore: Double,
+    val source: CandidateSource,
+    val isNovel: Boolean = false,
+    val timeContextMatch: Double = 0.5,
+)
+
 class AdaptiveCandidateScorer private constructor(
     private val rankingRepository: AdaptiveRankingRepository,
 ) {
@@ -139,6 +147,106 @@ class AdaptiveCandidateScorer private constructor(
             )
             input.episode.id to score.finalScore
         }
+    }
+
+    suspend fun rankEpisodes(
+        inputs: List<EpisodeRankingInput>,
+        history: List<ListeningHistoryEntity>,
+        objective: RankingObjective,
+        diversityPolicy: DiversityPolicy,
+        nowMs: Long = System.currentTimeMillis(),
+    ): List<Episode> {
+        val scores = scoreEpisodes(inputs, history, objective, nowMs)
+        val candidates = inputs.map { input ->
+            RankedCandidate(
+                value = input.episode,
+                episodeId = input.episode.id,
+                podcastId = input.podcast.id,
+                genre = input.episode.podcastGenre ?: input.podcast.genre,
+                score = scores[input.episode.id] ?: 0.0,
+                isNovel = input.isNovel,
+            )
+        }
+        return DiversityReranker.rerank(candidates, diversityPolicy)
+            .map(RankedCandidate<Episode>::value)
+    }
+
+    suspend fun rankPodcasts(
+        inputs: List<PodcastRankingInput>,
+        history: List<ListeningHistoryEntity>,
+        objective: RankingObjective,
+        diversityPolicy: DiversityPolicy? = null,
+        nowMs: Long = System.currentTimeMillis(),
+    ): List<Podcast> {
+        if (inputs.isEmpty()) return emptyList()
+        val normalizedPriors = normalizePriors(inputs.associate { it.podcast.id to it.priorScore })
+        val historyByPodcast = history.groupBy(ListeningHistoryEntity::podcastId)
+        val scored = inputs.map { input ->
+            val podcast = input.podcast
+            val latestHistory = podcast.latestEpisode?.let { episode ->
+                historyByPodcast[podcast.id].orEmpty().firstOrNull { it.episodeId == episode.id }
+            }
+            val showAffinity = rankingRepository.facetAffinity(
+                PreferenceFacetType.SHOW,
+                podcast.id,
+                nowMs,
+            )
+            val genreAffinity = podcast.genre
+                .split(",")
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .map { rankingRepository.facetAffinity(PreferenceFacetType.GENRE, it, nowMs) }
+                .averageOrNeutral()
+            val features = CandidateFeatureBuilder.build(
+                CandidateSignals(
+                    showAffinity = showAffinity.toUnitAffinity(),
+                    genreAffinity = genreAffinity.toUnitAffinity(),
+                    sourceAffinity = rankingRepository.facetAffinity(
+                        PreferenceFacetType.SOURCE,
+                        input.source.name,
+                        nowMs,
+                    ).toUnitAffinity(),
+                    ageHours = podcast.latestEpisode?.let { episode ->
+                        (nowMs / 1_000.0 - episode.publishedDate).coerceAtLeast(0.0) / 3_600.0
+                    },
+                    isUnseenShow = input.isNovel,
+                    isSubscribed = podcast.subscribedAt > 0L,
+                    progressRatio = latestHistory.progressRatio(),
+                    isUnplayed = latestHistory == null ||
+                        (latestHistory.progressMs == 0L && !latestHistory.isCompleted),
+                    serverRelevance = normalizedPriors[podcast.id] ?: 0.0,
+                    timeContextMatch = input.timeContextMatch,
+                    explicitPreference = when {
+                        podcast.autoDownloadEnabled -> 1.0
+                        podcast.notificationsEnabled -> 0.7
+                        else -> 0.0
+                    },
+                    hoursSinceSubscription = podcast.subscribedAt
+                        .takeIf { it > 0L }
+                        ?.let { (nowMs - it).coerceAtLeast(0L) / 3_600_000.0 },
+                ),
+            )
+            val score = rankingRepository.score(
+                objective = objective,
+                features = features,
+                priorScore = normalizedPriors[podcast.id] ?: 0.0,
+            )
+            RankedCandidate(
+                value = podcast,
+                episodeId = podcast.id,
+                podcastId = podcast.id,
+                genre = podcast.genre.substringBefore(",").trim(),
+                score = score.finalScore,
+                isNovel = input.isNovel,
+            )
+        }
+        val ordered = if (diversityPolicy == null) {
+            scored.distinctBy(RankedCandidate<Podcast>::episodeId)
+                .sortedByDescending(RankedCandidate<Podcast>::score)
+        } else {
+            DiversityReranker.rerank(scored, diversityPolicy)
+        }
+        return ordered.map(RankedCandidate<Podcast>::value)
     }
 
     private fun normalizePriors(scores: Map<String, Double>): Map<String, Double> {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveCandidateScorer.kt
@@ -27,6 +27,7 @@ data class PodcastRankingInput(
 
 class AdaptiveCandidateScorer private constructor(
     private val rankingRepository: AdaptiveRankingRepository,
+    private val runtimeControls: RankingRuntimeControls,
 ) {
     suspend fun scorePodcasts(
         podcasts: List<ScorablePodcast>,
@@ -41,9 +42,10 @@ class AdaptiveCandidateScorer private constructor(
             allHistory = history,
             includeAutoDownloadBoost = includeAutoDownloadBoost,
         )
+        if (!runtimeControls.isAdaptiveEnabled(objective)) return legacy
         val normalizedPriors = normalizePriors(legacy)
         val historyByPodcast = history.groupBy(ListeningHistoryEntity::podcastId)
-        return podcasts.associate { podcast ->
+        val adaptive = podcasts.associate { podcast ->
             val podcastHistory = historyByPodcast[podcast.id].orEmpty()
             val latestHistory = podcast.latestEpisode?.let { latest ->
                 podcastHistory.firstOrNull { it.episodeId == latest.id }
@@ -81,6 +83,8 @@ class AdaptiveCandidateScorer private constructor(
             )
             podcast.id to score.finalScore
         }
+        recordShadowComparison(objective, legacy, adaptive)
+        return adaptive
     }
 
     suspend fun scoreEpisodes(
@@ -91,8 +95,9 @@ class AdaptiveCandidateScorer private constructor(
     ): Map<String, Double> {
         if (inputs.isEmpty()) return emptyMap()
         val normalizedPriors = normalizePriors(inputs.associate { it.episode.id to it.priorScore })
+        if (!runtimeControls.isAdaptiveEnabled(objective)) return normalizedPriors
         val historyByEpisode = history.associateBy(ListeningHistoryEntity::episodeId)
-        return inputs.associate { input ->
+        val adaptive = inputs.associate { input ->
             val episodeHistory = historyByEpisode[input.episode.id]
             val showAffinity = rankingRepository.facetAffinity(
                 PreferenceFacetType.SHOW,
@@ -147,6 +152,8 @@ class AdaptiveCandidateScorer private constructor(
             )
             input.episode.id to score.finalScore
         }
+        recordShadowComparison(objective, normalizedPriors, adaptive)
+        return adaptive
     }
 
     suspend fun rankEpisodes(
@@ -167,8 +174,17 @@ class AdaptiveCandidateScorer private constructor(
                 isNovel = input.isNovel,
             )
         }
-        return DiversityReranker.rerank(candidates, diversityPolicy)
+        val ranked = DiversityReranker.rerank(candidates, diversityPolicy)
             .map(RankedCandidate<Episode>::value)
+        if (runtimeControls.isShadowDiagnosticsEnabled()) {
+            RankingShadowDiagnostics.record(
+                objective = objective,
+                priorOrder = inputs.sortedByDescending(EpisodeRankingInput::priorScore)
+                    .map { it.episode.id },
+                adaptiveOrder = ranked.map(Episode::id),
+            )
+        }
+        return ranked
     }
 
     suspend fun rankPodcasts(
@@ -226,17 +242,22 @@ class AdaptiveCandidateScorer private constructor(
                         ?.let { (nowMs - it).coerceAtLeast(0L) / 3_600_000.0 },
                 ),
             )
-            val score = rankingRepository.score(
-                objective = objective,
-                features = features,
-                priorScore = normalizedPriors[podcast.id] ?: 0.0,
-            )
+            val priorScore = normalizedPriors[podcast.id] ?: 0.0
+            val finalScore = if (runtimeControls.isAdaptiveEnabled(objective)) {
+                rankingRepository.score(
+                    objective = objective,
+                    features = features,
+                    priorScore = priorScore,
+                ).finalScore
+            } else {
+                priorScore
+            }
             RankedCandidate(
                 value = podcast,
                 episodeId = podcast.id,
                 podcastId = podcast.id,
                 genre = podcast.genre.substringBefore(",").trim(),
-                score = score.finalScore,
+                score = finalScore,
                 isNovel = input.isNovel,
             )
         }
@@ -246,7 +267,16 @@ class AdaptiveCandidateScorer private constructor(
         } else {
             DiversityReranker.rerank(scored, diversityPolicy)
         }
-        return ordered.map(RankedCandidate<Podcast>::value)
+        val ranked = ordered.map(RankedCandidate<Podcast>::value)
+        if (runtimeControls.isShadowDiagnosticsEnabled()) {
+            RankingShadowDiagnostics.record(
+                objective = objective,
+                priorOrder = inputs.sortedByDescending(PodcastRankingInput::priorScore)
+                    .map { it.podcast.id },
+                adaptiveOrder = ranked.map(Podcast::id),
+            )
+        }
+        return ranked
     }
 
     private fun normalizePriors(scores: Map<String, Double>): Map<String, Double> {
@@ -260,6 +290,21 @@ class AdaptiveCandidateScorer private constructor(
         }
     }
 
+    private fun recordShadowComparison(
+        objective: RankingObjective,
+        priors: Map<String, Double>,
+        adaptive: Map<String, Double>,
+    ) {
+        if (!runtimeControls.isShadowDiagnosticsEnabled()) return
+        RankingShadowDiagnostics.record(
+            objective = objective,
+            priorOrder = priors.entries.sortedByDescending(Map.Entry<String, Double>::value)
+                .map(Map.Entry<String, Double>::key),
+            adaptiveOrder = adaptive.entries.sortedByDescending(Map.Entry<String, Double>::value)
+                .map(Map.Entry<String, Double>::key),
+        )
+    }
+
     companion object {
         @Volatile
         private var instance: AdaptiveCandidateScorer? = null
@@ -268,6 +313,7 @@ class AdaptiveCandidateScorer private constructor(
             return instance ?: synchronized(this) {
                 instance ?: AdaptiveCandidateScorer(
                     AdaptiveRankingRepository.getInstance(context.applicationContext),
+                    RankingRuntimeControls.getInstance(context.applicationContext),
                 ).also { instance = it }
             }
         }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveLinearModel.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveLinearModel.kt
@@ -1,0 +1,189 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import kotlin.math.sqrt
+import kotlin.math.tanh
+
+data class AdaptiveModelState(
+    val featureSchemaVersion: Int = RankingFeatureSchema.VERSION,
+    val dimension: Int = RankingFeatureSchema.dimension,
+    val covariance: DoubleArray = identityMatrix(RankingFeatureSchema.dimension, RIDGE),
+    val inverseCovariance: DoubleArray = identityMatrix(
+        RankingFeatureSchema.dimension,
+        1.0 / RIDGE,
+    ),
+    val rewardVector: DoubleArray = DoubleArray(RankingFeatureSchema.dimension),
+    val updateCount: Long = 0,
+) {
+    init {
+        require(dimension > 0)
+        require(covariance.size == dimension * dimension)
+        require(inverseCovariance.size == dimension * dimension)
+        require(rewardVector.size == dimension)
+    }
+
+    companion object {
+        const val RIDGE = 1.0
+    }
+}
+
+class AdaptiveLinearModel(
+    private val forgettingFactor: Double = 0.995,
+    private val explorationAlpha: Double = 0.15,
+    private val explorationThreshold: Long = 50,
+    private val maximumLearnedBlend: Double = 0.65,
+) {
+    init {
+        require(forgettingFactor in 0.9..1.0)
+        require(explorationAlpha >= 0.0)
+        require(explorationThreshold > 0)
+        require(maximumLearnedBlend in 0.0..1.0)
+    }
+
+    fun score(
+        objective: RankingObjective,
+        features: RankingFeatures,
+        priorScore: Double,
+        state: AdaptiveModelState,
+    ): RankingScore {
+        requireCompatible(features, state)
+        val theta = multiply(state.inverseCovariance, state.rewardVector, state.dimension)
+        val rawLearned = dot(theta, features.values)
+        val learned = tanh(rawLearned)
+        val uncertainty = if (objective.allowsExploration && state.updateCount >= explorationThreshold) {
+            val projected = multiply(state.inverseCovariance, features.values, state.dimension)
+            explorationAlpha * sqrt(dot(features.values, projected).coerceAtLeast(0.0))
+        } else {
+            0.0
+        }
+        val blend = (state.updateCount.toDouble() / explorationThreshold)
+            .coerceIn(0.0, 1.0) * maximumLearnedBlend
+        val boundedPrior = priorScore.coerceIn(-1.0, 1.0)
+        val final = ((1.0 - blend) * boundedPrior + blend * learned + uncertainty)
+            .coerceIn(-1.0, 1.0)
+        val contributions = FeatureSlot.entries.associateWith { slot ->
+            theta[slot.ordinal] * features.values[slot.ordinal]
+        }
+        return RankingScore(
+            finalScore = final,
+            priorScore = boundedPrior,
+            learnedScore = learned,
+            explorationBonus = uncertainty,
+            learnedBlend = blend,
+            updateCount = state.updateCount,
+            contributions = contributions,
+        )
+    }
+
+    fun update(
+        features: RankingFeatures,
+        reward: Double,
+        state: AdaptiveModelState,
+    ): AdaptiveModelState {
+        requireCompatible(features, state)
+        val boundedReward = reward.coerceIn(-1.0, 1.0)
+        val dimension = state.dimension
+        val covariance = DoubleArray(state.covariance.size)
+        for (row in 0 until dimension) {
+            for (column in 0 until dimension) {
+                val index = row * dimension + column
+                val retained = state.covariance[index] * forgettingFactor
+                val ridgeRefresh = if (row == column) {
+                    (1.0 - forgettingFactor) * AdaptiveModelState.RIDGE
+                } else {
+                    0.0
+                }
+                covariance[index] = retained +
+                    ridgeRefresh +
+                    features.values[row] * features.values[column]
+            }
+        }
+        val rewardVector = DoubleArray(dimension) { index ->
+            state.rewardVector[index] * forgettingFactor + features.values[index] * boundedReward
+        }
+        val inverse = invertPositiveDefinite(covariance, dimension)
+        return AdaptiveModelState(
+            featureSchemaVersion = state.featureSchemaVersion,
+            dimension = dimension,
+            covariance = covariance,
+            inverseCovariance = inverse,
+            rewardVector = rewardVector,
+            updateCount = state.updateCount + 1,
+        )
+    }
+
+    private fun requireCompatible(features: RankingFeatures, state: AdaptiveModelState) {
+        require(features.schemaVersion == state.featureSchemaVersion) {
+            "Feature schema ${features.schemaVersion} does not match model ${state.featureSchemaVersion}"
+        }
+        require(features.values.size == state.dimension)
+    }
+}
+
+internal fun identityMatrix(dimension: Int, diagonal: Double): DoubleArray {
+    return DoubleArray(dimension * dimension) { index ->
+        if (index / dimension == index % dimension) diagonal else 0.0
+    }
+}
+
+internal fun dot(left: DoubleArray, right: DoubleArray): Double {
+    require(left.size == right.size)
+    return left.indices.sumOf { index -> left[index] * right[index] }
+}
+
+internal fun multiply(matrix: DoubleArray, vector: DoubleArray, dimension: Int): DoubleArray {
+    require(matrix.size == dimension * dimension)
+    require(vector.size == dimension)
+    return DoubleArray(dimension) { row ->
+        var sum = 0.0
+        for (column in 0 until dimension) {
+            sum += matrix[row * dimension + column] * vector[column]
+        }
+        sum
+    }
+}
+
+internal fun invertPositiveDefinite(matrix: DoubleArray, dimension: Int): DoubleArray {
+    require(matrix.size == dimension * dimension)
+    val augmented = Array(dimension) { row ->
+        DoubleArray(dimension * 2) { column ->
+            when {
+                column < dimension -> matrix[row * dimension + column]
+                column - dimension == row -> 1.0
+                else -> 0.0
+            }
+        }
+    }
+    for (pivotIndex in 0 until dimension) {
+        var bestRow = pivotIndex
+        for (row in pivotIndex + 1 until dimension) {
+            if (kotlin.math.abs(augmented[row][pivotIndex]) >
+                kotlin.math.abs(augmented[bestRow][pivotIndex])
+            ) {
+                bestRow = row
+            }
+        }
+        if (bestRow != pivotIndex) {
+            val temp = augmented[pivotIndex]
+            augmented[pivotIndex] = augmented[bestRow]
+            augmented[bestRow] = temp
+        }
+        val pivot = augmented[pivotIndex][pivotIndex]
+        require(kotlin.math.abs(pivot) > 1e-12) { "Ranking covariance matrix is singular" }
+        for (column in 0 until dimension * 2) {
+            augmented[pivotIndex][column] /= pivot
+        }
+        for (row in 0 until dimension) {
+            if (row == pivotIndex) continue
+            val factor = augmented[row][pivotIndex]
+            if (factor == 0.0) continue
+            for (column in 0 until dimension * 2) {
+                augmented[row][column] -= factor * augmented[pivotIndex][column]
+            }
+        }
+    }
+    return DoubleArray(dimension * dimension) { index ->
+        val row = index / dimension
+        val column = index % dimension
+        augmented[row][column + dimension]
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveLinearModel.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveLinearModel.kt
@@ -144,7 +144,24 @@ internal fun multiply(matrix: DoubleArray, vector: DoubleArray, dimension: Int):
 
 internal fun invertPositiveDefinite(matrix: DoubleArray, dimension: Int): DoubleArray {
     require(matrix.size == dimension * dimension)
-    val augmented = Array(dimension) { row ->
+    val augmented = augmentedWithIdentity(matrix, dimension)
+    for (pivotIndex in 0 until dimension) {
+        swapBestPivotIntoPlace(augmented, pivotIndex)
+        normalizePivotRow(augmented, pivotIndex)
+        eliminatePivotColumn(augmented, pivotIndex)
+    }
+    return DoubleArray(dimension * dimension) { index ->
+        val row = index / dimension
+        val column = index % dimension
+        augmented[row][column + dimension]
+    }
+}
+
+private fun augmentedWithIdentity(
+    matrix: DoubleArray,
+    dimension: Int,
+): Array<DoubleArray> {
+    return Array(dimension) { row ->
         DoubleArray(dimension * 2) { column ->
             when {
                 column < dimension -> matrix[row * dimension + column]
@@ -153,37 +170,49 @@ internal fun invertPositiveDefinite(matrix: DoubleArray, dimension: Int): Double
             }
         }
     }
-    for (pivotIndex in 0 until dimension) {
-        var bestRow = pivotIndex
-        for (row in pivotIndex + 1 until dimension) {
-            if (kotlin.math.abs(augmented[row][pivotIndex]) >
-                kotlin.math.abs(augmented[bestRow][pivotIndex])
-            ) {
-                bestRow = row
-            }
-        }
-        if (bestRow != pivotIndex) {
-            val temp = augmented[pivotIndex]
-            augmented[pivotIndex] = augmented[bestRow]
-            augmented[bestRow] = temp
-        }
-        val pivot = augmented[pivotIndex][pivotIndex]
-        require(kotlin.math.abs(pivot) > 1e-12) { "Ranking covariance matrix is singular" }
-        for (column in 0 until dimension * 2) {
-            augmented[pivotIndex][column] /= pivot
-        }
-        for (row in 0 until dimension) {
-            if (row == pivotIndex) continue
-            val factor = augmented[row][pivotIndex]
-            if (factor == 0.0) continue
-            for (column in 0 until dimension * 2) {
-                augmented[row][column] -= factor * augmented[pivotIndex][column]
-            }
-        }
+}
+
+private fun swapBestPivotIntoPlace(
+    augmented: Array<DoubleArray>,
+    pivotIndex: Int,
+) {
+    val bestRow = (pivotIndex until augmented.size).maxBy { row ->
+        kotlin.math.abs(augmented[row][pivotIndex])
     }
-    return DoubleArray(dimension * dimension) { index ->
-        val row = index / dimension
-        val column = index % dimension
-        augmented[row][column + dimension]
+    if (bestRow == pivotIndex) return
+    val temporary = augmented[pivotIndex]
+    augmented[pivotIndex] = augmented[bestRow]
+    augmented[bestRow] = temporary
+}
+
+private fun normalizePivotRow(
+    augmented: Array<DoubleArray>,
+    pivotIndex: Int,
+) {
+    val pivot = augmented[pivotIndex][pivotIndex]
+    require(kotlin.math.abs(pivot) > 1e-12) { "Ranking covariance matrix is singular" }
+    for (column in augmented[pivotIndex].indices) {
+        augmented[pivotIndex][column] /= pivot
+    }
+}
+
+private fun eliminatePivotColumn(
+    augmented: Array<DoubleArray>,
+    pivotIndex: Int,
+) {
+    for (row in augmented.indices) {
+        if (row != pivotIndex) eliminateFromRow(augmented, row, pivotIndex)
+    }
+}
+
+private fun eliminateFromRow(
+    augmented: Array<DoubleArray>,
+    row: Int,
+    pivotIndex: Int,
+) {
+    val factor = augmented[row][pivotIndex]
+    if (factor == 0.0) return
+    for (column in augmented[row].indices) {
+        augmented[row][column] -= factor * augmented[pivotIndex][column]
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveLinearModel.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveLinearModel.kt
@@ -60,9 +60,6 @@ class AdaptiveLinearModel(
         val boundedPrior = priorScore.coerceIn(-1.0, 1.0)
         val final = ((1.0 - blend) * boundedPrior + blend * learned + uncertainty)
             .coerceIn(-1.0, 1.0)
-        val contributions = FeatureSlot.entries.associateWith { slot ->
-            theta[slot.ordinal] * features.values[slot.ordinal]
-        }
         return RankingScore(
             finalScore = final,
             priorScore = boundedPrior,
@@ -70,7 +67,11 @@ class AdaptiveLinearModel(
             explorationBonus = uncertainty,
             learnedBlend = blend,
             updateCount = state.updateCount,
-            contributions = contributions,
+            contributions = lazy(LazyThreadSafetyMode.NONE) {
+                FeatureSlot.entries.associateWith { slot ->
+                    theta[slot.ordinal] * features.values[slot.ordinal]
+                }
+            },
         )
     }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
@@ -39,6 +39,16 @@ data class RankingAggregateTelemetry(
     val explorationEligible: Boolean,
 )
 
+data class RankingScoreInput(
+    val features: RankingFeatures,
+    val priorScore: Double,
+)
+
+data class PreferenceFacetKey(
+    val type: PreferenceFacetType,
+    val key: String,
+)
+
 data class AdaptiveRankingBackup(
     val version: Int = 1,
     val models: List<AdaptiveModelEntity>? = emptyList(),
@@ -66,6 +76,24 @@ class AdaptiveRankingRepository private constructor(
                 priorScore = priorScore,
                 state = loadState(objective),
             )
+        }
+    }
+
+    suspend fun scoreBatch(
+        objective: RankingObjective,
+        inputs: List<RankingScoreInput>,
+    ): List<RankingScore> {
+        if (inputs.isEmpty()) return emptyList()
+        return objectiveLock(objective).withLock {
+            val state = loadState(objective)
+            inputs.map { input ->
+                model.score(
+                    objective = objective,
+                    features = input.features,
+                    priorScore = input.priorScore,
+                    state = state,
+                )
+            }
         }
     }
 
@@ -153,6 +181,22 @@ class AdaptiveRankingRepository private constructor(
             ?: 0.0
     }
 
+    suspend fun facetAffinities(
+        keys: Set<PreferenceFacetKey>,
+        now: Long = System.currentTimeMillis(),
+    ): Map<PreferenceFacetKey, Double> {
+        if (keys.isEmpty()) return emptyMap()
+        val stored = dao.getAllFacets().associateBy { entity ->
+            entity.facetType to entity.facetKey
+        }
+        return keys.associateWith { request ->
+            stored[request.type.name to request.key.normalizedFacetKey()]
+                ?.toFacet()
+                ?.affinity(now)
+                ?: 0.0
+        }
+    }
+
     suspend fun updateFacet(
         type: PreferenceFacetType,
         key: String,
@@ -222,9 +266,9 @@ class AdaptiveRankingRepository private constructor(
         require(backup.version == ADAPTIVE_BACKUP_VERSION) {
             "Unsupported adaptive ranking backup version ${backup.version}"
         }
-        val models = backup.models.orEmpty()
-        val facets = backup.facets.orEmpty()
-        val exposures = backup.exposures.orEmpty()
+        val models = requireNotNull(backup.models) { "Adaptive model backup section is missing" }
+        val facets = requireNotNull(backup.facets) { "Preference facet backup section is missing" }
+        val exposures = requireNotNull(backup.exposures) { "Ranking exposure backup section is missing" }
         require(models.all(::isValidBackupModel)) { "Invalid adaptive model backup" }
         require(facets.all(::isValidBackupFacet)) { "Invalid preference facet backup" }
         require(exposures.size <= MAX_EXPOSURES && exposures.all(::isValidBackupExposure)) {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
@@ -1,0 +1,260 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import android.content.Context
+import cx.aswin.boxcast.core.data.ranking.database.AdaptiveModelEntity
+import cx.aswin.boxcast.core.data.ranking.database.AdaptiveRankingDatabase
+import cx.aswin.boxcast.core.data.ranking.database.PreferenceFacetEntity
+import cx.aswin.boxcast.core.data.ranking.database.RankingExposureEntity
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+data class RankingExposure(
+    val episodeId: String,
+    val podcastId: String,
+    val objective: RankingObjective,
+    val surface: RankingSurface,
+    val source: CandidateSource,
+    val features: RankingFeatures,
+    val entryPoint: String? = null,
+    val online: Boolean,
+    val shownAt: Long = System.currentTimeMillis(),
+)
+
+data class RankingDebugSnapshot(
+    val objective: RankingObjective,
+    val updateCount: Long,
+    val learnedBlend: Double,
+    val explorationEnabled: Boolean,
+    val featureSchemaVersion: Int,
+)
+
+class AdaptiveRankingRepository private constructor(
+    private val database: AdaptiveRankingDatabase,
+    private val model: AdaptiveLinearModel = AdaptiveLinearModel(),
+) {
+    private val dao = database.adaptiveRankingDao()
+    private val objectiveLocks = ConcurrentHashMap<RankingObjective, Mutex>()
+
+    suspend fun score(
+        objective: RankingObjective,
+        features: RankingFeatures,
+        priorScore: Double,
+    ): RankingScore {
+        return objectiveLock(objective).withLock {
+            model.score(
+                objective = objective,
+                features = features,
+                priorScore = priorScore,
+                state = loadState(objective),
+            )
+        }
+    }
+
+    suspend fun recordExposure(exposure: RankingExposure): String {
+        val exposureId = UUID.randomUUID().toString()
+        dao.insertExposure(
+            RankingExposureEntity(
+                exposureId = exposureId,
+                episodeId = exposure.episodeId,
+                podcastId = exposure.podcastId,
+                objective = exposure.objective.name,
+                surface = exposure.surface.name,
+                source = exposure.source.name,
+                featureSchemaVersion = exposure.features.schemaVersion,
+                featureVector = RankingSerialization.encode(exposure.features.values),
+                shownAt = exposure.shownAt,
+                resolvedAt = null,
+                reward = null,
+                listenSeconds = 0,
+                entryPoint = exposure.entryPoint,
+                online = exposure.online,
+            ),
+        )
+        pruneExposures(exposure.shownAt)
+        return exposureId
+    }
+
+    suspend fun resolveExposure(
+        exposureId: String,
+        reward: Double,
+        listenSeconds: Long = 0,
+        resolvedAt: Long = System.currentTimeMillis(),
+    ): Boolean {
+        val exposure = dao.getExposure(exposureId) ?: return false
+        if (exposure.resolvedAt != null) return false
+        val objective = runCatching { RankingObjective.valueOf(exposure.objective) }.getOrNull()
+            ?: return false
+        if (exposure.featureSchemaVersion != RankingFeatureSchema.VERSION) return false
+        val features = runCatching {
+            RankingFeatures(
+                schemaVersion = exposure.featureSchemaVersion,
+                values = RankingSerialization.decode(
+                    exposure.featureVector,
+                    RankingFeatureSchema.dimension,
+                ),
+            )
+        }.getOrNull() ?: return false
+        return objectiveLock(objective).withLock {
+            val changed = dao.resolveExposure(
+                exposureId = exposureId,
+                resolvedAt = resolvedAt,
+                reward = reward.coerceIn(-1.0, 1.0),
+                listenSeconds = listenSeconds.coerceAtLeast(0),
+            )
+            if (changed == 0) return@withLock false
+            val updated = model.update(features, reward, loadState(objective))
+            dao.upsertModel(updated.toEntity(objective, resolvedAt))
+            true
+        }
+    }
+
+    suspend fun resolveLatestExposure(
+        episodeId: String,
+        reward: Double,
+        listenSeconds: Long = 0,
+        resolvedAt: Long = System.currentTimeMillis(),
+    ): Boolean {
+        val exposure = dao.getLatestUnresolvedExposure(episodeId) ?: return false
+        return resolveExposure(exposure.exposureId, reward, listenSeconds, resolvedAt)
+    }
+
+    suspend fun facetAffinity(
+        type: PreferenceFacetType,
+        key: String,
+        now: Long = System.currentTimeMillis(),
+    ): Double {
+        val normalizedKey = key.normalizedFacetKey()
+        if (normalizedKey.isEmpty()) return 0.0
+        return dao.getFacet(type.name, normalizedKey)
+            ?.toFacet()
+            ?.affinity(now)
+            ?: 0.0
+    }
+
+    suspend fun updateFacet(
+        type: PreferenceFacetType,
+        key: String,
+        reward: Double,
+        now: Long = System.currentTimeMillis(),
+    ) {
+        val normalizedKey = key.normalizedFacetKey()
+        if (normalizedKey.isEmpty()) return
+        val existing = dao.getFacet(type.name, normalizedKey)?.toFacet()
+            ?: BayesianPreferenceFacet(updatedAt = now)
+        val updated = existing.update(reward, now)
+        dao.upsertFacet(
+            PreferenceFacetEntity(
+                facetType = type.name,
+                facetKey = normalizedKey,
+                positiveEvidence = updated.positiveEvidence,
+                negativeEvidence = updated.negativeEvidence,
+                updatedAt = updated.updatedAt,
+            ),
+        )
+    }
+
+    suspend fun debugSnapshot(objective: RankingObjective): RankingDebugSnapshot {
+        val state = loadState(objective)
+        val score = model.score(
+            objective = objective,
+            features = CandidateFeatureBuilder.build(CandidateSignals()),
+            priorScore = 0.0,
+            state = state,
+        )
+        return RankingDebugSnapshot(
+            objective = objective,
+            updateCount = state.updateCount,
+            learnedBlend = score.learnedBlend,
+            explorationEnabled = score.explorationBonus > 0.0 ||
+                (objective.allowsExploration && state.updateCount >= 50),
+            featureSchemaVersion = state.featureSchemaVersion,
+        )
+    }
+
+    suspend fun reset() {
+        dao.clearAll()
+    }
+
+    private suspend fun loadState(objective: RankingObjective): AdaptiveModelState {
+        val entity = dao.getModel(objective.name) ?: return AdaptiveModelState()
+        if (entity.featureSchemaVersion != RankingFeatureSchema.VERSION ||
+            entity.dimension != RankingFeatureSchema.dimension
+        ) {
+            return AdaptiveModelState()
+        }
+        return runCatching {
+            AdaptiveModelState(
+                featureSchemaVersion = entity.featureSchemaVersion,
+                dimension = entity.dimension,
+                covariance = RankingSerialization.decode(
+                    entity.covariance,
+                    entity.dimension * entity.dimension,
+                ),
+                inverseCovariance = RankingSerialization.decode(
+                    entity.inverseCovariance,
+                    entity.dimension * entity.dimension,
+                ),
+                rewardVector = RankingSerialization.decode(
+                    entity.rewardVector,
+                    entity.dimension,
+                ),
+                updateCount = entity.updateCount,
+            )
+        }.getOrElse { AdaptiveModelState() }
+    }
+
+    private suspend fun pruneExposures(now: Long) {
+        dao.pruneExposuresBefore(now - EXPOSURE_RETENTION_MILLIS)
+        dao.pruneExposuresToCount(MAX_EXPOSURES)
+    }
+
+    private fun objectiveLock(objective: RankingObjective): Mutex {
+        return objectiveLocks.getOrPut(objective) { Mutex() }
+    }
+
+    companion object {
+        private const val MAX_EXPOSURES = 1_000
+        private const val EXPOSURE_RETENTION_MILLIS = 30L * 24L * 60L * 60L * 1_000L
+
+        @Volatile
+        private var instance: AdaptiveRankingRepository? = null
+
+        fun getInstance(context: Context): AdaptiveRankingRepository {
+            return instance ?: synchronized(this) {
+                instance ?: AdaptiveRankingRepository(
+                    AdaptiveRankingDatabase.getDatabase(context.applicationContext),
+                ).also { instance = it }
+            }
+        }
+    }
+}
+
+private fun AdaptiveModelState.toEntity(
+    objective: RankingObjective,
+    now: Long,
+): AdaptiveModelEntity {
+    return AdaptiveModelEntity(
+        objective = objective.name,
+        featureSchemaVersion = featureSchemaVersion,
+        dimension = dimension,
+        covariance = RankingSerialization.encode(covariance),
+        inverseCovariance = RankingSerialization.encode(inverseCovariance),
+        rewardVector = RankingSerialization.encode(rewardVector),
+        updateCount = updateCount,
+        updatedAt = now,
+    )
+}
+
+private fun PreferenceFacetEntity.toFacet(): BayesianPreferenceFacet {
+    return BayesianPreferenceFacet(
+        positiveEvidence = positiveEvidence,
+        negativeEvidence = negativeEvidence,
+        updatedAt = updatedAt,
+    )
+}
+
+private fun String.normalizedFacetKey(): String {
+    return trim().lowercase().replace(Regex("\\s+"), " ").take(200)
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
@@ -30,6 +30,14 @@ data class RankingDebugSnapshot(
     val featureSchemaVersion: Int,
 )
 
+data class RankingAggregateTelemetry(
+    val objective: String,
+    val rankerVersion: Int,
+    val learningStage: String,
+    val outcomeCountBucket: String,
+    val explorationEligible: Boolean,
+)
+
 class AdaptiveRankingRepository private constructor(
     private val database: AdaptiveRankingDatabase,
     private val model: AdaptiveLinearModel = AdaptiveLinearModel(),
@@ -173,6 +181,23 @@ class AdaptiveRankingRepository private constructor(
         )
     }
 
+    suspend fun aggregateTelemetry(): List<RankingAggregateTelemetry> {
+        return RankingObjective.entries.map { objective ->
+            val state = loadState(objective)
+            RankingAggregateTelemetry(
+                objective = objective.name,
+                rankerVersion = RankingFeatureSchema.VERSION,
+                learningStage = when {
+                    state.updateCount == 0L -> "cold_start"
+                    state.updateCount < 50L -> "learning"
+                    else -> "adaptive"
+                },
+                outcomeCountBucket = state.updateCount.toOutcomeCountBucket(),
+                explorationEligible = objective.allowsExploration && state.updateCount >= 50L,
+            )
+        }
+    }
+
     suspend fun reset() {
         dao.clearAll()
     }
@@ -257,4 +282,12 @@ private fun PreferenceFacetEntity.toFacet(): BayesianPreferenceFacet {
 
 private fun String.normalizedFacetKey(): String {
     return trim().lowercase().replace(Regex("\\s+"), " ").take(200)
+}
+
+private fun Long.toOutcomeCountBucket(): String = when {
+    this == 0L -> "0"
+    this < 10L -> "1_9"
+    this < 50L -> "10_49"
+    this < 200L -> "50_199"
+    else -> "200_plus"
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
@@ -38,6 +38,13 @@ data class RankingAggregateTelemetry(
     val explorationEligible: Boolean,
 )
 
+data class AdaptiveRankingBackup(
+    val version: Int = 1,
+    val models: List<AdaptiveModelEntity>? = emptyList(),
+    val facets: List<PreferenceFacetEntity>? = emptyList(),
+    val exposures: List<RankingExposureEntity>? = emptyList(),
+)
+
 class AdaptiveRankingRepository private constructor(
     private val database: AdaptiveRankingDatabase,
     private val model: AdaptiveLinearModel = AdaptiveLinearModel(),
@@ -198,6 +205,30 @@ class AdaptiveRankingRepository private constructor(
         }
     }
 
+    suspend fun exportBackup(): AdaptiveRankingBackup {
+        return AdaptiveRankingBackup(
+            models = dao.getAllModels(),
+            facets = dao.getAllFacets(),
+            exposures = dao.getAllExposures(),
+        )
+    }
+
+    suspend fun restoreBackup(backup: AdaptiveRankingBackup) {
+        require(backup.version == ADAPTIVE_BACKUP_VERSION) {
+            "Unsupported adaptive ranking backup version ${backup.version}"
+        }
+        val models = backup.models.orEmpty()
+        val facets = backup.facets.orEmpty()
+        val exposures = backup.exposures.orEmpty()
+        require(models.all(::isValidBackupModel)) { "Invalid adaptive model backup" }
+        require(facets.all(::isValidBackupFacet)) { "Invalid preference facet backup" }
+        require(exposures.size <= MAX_EXPOSURES && exposures.all(::isValidBackupExposure)) {
+            "Invalid ranking exposure backup"
+        }
+        dao.replaceAll(models, facets, exposures)
+        RankingShadowDiagnostics.clear()
+    }
+
     suspend fun reset() {
         dao.clearAll()
     }
@@ -240,6 +271,7 @@ class AdaptiveRankingRepository private constructor(
     }
 
     companion object {
+        private const val ADAPTIVE_BACKUP_VERSION = 1
         private const val MAX_EXPOSURES = 1_000
         private const val EXPOSURE_RETENTION_MILLIS = 30L * 24L * 60L * 60L * 1_000L
 
@@ -254,6 +286,53 @@ class AdaptiveRankingRepository private constructor(
             }
         }
     }
+}
+
+private fun isValidBackupModel(model: AdaptiveModelEntity): Boolean {
+    return runCatching {
+        RankingObjective.valueOf(model.objective)
+        model.featureSchemaVersion == RankingFeatureSchema.VERSION &&
+            model.dimension == RankingFeatureSchema.dimension &&
+            model.updateCount >= 0L &&
+            RankingSerialization.decode(
+                model.covariance,
+                model.dimension * model.dimension,
+            ).all(Double::isFinite) &&
+            RankingSerialization.decode(
+                model.inverseCovariance,
+                model.dimension * model.dimension,
+            ).all(Double::isFinite) &&
+            RankingSerialization.decode(model.rewardVector, model.dimension).all(Double::isFinite)
+    }.getOrDefault(false)
+}
+
+private fun isValidBackupFacet(facet: PreferenceFacetEntity): Boolean {
+    return runCatching {
+        PreferenceFacetType.valueOf(facet.facetType)
+        facet.facetKey.isNotBlank() &&
+            facet.facetKey.length <= 200 &&
+            facet.positiveEvidence.isFinite() &&
+            facet.positiveEvidence >= 0.0 &&
+            facet.negativeEvidence.isFinite() &&
+            facet.negativeEvidence >= 0.0
+    }.getOrDefault(false)
+}
+
+private fun isValidBackupExposure(exposure: RankingExposureEntity): Boolean {
+    return runCatching {
+        RankingObjective.valueOf(exposure.objective)
+        RankingSurface.valueOf(exposure.surface)
+        CandidateSource.valueOf(exposure.source)
+        exposure.exposureId.isNotBlank() &&
+            exposure.episodeId.isNotBlank() &&
+            exposure.featureSchemaVersion == RankingFeatureSchema.VERSION &&
+            exposure.listenSeconds >= 0L &&
+            (exposure.reward == null || exposure.reward.isFinite()) &&
+            RankingSerialization.decode(
+                exposure.featureVector,
+                RankingFeatureSchema.dimension,
+            ).all(Double::isFinite)
+    }.getOrDefault(false)
 }
 
 private fun AdaptiveModelState.toEntity(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingRepository.kt
@@ -7,6 +7,7 @@ import cx.aswin.boxcast.core.data.ranking.database.PreferenceFacetEntity
 import cx.aswin.boxcast.core.data.ranking.database.RankingExposureEntity
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -51,6 +52,7 @@ class AdaptiveRankingRepository private constructor(
 ) {
     private val dao = database.adaptiveRankingDao()
     private val objectiveLocks = ConcurrentHashMap<RankingObjective, Mutex>()
+    private val exposureInsertCount = AtomicLong()
 
     suspend fun score(
         objective: RankingObjective,
@@ -87,7 +89,10 @@ class AdaptiveRankingRepository private constructor(
                 online = exposure.online,
             ),
         )
-        pruneExposures(exposure.shownAt)
+        val insertCount = exposureInsertCount.incrementAndGet()
+        if (insertCount == 1L || insertCount % EXPOSURE_PRUNE_INTERVAL == 0L) {
+            pruneExposures(exposure.shownAt)
+        }
         return exposureId
     }
 
@@ -273,6 +278,7 @@ class AdaptiveRankingRepository private constructor(
     companion object {
         private const val ADAPTIVE_BACKUP_VERSION = 1
         private const val MAX_EXPOSURES = 1_000
+        private const val EXPOSURE_PRUNE_INTERVAL = 25L
         private const val EXPOSURE_RETENTION_MILLIS = 30L * 24L * 60L * 60L * 1_000L
 
         @Volatile

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/BayesianPreferenceFacet.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/BayesianPreferenceFacet.kt
@@ -1,0 +1,60 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import kotlin.math.pow
+
+enum class PreferenceFacetType {
+    SHOW,
+    GENRE,
+    SOURCE,
+    DURATION_BUCKET,
+    TIME_CONTEXT,
+    INTENT,
+}
+
+data class BayesianPreferenceFacet(
+    val positiveEvidence: Double = 0.0,
+    val negativeEvidence: Double = 0.0,
+    val updatedAt: Long,
+) {
+    fun decayed(
+        now: Long,
+        halfLifeMillis: Long = DEFAULT_HALF_LIFE_MILLIS,
+    ): BayesianPreferenceFacet {
+        if (now <= updatedAt) return copy(updatedAt = now)
+        val elapsed = now - updatedAt
+        val factor = 2.0.pow(-elapsed.toDouble() / halfLifeMillis)
+        return copy(
+            positiveEvidence = positiveEvidence * factor,
+            negativeEvidence = negativeEvidence * factor,
+            updatedAt = now,
+        )
+    }
+
+    fun update(
+        reward: Double,
+        now: Long,
+    ): BayesianPreferenceFacet {
+        val current = decayed(now)
+        val boundedReward = reward.coerceIn(-1.0, 1.0)
+        return current.copy(
+            positiveEvidence = current.positiveEvidence + boundedReward.coerceAtLeast(0.0),
+            negativeEvidence = current.negativeEvidence + (-boundedReward).coerceAtLeast(0.0),
+        )
+    }
+
+    fun affinity(
+        now: Long,
+        priorStrength: Double = 2.0,
+    ): Double {
+        val current = decayed(now)
+        val boundedPrior = priorStrength.coerceAtLeast(0.001)
+        val alpha = boundedPrior / 2.0 + current.positiveEvidence
+        val beta = boundedPrior / 2.0 + current.negativeEvidence
+        val posterior = alpha / (alpha + beta)
+        return ((posterior - 0.5) * 2.0).coerceIn(-1.0, 1.0)
+    }
+
+    companion object {
+        const val DEFAULT_HALF_LIFE_MILLIS: Long = 90L * 24L * 60L * 60L * 1_000L
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingFeedbackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingFeedbackRepository.kt
@@ -83,11 +83,12 @@ class RankingFeedbackRepository private constructor(
         }
     }
 
-    suspend fun reset() {
-        safely("reset recommendations", Unit) {
+    suspend fun reset(): Boolean {
+        return safely("reset recommendations", false) {
             adaptiveRankingRepository?.reset()
             recentActions.clear()
             RankingShadowDiagnostics.clear()
+            adaptiveRankingRepository != null
         }
     }
 

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingFeedbackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingFeedbackRepository.kt
@@ -1,0 +1,155 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import android.content.Context
+import java.util.concurrent.ConcurrentHashMap
+
+data class FeedbackTarget(
+    val episodeId: String,
+    val podcastId: String,
+    val genre: String? = null,
+    val source: CandidateSource? = null,
+)
+
+class RankingFeedbackRepository private constructor(
+    private val adaptiveRankingRepository: AdaptiveRankingRepository,
+) {
+    private val recentActions = ConcurrentHashMap<String, Long>()
+
+    suspend fun recordExposure(exposure: RankingExposure): String {
+        return adaptiveRankingRepository.recordExposure(exposure)
+    }
+
+    suspend fun recordAction(
+        target: FeedbackTarget,
+        action: RankingAction,
+        listenSeconds: Long = 0,
+        durationSeconds: Long = 0,
+    ) {
+        if (isRecentDuplicate(target.episodeId, action)) return
+        val reward = RankingReward.calculate(
+            RankingOutcome(
+                actions = setOf(action),
+                listenSeconds = listenSeconds,
+                durationSeconds = durationSeconds,
+            ),
+        )
+        updateTasteFacets(target, reward)
+        if (action in terminalExposureActions) {
+            adaptiveRankingRepository.resolveLatestExposure(
+                episodeId = target.episodeId,
+                reward = reward,
+                listenSeconds = listenSeconds,
+            )
+        }
+    }
+
+    suspend fun recordPlayback(
+        target: FeedbackTarget,
+        listenSeconds: Long,
+        durationSeconds: Long,
+        completed: Boolean,
+        earlySkip: Boolean,
+    ) {
+        val actions = buildSet {
+            if (listenSeconds >= MEANINGFUL_PLAY_SECONDS ||
+                progressRatio(listenSeconds, durationSeconds) >= MEANINGFUL_PROGRESS_RATIO
+            ) {
+                add(RankingAction.MEANINGFUL_PLAY)
+            }
+            if (completed) add(RankingAction.COMPLETE)
+            if (earlySkip) add(RankingAction.EARLY_SKIP)
+        }
+        if (actions.isEmpty()) return
+        val reward = RankingReward.calculate(
+            RankingOutcome(
+                actions = actions,
+                listenSeconds = listenSeconds,
+                durationSeconds = durationSeconds,
+            ),
+        )
+        updateTasteFacets(target, reward)
+        adaptiveRankingRepository.resolveLatestExposure(
+            episodeId = target.episodeId,
+            reward = reward,
+            listenSeconds = listenSeconds,
+        )
+    }
+
+    suspend fun reset() {
+        adaptiveRankingRepository.reset()
+    }
+
+    private suspend fun updateTasteFacets(
+        target: FeedbackTarget,
+        reward: Double,
+    ) {
+        adaptiveRankingRepository.updateFacet(PreferenceFacetType.SHOW, target.podcastId, reward)
+        target.genre?.takeIf(String::isNotBlank)?.let { genre ->
+            adaptiveRankingRepository.updateFacet(PreferenceFacetType.GENRE, genre, reward)
+        }
+        target.source?.let { source ->
+            adaptiveRankingRepository.updateFacet(
+                PreferenceFacetType.SOURCE,
+                source.name,
+                reward,
+            )
+        }
+    }
+
+    private fun isRecentDuplicate(
+        episodeId: String,
+        action: RankingAction,
+    ): Boolean {
+        val now = System.currentTimeMillis()
+        val key = "$episodeId:${action.name}"
+        val previous = recentActions.put(key, now)
+        if (recentActions.size > MAX_RECENT_ACTIONS) {
+            recentActions.entries.removeIf { now - it.value > ACTION_DEDUP_WINDOW_MILLIS }
+        }
+        return previous != null && now - previous < ACTION_DEDUP_WINDOW_MILLIS
+    }
+
+    companion object {
+        private const val MEANINGFUL_PLAY_SECONDS = 60L
+        private const val MEANINGFUL_PROGRESS_RATIO = 0.2
+        private const val ACTION_DEDUP_WINDOW_MILLIS = 5_000L
+        private const val MAX_RECENT_ACTIONS = 500
+
+        private val terminalExposureActions = setOf(
+            RankingAction.MEANINGFUL_PLAY,
+            RankingAction.COMPLETE,
+            RankingAction.LIKE,
+            RankingAction.UNLIKE,
+            RankingAction.SUBSCRIBE,
+            RankingAction.UNSUBSCRIBE,
+            RankingAction.EXPLICIT_QUEUE,
+            RankingAction.MANUAL_DOWNLOAD,
+            RankingAction.EARLY_SKIP,
+            RankingAction.REMOVE_AUTOFILLED,
+            RankingAction.MOVE_UP,
+            RankingAction.MOVE_DOWN,
+            RankingAction.DISMISS,
+        )
+
+        @Volatile
+        private var instance: RankingFeedbackRepository? = null
+
+        fun getInstance(context: Context): RankingFeedbackRepository {
+            return instance ?: synchronized(this) {
+                instance ?: RankingFeedbackRepository(
+                    AdaptiveRankingRepository.getInstance(context.applicationContext),
+                ).also { instance = it }
+            }
+        }
+
+        fun getIfInitialized(): RankingFeedbackRepository? = instance
+
+        private fun progressRatio(
+            listenSeconds: Long,
+            durationSeconds: Long,
+        ): Double {
+            if (durationSeconds <= 0) return 0.0
+            return listenSeconds.toDouble() / durationSeconds
+        }
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingFeedbackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingFeedbackRepository.kt
@@ -77,6 +77,8 @@ class RankingFeedbackRepository private constructor(
 
     suspend fun reset() {
         adaptiveRankingRepository.reset()
+        recentActions.clear()
+        RankingShadowDiagnostics.clear()
     }
 
     private suspend fun updateTasteFacets(

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingFeedbackRepository.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingFeedbackRepository.kt
@@ -1,7 +1,9 @@
 package cx.aswin.boxcast.core.data.ranking
 
 import android.content.Context
+import android.util.Log
 import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CancellationException
 
 data class FeedbackTarget(
     val episodeId: String,
@@ -11,12 +13,14 @@ data class FeedbackTarget(
 )
 
 class RankingFeedbackRepository private constructor(
-    private val adaptiveRankingRepository: AdaptiveRankingRepository,
+    private val adaptiveRankingRepository: AdaptiveRankingRepository?,
 ) {
     private val recentActions = ConcurrentHashMap<String, Long>()
 
     suspend fun recordExposure(exposure: RankingExposure): String {
-        return adaptiveRankingRepository.recordExposure(exposure)
+        return safely("record exposure", "") {
+            adaptiveRankingRepository?.recordExposure(exposure).orEmpty()
+        }
     }
 
     suspend fun recordAction(
@@ -25,21 +29,23 @@ class RankingFeedbackRepository private constructor(
         listenSeconds: Long = 0,
         durationSeconds: Long = 0,
     ) {
-        if (isRecentDuplicate(target.episodeId, action)) return
-        val reward = RankingReward.calculate(
-            RankingOutcome(
-                actions = setOf(action),
-                listenSeconds = listenSeconds,
-                durationSeconds = durationSeconds,
-            ),
-        )
-        updateTasteFacets(target, reward)
-        if (action in terminalExposureActions) {
-            adaptiveRankingRepository.resolveLatestExposure(
-                episodeId = target.episodeId,
-                reward = reward,
-                listenSeconds = listenSeconds,
+        safely("record action", Unit) {
+            if (isRecentDuplicate(target.episodeId, action)) return@safely
+            val reward = RankingReward.calculate(
+                RankingOutcome(
+                    actions = setOf(action),
+                    listenSeconds = listenSeconds,
+                    durationSeconds = durationSeconds,
+                ),
             )
+            updateTasteFacets(target, reward)
+            if (action in terminalExposureActions) {
+                adaptiveRankingRepository?.resolveLatestExposure(
+                    episodeId = target.episodeId,
+                    reward = reward,
+                    listenSeconds = listenSeconds,
+                )
+            }
         }
     }
 
@@ -50,47 +56,52 @@ class RankingFeedbackRepository private constructor(
         completed: Boolean,
         earlySkip: Boolean,
     ) {
-        val actions = buildSet {
-            if (listenSeconds >= MEANINGFUL_PLAY_SECONDS ||
-                progressRatio(listenSeconds, durationSeconds) >= MEANINGFUL_PROGRESS_RATIO
-            ) {
-                add(RankingAction.MEANINGFUL_PLAY)
+        safely("record playback", Unit) {
+            val actions = buildSet {
+                if (listenSeconds >= MEANINGFUL_PLAY_SECONDS ||
+                    progressRatio(listenSeconds, durationSeconds) >= MEANINGFUL_PROGRESS_RATIO
+                ) {
+                    add(RankingAction.MEANINGFUL_PLAY)
+                }
+                if (completed) add(RankingAction.COMPLETE)
+                if (earlySkip) add(RankingAction.EARLY_SKIP)
             }
-            if (completed) add(RankingAction.COMPLETE)
-            if (earlySkip) add(RankingAction.EARLY_SKIP)
-        }
-        if (actions.isEmpty()) return
-        val reward = RankingReward.calculate(
-            RankingOutcome(
-                actions = actions,
+            if (actions.isEmpty()) return@safely
+            val reward = RankingReward.calculate(
+                RankingOutcome(
+                    actions = actions,
+                    listenSeconds = listenSeconds,
+                    durationSeconds = durationSeconds,
+                ),
+            )
+            updateTasteFacets(target, reward)
+            adaptiveRankingRepository?.resolveLatestExposure(
+                episodeId = target.episodeId,
+                reward = reward,
                 listenSeconds = listenSeconds,
-                durationSeconds = durationSeconds,
-            ),
-        )
-        updateTasteFacets(target, reward)
-        adaptiveRankingRepository.resolveLatestExposure(
-            episodeId = target.episodeId,
-            reward = reward,
-            listenSeconds = listenSeconds,
-        )
+            )
+        }
     }
 
     suspend fun reset() {
-        adaptiveRankingRepository.reset()
-        recentActions.clear()
-        RankingShadowDiagnostics.clear()
+        safely("reset recommendations", Unit) {
+            adaptiveRankingRepository?.reset()
+            recentActions.clear()
+            RankingShadowDiagnostics.clear()
+        }
     }
 
     private suspend fun updateTasteFacets(
         target: FeedbackTarget,
         reward: Double,
     ) {
-        adaptiveRankingRepository.updateFacet(PreferenceFacetType.SHOW, target.podcastId, reward)
+        val repository = adaptiveRankingRepository ?: return
+        repository.updateFacet(PreferenceFacetType.SHOW, target.podcastId, reward)
         target.genre?.takeIf(String::isNotBlank)?.let { genre ->
-            adaptiveRankingRepository.updateFacet(PreferenceFacetType.GENRE, genre, reward)
+            repository.updateFacet(PreferenceFacetType.GENRE, genre, reward)
         }
         target.source?.let { source ->
-            adaptiveRankingRepository.updateFacet(
+            repository.updateFacet(
                 PreferenceFacetType.SOURCE,
                 source.name,
                 reward,
@@ -111,11 +122,27 @@ class RankingFeedbackRepository private constructor(
         return previous != null && now - previous < ACTION_DEDUP_WINDOW_MILLIS
     }
 
+    private suspend fun <T> safely(
+        operation: String,
+        fallback: T,
+        block: suspend () -> T,
+    ): T {
+        return try {
+            block()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            Log.e(TAG, "Failed to $operation", error)
+            fallback
+        }
+    }
+
     companion object {
         private const val MEANINGFUL_PLAY_SECONDS = 60L
         private const val MEANINGFUL_PROGRESS_RATIO = 0.2
         private const val ACTION_DEDUP_WINDOW_MILLIS = 5_000L
         private const val MAX_RECENT_ACTIONS = 500
+        private const val TAG = "RankingFeedback"
 
         private val terminalExposureActions = setOf(
             RankingAction.MEANINGFUL_PLAY,
@@ -139,7 +166,11 @@ class RankingFeedbackRepository private constructor(
         fun getInstance(context: Context): RankingFeedbackRepository {
             return instance ?: synchronized(this) {
                 instance ?: RankingFeedbackRepository(
-                    AdaptiveRankingRepository.getInstance(context.applicationContext),
+                    runCatching {
+                        AdaptiveRankingRepository.getInstance(context.applicationContext)
+                    }.onFailure { error ->
+                        Log.e(TAG, "Failed to initialize adaptive ranking", error)
+                    }.getOrNull(),
                 ).also { instance = it }
             }
         }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingModels.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingModels.kt
@@ -1,0 +1,204 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import kotlin.math.exp
+import kotlin.math.max
+import kotlin.math.min
+
+enum class RankingObjective(
+    val allowsExploration: Boolean,
+) {
+    YOUR_SHOWS(allowsExploration = false),
+    DISCOVERY(allowsExploration = true),
+    CONTINUATION(allowsExploration = true),
+    OFFLINE(allowsExploration = false),
+    SLATE(allowsExploration = true),
+}
+
+enum class RankingSurface {
+    HOME,
+    EXPLORE,
+    LIBRARY,
+    QUEUE,
+    DOWNLOADS,
+    ANDROID_AUTO,
+}
+
+enum class CandidateSource {
+    SUBSCRIPTION,
+    LOCAL_HISTORY,
+    SERVER_RECOMMENDATION,
+    CURATED_INTENT,
+    TRENDING,
+    LIKED,
+    DOWNLOADED,
+}
+
+enum class FeatureSlot {
+    INTERCEPT,
+    SHOW_AFFINITY,
+    GENRE_AFFINITY,
+    SOURCE_AFFINITY,
+    FRESHNESS,
+    NOVELTY,
+    DURATION_FIT,
+    SUBSCRIBED,
+    RESUME_PROGRESS,
+    UNPLAYED,
+    SERIAL_MATCH,
+    SERVER_RELEVANCE,
+    EXPOSURE_FATIGUE,
+    TIME_CONTEXT,
+    OFFLINE_SUITABILITY,
+    EXPLICIT_PREFERENCE,
+    RECENT_SUBSCRIPTION,
+    CURRENT_SHOW,
+}
+
+object RankingFeatureSchema {
+    const val VERSION = 1
+    val dimension: Int = FeatureSlot.entries.size
+}
+
+data class CandidateSignals(
+    val showAffinity: Double = 0.0,
+    val genreAffinity: Double = 0.0,
+    val sourceAffinity: Double = 0.0,
+    val ageHours: Double? = null,
+    val isUnseenShow: Boolean = false,
+    val durationFit: Double = 0.5,
+    val isSubscribed: Boolean = false,
+    val progressRatio: Double = 0.0,
+    val isUnplayed: Boolean = true,
+    val serialMatch: Double = 0.5,
+    val serverRelevance: Double = 0.0,
+    val recentExposureCount: Int = 0,
+    val timeContextMatch: Double = 0.5,
+    val offlineSuitability: Double = 0.5,
+    val explicitPreference: Double = 0.0,
+    val hoursSinceSubscription: Double? = null,
+    val isCurrentShow: Boolean = false,
+)
+
+data class RankingFeatures(
+    val schemaVersion: Int = RankingFeatureSchema.VERSION,
+    val values: DoubleArray,
+) {
+    init {
+        require(values.size == RankingFeatureSchema.dimension) {
+            "Expected ${RankingFeatureSchema.dimension} ranking features, got ${values.size}"
+        }
+        require(values.all(Double::isFinite)) { "Ranking features must be finite" }
+    }
+}
+
+object CandidateFeatureBuilder {
+    fun build(signals: CandidateSignals): RankingFeatures {
+        val values = DoubleArray(RankingFeatureSchema.dimension)
+        values[FeatureSlot.INTERCEPT.ordinal] = 1.0
+        values[FeatureSlot.SHOW_AFFINITY.ordinal] = signals.showAffinity.unit()
+        values[FeatureSlot.GENRE_AFFINITY.ordinal] = signals.genreAffinity.unit()
+        values[FeatureSlot.SOURCE_AFFINITY.ordinal] = signals.sourceAffinity.unit()
+        values[FeatureSlot.FRESHNESS.ordinal] = signals.ageHours
+            ?.coerceAtLeast(0.0)
+            ?.let { exp(-it / (24.0 * 14.0)) }
+            ?: 0.0
+        values[FeatureSlot.NOVELTY.ordinal] = signals.isUnseenShow.asUnit()
+        values[FeatureSlot.DURATION_FIT.ordinal] = signals.durationFit.unit()
+        values[FeatureSlot.SUBSCRIBED.ordinal] = signals.isSubscribed.asUnit()
+        values[FeatureSlot.RESUME_PROGRESS.ordinal] = signals.progressRatio.unit()
+        values[FeatureSlot.UNPLAYED.ordinal] = signals.isUnplayed.asUnit()
+        values[FeatureSlot.SERIAL_MATCH.ordinal] = signals.serialMatch.unit()
+        values[FeatureSlot.SERVER_RELEVANCE.ordinal] = signals.serverRelevance.unit()
+        values[FeatureSlot.EXPOSURE_FATIGUE.ordinal] =
+            -(1.0 - exp(-signals.recentExposureCount.coerceAtLeast(0) / 3.0))
+        values[FeatureSlot.TIME_CONTEXT.ordinal] = signals.timeContextMatch.unit()
+        values[FeatureSlot.OFFLINE_SUITABILITY.ordinal] = signals.offlineSuitability.unit()
+        values[FeatureSlot.EXPLICIT_PREFERENCE.ordinal] = signals.explicitPreference.coerceIn(-1.0, 1.0)
+        values[FeatureSlot.RECENT_SUBSCRIPTION.ordinal] = signals.hoursSinceSubscription
+            ?.coerceAtLeast(0.0)
+            ?.let { exp(-it / (24.0 * 14.0)) }
+            ?: 0.0
+        values[FeatureSlot.CURRENT_SHOW.ordinal] = signals.isCurrentShow.asUnit()
+        return RankingFeatures(values = values)
+    }
+}
+
+data class RankingScore(
+    val finalScore: Double,
+    val priorScore: Double,
+    val learnedScore: Double,
+    val explorationBonus: Double,
+    val learnedBlend: Double,
+    val updateCount: Long,
+    val contributions: Map<FeatureSlot, Double>,
+)
+
+data class RankedCandidate<T>(
+    val value: T,
+    val episodeId: String,
+    val podcastId: String,
+    val genre: String?,
+    val score: Double,
+    val isNovel: Boolean = false,
+)
+
+data class DiversityPolicy(
+    val limit: Int,
+    val maxPerShow: Int = 2,
+    val genreRepeatPenalty: Double = 0.08,
+    val recentPodcastIds: Set<String> = emptySet(),
+    val recentShowPenalty: Double = 0.12,
+    val reserveNovelSlot: Boolean = false,
+)
+
+object DiversityReranker {
+    fun <T> rerank(
+        candidates: List<RankedCandidate<T>>,
+        policy: DiversityPolicy,
+    ): List<RankedCandidate<T>> {
+        if (policy.limit <= 0) return emptyList()
+        val remaining = candidates.distinctBy { it.episodeId }.toMutableList()
+        val selected = mutableListOf<RankedCandidate<T>>()
+        val showCounts = mutableMapOf<String, Int>()
+        val genreCounts = mutableMapOf<String, Int>()
+
+        while (selected.size < policy.limit && remaining.isNotEmpty()) {
+            val best = remaining
+                .asSequence()
+                .filter { (showCounts[it.podcastId] ?: 0) < policy.maxPerShow }
+                .maxByOrNull { candidate ->
+                    val normalizedGenre = candidate.genre?.trim()?.lowercase().orEmpty()
+                    val genrePenalty = (genreCounts[normalizedGenre] ?: 0) * policy.genreRepeatPenalty
+                    val recentPenalty = if (candidate.podcastId in policy.recentPodcastIds) {
+                        policy.recentShowPenalty
+                    } else {
+                        0.0
+                    }
+                    candidate.score - genrePenalty - recentPenalty
+                }
+                ?: break
+            selected += best
+            remaining.remove(best)
+            showCounts[best.podcastId] = (showCounts[best.podcastId] ?: 0) + 1
+            val genre = best.genre?.trim()?.lowercase().orEmpty()
+            if (genre.isNotEmpty()) genreCounts[genre] = (genreCounts[genre] ?: 0) + 1
+        }
+
+        if (policy.reserveNovelSlot && selected.none { it.isNovel }) {
+            val novel = candidates
+                .asSequence()
+                .filter { it.isNovel && selected.none { selectedItem -> selectedItem.episodeId == it.episodeId } }
+                .filter { (showCounts[it.podcastId] ?: 0) < policy.maxPerShow }
+                .maxByOrNull { it.score }
+            if (novel != null) {
+                if (selected.size >= policy.limit) selected.removeAt(selected.lastIndex)
+                selected += novel
+            }
+        }
+        return selected
+    }
+}
+
+private fun Double.unit(): Double = min(1.0, max(0.0, this))
+
+private fun Boolean.asUnit(): Double = if (this) 1.0 else 0.0

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingModels.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingModels.kt
@@ -130,7 +130,7 @@ data class RankingScore(
     val explorationBonus: Double,
     val learnedBlend: Double,
     val updateCount: Long,
-    val contributions: Map<FeatureSlot, Double>,
+    val contributions: Lazy<Map<FeatureSlot, Double>>,
 )
 
 data class RankedCandidate<T>(
@@ -200,15 +200,29 @@ private class DiversitySelectionState<T>(
             .asSequence()
             .filter { it.isNovel }
             .filter { novel -> selected.none { it.episodeId == novel.episodeId } }
-            .filter(::isWithinShowCap)
+            .filter(::isWithinShowCapAfterEviction)
             .maxByOrNull { it.score }
             ?: return
-        if (selected.size >= policy.limit) selected.removeAt(selected.lastIndex)
-        selected += novel
+        if (selected.size >= policy.limit) removeLastSelected()
+        select(novel)
     }
 
     private fun isWithinShowCap(candidate: RankedCandidate<T>): Boolean {
         return (showCounts[candidate.podcastId] ?: 0) < policy.maxPerShow
+    }
+
+    private fun isWithinShowCapAfterEviction(candidate: RankedCandidate<T>): Boolean {
+        val evicted = selected.lastOrNull().takeIf { selected.size >= policy.limit }
+        val countAfterEviction = (showCounts[candidate.podcastId] ?: 0) -
+            if (evicted?.podcastId == candidate.podcastId) 1 else 0
+        return countAfterEviction < policy.maxPerShow
+    }
+
+    private fun removeLastSelected() {
+        val evicted = selected.removeAt(selected.lastIndex)
+        showCounts.decrement(evicted.podcastId)
+        evicted.normalizedGenre().takeIf(String::isNotEmpty)?.let(genreCounts::decrement)
+        if (remaining.none { it.episodeId == evicted.episodeId }) remaining += evicted
     }
 
     private fun adjustedScore(candidate: RankedCandidate<T>): Double {
@@ -219,6 +233,11 @@ private class DiversitySelectionState<T>(
         } ?: 0.0
         return candidate.score - genrePenalty - recentPenalty
     }
+}
+
+private fun MutableMap<String, Int>.decrement(key: String) {
+    val next = (this[key] ?: 1) - 1
+    if (next <= 0) remove(key) else this[key] = next
 }
 
 private fun <T> RankedCandidate<T>.normalizedGenre(): String {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingModels.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingModels.kt
@@ -157,46 +157,72 @@ object DiversityReranker {
         policy: DiversityPolicy,
     ): List<RankedCandidate<T>> {
         if (policy.limit <= 0) return emptyList()
-        val remaining = candidates.distinctBy { it.episodeId }.toMutableList()
-        val selected = mutableListOf<RankedCandidate<T>>()
-        val showCounts = mutableMapOf<String, Int>()
-        val genreCounts = mutableMapOf<String, Int>()
-
-        while (selected.size < policy.limit && remaining.isNotEmpty()) {
-            val best = remaining
-                .asSequence()
-                .filter { (showCounts[it.podcastId] ?: 0) < policy.maxPerShow }
-                .maxByOrNull { candidate ->
-                    val normalizedGenre = candidate.genre?.trim()?.lowercase().orEmpty()
-                    val genrePenalty = (genreCounts[normalizedGenre] ?: 0) * policy.genreRepeatPenalty
-                    val recentPenalty = if (candidate.podcastId in policy.recentPodcastIds) {
-                        policy.recentShowPenalty
-                    } else {
-                        0.0
-                    }
-                    candidate.score - genrePenalty - recentPenalty
-                }
-                ?: break
-            selected += best
-            remaining.remove(best)
-            showCounts[best.podcastId] = (showCounts[best.podcastId] ?: 0) + 1
-            val genre = best.genre?.trim()?.lowercase().orEmpty()
-            if (genre.isNotEmpty()) genreCounts[genre] = (genreCounts[genre] ?: 0) + 1
+        val state = DiversitySelectionState(candidates, policy)
+        while (state.canSelectMore()) {
+            val next = state.nextCandidate() ?: break
+            state.select(next)
         }
-
-        if (policy.reserveNovelSlot && selected.none { it.isNovel }) {
-            val novel = candidates
-                .asSequence()
-                .filter { it.isNovel && selected.none { selectedItem -> selectedItem.episodeId == it.episodeId } }
-                .filter { (showCounts[it.podcastId] ?: 0) < policy.maxPerShow }
-                .maxByOrNull { it.score }
-            if (novel != null) {
-                if (selected.size >= policy.limit) selected.removeAt(selected.lastIndex)
-                selected += novel
-            }
-        }
-        return selected
+        state.reserveNovelCandidate()
+        return state.selected
     }
+}
+
+private class DiversitySelectionState<T>(
+    private val candidates: List<RankedCandidate<T>>,
+    private val policy: DiversityPolicy,
+) {
+    val selected = mutableListOf<RankedCandidate<T>>()
+    private val remaining = candidates.distinctBy { it.episodeId }.toMutableList()
+    private val showCounts = mutableMapOf<String, Int>()
+    private val genreCounts = mutableMapOf<String, Int>()
+
+    fun canSelectMore(): Boolean = selected.size < policy.limit && remaining.isNotEmpty()
+
+    fun nextCandidate(): RankedCandidate<T>? {
+        return remaining
+            .asSequence()
+            .filter(::isWithinShowCap)
+            .maxByOrNull(::adjustedScore)
+    }
+
+    fun select(candidate: RankedCandidate<T>) {
+        selected += candidate
+        remaining.remove(candidate)
+        showCounts[candidate.podcastId] = (showCounts[candidate.podcastId] ?: 0) + 1
+        candidate.normalizedGenre().takeIf(String::isNotEmpty)?.let { genre ->
+            genreCounts[genre] = (genreCounts[genre] ?: 0) + 1
+        }
+    }
+
+    fun reserveNovelCandidate() {
+        if (!policy.reserveNovelSlot || selected.any { it.isNovel }) return
+        val novel = candidates
+            .asSequence()
+            .filter { it.isNovel }
+            .filter { novel -> selected.none { it.episodeId == novel.episodeId } }
+            .filter(::isWithinShowCap)
+            .maxByOrNull { it.score }
+            ?: return
+        if (selected.size >= policy.limit) selected.removeAt(selected.lastIndex)
+        selected += novel
+    }
+
+    private fun isWithinShowCap(candidate: RankedCandidate<T>): Boolean {
+        return (showCounts[candidate.podcastId] ?: 0) < policy.maxPerShow
+    }
+
+    private fun adjustedScore(candidate: RankedCandidate<T>): Double {
+        val genrePenalty =
+            (genreCounts[candidate.normalizedGenre()] ?: 0) * policy.genreRepeatPenalty
+        val recentPenalty = policy.recentShowPenalty.takeIf {
+            candidate.podcastId in policy.recentPodcastIds
+        } ?: 0.0
+        return candidate.score - genrePenalty - recentPenalty
+    }
+}
+
+private fun <T> RankedCandidate<T>.normalizedGenre(): String {
+    return genre?.trim()?.lowercase().orEmpty()
 }
 
 private fun Double.unit(): Double = min(1.0, max(0.0, this))

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingReward.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingReward.kt
@@ -1,0 +1,66 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import kotlin.math.ln
+
+enum class RankingAction {
+    OPEN_DETAILS,
+    MEANINGFUL_PLAY,
+    COMPLETE,
+    LIKE,
+    UNLIKE,
+    SUBSCRIBE,
+    UNSUBSCRIBE,
+    EXPLICIT_QUEUE,
+    MANUAL_DOWNLOAD,
+    EARLY_SKIP,
+    REMOVE_AUTOFILLED,
+    MOVE_UP,
+    MOVE_DOWN,
+    DISMISS,
+}
+
+data class RankingOutcome(
+    val actions: Set<RankingAction> = emptySet(),
+    val listenSeconds: Long = 0,
+    val durationSeconds: Long = 0,
+)
+
+object RankingReward {
+    private val actionWeights = mapOf(
+        RankingAction.OPEN_DETAILS to 0.08,
+        RankingAction.MEANINGFUL_PLAY to 0.22,
+        RankingAction.COMPLETE to 0.35,
+        RankingAction.LIKE to 0.65,
+        RankingAction.UNLIKE to -0.5,
+        RankingAction.SUBSCRIBE to 0.8,
+        RankingAction.UNSUBSCRIBE to -0.7,
+        RankingAction.EXPLICIT_QUEUE to 0.55,
+        RankingAction.MANUAL_DOWNLOAD to 0.55,
+        RankingAction.EARLY_SKIP to -0.7,
+        RankingAction.REMOVE_AUTOFILLED to -0.8,
+        RankingAction.MOVE_UP to 0.25,
+        RankingAction.MOVE_DOWN to -0.25,
+        RankingAction.DISMISS to -0.75,
+    )
+
+    fun calculate(outcome: RankingOutcome): Double {
+        val actionReward = outcome.actions.sumOf { actionWeights[it] ?: 0.0 }
+        val listenReward = listeningValue(outcome.listenSeconds, outcome.durationSeconds)
+        return (actionReward + listenReward).coerceIn(-1.0, 1.0)
+    }
+
+    private fun listeningValue(
+        listenSeconds: Long,
+        durationSeconds: Long,
+    ): Double {
+        if (listenSeconds <= 0) return 0.0
+        val absoluteValue = (ln(1.0 + listenSeconds.coerceAtMost(3_600)) / ln(3_601.0)) * 0.2
+        val progressValue = if (durationSeconds > 0) {
+            (listenSeconds.toDouble() / durationSeconds)
+                .coerceIn(0.0, 1.0) * 0.2
+        } else {
+            0.0
+        }
+        return absoluteValue + progressValue
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingRuntimeControls.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingRuntimeControls.kt
@@ -12,15 +12,28 @@ data class RankingShadowSnapshot(
     val recordedAt: Long,
 )
 
+object RankingRolloutPolicy {
+    fun isEnabledByDefault(surface: RankingSurface): Boolean {
+        return surface == RankingSurface.HOME
+    }
+}
+
 class RankingRuntimeControls private constructor(context: Context) {
     private val preferences = context.applicationContext.getSharedPreferences(
         PREFERENCES_NAME,
         Context.MODE_PRIVATE,
     )
 
-    fun isAdaptiveEnabled(objective: RankingObjective): Boolean {
+    fun isAdaptiveEnabled(
+        objective: RankingObjective,
+        surface: RankingSurface,
+    ): Boolean {
         return preferences.getBoolean(ADAPTIVE_ENABLED, true) &&
-            preferences.getBoolean(objectiveKey(objective), true)
+            preferences.getBoolean(objectiveKey(objective), true) &&
+            preferences.getBoolean(
+                surfaceKey(surface),
+                RankingRolloutPolicy.isEnabledByDefault(surface),
+            )
     }
 
     fun isShadowDiagnosticsEnabled(): Boolean {
@@ -33,6 +46,10 @@ class RankingRuntimeControls private constructor(context: Context) {
 
     fun setObjectiveEnabled(objective: RankingObjective, enabled: Boolean) {
         preferences.edit().putBoolean(objectiveKey(objective), enabled).apply()
+    }
+
+    fun setSurfaceEnabled(surface: RankingSurface, enabled: Boolean) {
+        preferences.edit().putBoolean(surfaceKey(surface), enabled).apply()
     }
 
     fun setShadowDiagnosticsEnabled(enabled: Boolean) {
@@ -55,6 +72,10 @@ class RankingRuntimeControls private constructor(context: Context) {
 
         private fun objectiveKey(objective: RankingObjective): String {
             return "objective_${objective.name.lowercase()}_enabled"
+        }
+
+        private fun surfaceKey(surface: RankingSurface): String {
+            return "surface_${surface.name.lowercase()}_enabled"
         }
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingRuntimeControls.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingRuntimeControls.kt
@@ -1,0 +1,98 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import android.content.Context
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.abs
+
+data class RankingShadowSnapshot(
+    val objective: RankingObjective,
+    val candidateCount: Int,
+    val topFiveOverlap: Int,
+    val meanAbsoluteRankShift: Double,
+    val recordedAt: Long,
+)
+
+class RankingRuntimeControls private constructor(context: Context) {
+    private val preferences = context.applicationContext.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE,
+    )
+
+    fun isAdaptiveEnabled(objective: RankingObjective): Boolean {
+        return preferences.getBoolean(ADAPTIVE_ENABLED, true) &&
+            preferences.getBoolean(objectiveKey(objective), true)
+    }
+
+    fun isShadowDiagnosticsEnabled(): Boolean {
+        return preferences.getBoolean(SHADOW_DIAGNOSTICS_ENABLED, true)
+    }
+
+    fun setAdaptiveEnabled(enabled: Boolean) {
+        preferences.edit().putBoolean(ADAPTIVE_ENABLED, enabled).apply()
+    }
+
+    fun setObjectiveEnabled(objective: RankingObjective, enabled: Boolean) {
+        preferences.edit().putBoolean(objectiveKey(objective), enabled).apply()
+    }
+
+    fun setShadowDiagnosticsEnabled(enabled: Boolean) {
+        preferences.edit().putBoolean(SHADOW_DIAGNOSTICS_ENABLED, enabled).apply()
+    }
+
+    companion object {
+        private const val PREFERENCES_NAME = "adaptive_ranking_runtime"
+        private const val ADAPTIVE_ENABLED = "adaptive_enabled"
+        private const val SHADOW_DIAGNOSTICS_ENABLED = "shadow_diagnostics_enabled"
+
+        @Volatile
+        private var instance: RankingRuntimeControls? = null
+
+        fun getInstance(context: Context): RankingRuntimeControls {
+            return instance ?: synchronized(this) {
+                instance ?: RankingRuntimeControls(context).also { instance = it }
+            }
+        }
+
+        private fun objectiveKey(objective: RankingObjective): String {
+            return "objective_${objective.name.lowercase()}_enabled"
+        }
+    }
+}
+
+object RankingShadowDiagnostics {
+    private const val TOP_K = 5
+    private val latest = ConcurrentHashMap<RankingObjective, RankingShadowSnapshot>()
+
+    fun record(
+        objective: RankingObjective,
+        priorOrder: List<String>,
+        adaptiveOrder: List<String>,
+        now: Long = System.currentTimeMillis(),
+    ) {
+        if (priorOrder.isEmpty() || adaptiveOrder.isEmpty()) return
+        val priorPositions = priorOrder.withIndex().associate { it.value to it.index }
+        val comparable = adaptiveOrder.mapIndexedNotNull { index, id ->
+            priorPositions[id]?.let { priorIndex -> abs(priorIndex - index).toDouble() }
+        }
+        val topFiveOverlap = priorOrder.take(TOP_K).toSet()
+            .intersect(adaptiveOrder.take(TOP_K).toSet())
+            .size
+        latest[objective] = RankingShadowSnapshot(
+            objective = objective,
+            candidateCount = minOf(priorOrder.size, adaptiveOrder.size),
+            topFiveOverlap = topFiveOverlap,
+            meanAbsoluteRankShift = comparable.averageOrZero(),
+            recordedAt = now,
+        )
+    }
+
+    fun snapshots(): List<RankingShadowSnapshot> {
+        return latest.values.sortedBy(RankingShadowSnapshot::objective)
+    }
+
+    fun clear() {
+        latest.clear()
+    }
+}
+
+private fun List<Double>.averageOrZero(): Double = if (isEmpty()) 0.0 else average()

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingSerialization.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/RankingSerialization.kt
@@ -1,0 +1,21 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+internal object RankingSerialization {
+    fun encode(values: DoubleArray): ByteArray {
+        return ByteBuffer.allocate(values.size * Double.SIZE_BYTES)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .apply { values.forEach(::putDouble) }
+            .array()
+    }
+
+    fun decode(bytes: ByteArray, expectedSize: Int): DoubleArray {
+        require(bytes.size == expectedSize * Double.SIZE_BYTES) {
+            "Expected ${expectedSize * Double.SIZE_BYTES} bytes, got ${bytes.size}"
+        }
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        return DoubleArray(expectedSize) { buffer.double }
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingDao.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingDao.kt
@@ -1,0 +1,89 @@
+package cx.aswin.boxcast.core.data.ranking.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+
+@Dao
+interface AdaptiveRankingDao {
+    @Query("SELECT * FROM adaptive_models WHERE objective = :objective LIMIT 1")
+    suspend fun getModel(objective: String): AdaptiveModelEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertModel(model: AdaptiveModelEntity)
+
+    @Query(
+        """
+        SELECT * FROM preference_facets
+        WHERE facetType = :facetType AND facetKey = :facetKey
+        LIMIT 1
+        """,
+    )
+    suspend fun getFacet(facetType: String, facetKey: String): PreferenceFacetEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertFacet(facet: PreferenceFacetEntity)
+
+    @Query("SELECT * FROM ranking_exposures WHERE exposureId = :exposureId LIMIT 1")
+    suspend fun getExposure(exposureId: String): RankingExposureEntity?
+
+    @Query(
+        """
+        SELECT * FROM ranking_exposures
+        WHERE episodeId = :episodeId AND resolvedAt IS NULL
+        ORDER BY shownAt DESC
+        LIMIT 1
+        """,
+    )
+    suspend fun getLatestUnresolvedExposure(episodeId: String): RankingExposureEntity?
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertExposure(exposure: RankingExposureEntity): Long
+
+    @Query(
+        """
+        UPDATE ranking_exposures
+        SET resolvedAt = :resolvedAt, reward = :reward, listenSeconds = :listenSeconds
+        WHERE exposureId = :exposureId AND resolvedAt IS NULL
+        """,
+    )
+    suspend fun resolveExposure(
+        exposureId: String,
+        resolvedAt: Long,
+        reward: Double,
+        listenSeconds: Long,
+    ): Int
+
+    @Query("DELETE FROM ranking_exposures WHERE shownAt < :cutoff")
+    suspend fun pruneExposuresBefore(cutoff: Long): Int
+
+    @Query(
+        """
+        DELETE FROM ranking_exposures
+        WHERE exposureId IN (
+            SELECT exposureId FROM ranking_exposures
+            ORDER BY shownAt DESC
+            LIMIT -1 OFFSET :keepCount
+        )
+        """,
+    )
+    suspend fun pruneExposuresToCount(keepCount: Int): Int
+
+    @Query("DELETE FROM adaptive_models")
+    suspend fun clearModels()
+
+    @Query("DELETE FROM preference_facets")
+    suspend fun clearFacets()
+
+    @Query("DELETE FROM ranking_exposures")
+    suspend fun clearExposures()
+
+    @Transaction
+    suspend fun clearAll() {
+        clearModels()
+        clearFacets()
+        clearExposures()
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingDao.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingDao.kt
@@ -11,8 +11,14 @@ interface AdaptiveRankingDao {
     @Query("SELECT * FROM adaptive_models WHERE objective = :objective LIMIT 1")
     suspend fun getModel(objective: String): AdaptiveModelEntity?
 
+    @Query("SELECT * FROM adaptive_models")
+    suspend fun getAllModels(): List<AdaptiveModelEntity>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertModel(model: AdaptiveModelEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertModels(models: List<AdaptiveModelEntity>)
 
     @Query(
         """
@@ -23,11 +29,20 @@ interface AdaptiveRankingDao {
     )
     suspend fun getFacet(facetType: String, facetKey: String): PreferenceFacetEntity?
 
+    @Query("SELECT * FROM preference_facets")
+    suspend fun getAllFacets(): List<PreferenceFacetEntity>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsertFacet(facet: PreferenceFacetEntity)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertFacets(facets: List<PreferenceFacetEntity>)
+
     @Query("SELECT * FROM ranking_exposures WHERE exposureId = :exposureId LIMIT 1")
     suspend fun getExposure(exposureId: String): RankingExposureEntity?
+
+    @Query("SELECT * FROM ranking_exposures ORDER BY shownAt DESC")
+    suspend fun getAllExposures(): List<RankingExposureEntity>
 
     @Query(
         """
@@ -41,6 +56,9 @@ interface AdaptiveRankingDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertExposure(exposure: RankingExposureEntity): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertExposures(exposures: List<RankingExposureEntity>)
 
     @Query(
         """
@@ -85,5 +103,17 @@ interface AdaptiveRankingDao {
         clearModels()
         clearFacets()
         clearExposures()
+    }
+
+    @Transaction
+    suspend fun replaceAll(
+        models: List<AdaptiveModelEntity>,
+        facets: List<PreferenceFacetEntity>,
+        exposures: List<RankingExposureEntity>,
+    ) {
+        clearAll()
+        upsertModels(models)
+        upsertFacets(facets)
+        upsertExposures(exposures)
     }
 }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingDatabase.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingDatabase.kt
@@ -1,0 +1,38 @@
+package cx.aswin.boxcast.core.data.ranking.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [
+        AdaptiveModelEntity::class,
+        PreferenceFacetEntity::class,
+        RankingExposureEntity::class,
+    ],
+    version = 1,
+    exportSchema = false,
+)
+abstract class AdaptiveRankingDatabase : RoomDatabase() {
+    abstract fun adaptiveRankingDao(): AdaptiveRankingDao
+
+    companion object {
+        private const val DATABASE_NAME = "adaptive_ranking_database"
+
+        @Volatile
+        private var instance: AdaptiveRankingDatabase? = null
+
+        fun getDatabase(context: Context): AdaptiveRankingDatabase {
+            return instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AdaptiveRankingDatabase::class.java,
+                    DATABASE_NAME,
+                ).fallbackToDestructiveMigration(dropAllTables = true)
+                    .build()
+                    .also { instance = it }
+            }
+        }
+    }
+}

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingDatabase.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingDatabase.kt
@@ -29,8 +29,7 @@ abstract class AdaptiveRankingDatabase : RoomDatabase() {
                     context.applicationContext,
                     AdaptiveRankingDatabase::class.java,
                     DATABASE_NAME,
-                ).fallbackToDestructiveMigration(dropAllTables = true)
-                    .build()
+                ).build()
                     .also { instance = it }
             }
         }

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingEntities.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/ranking/database/AdaptiveRankingEntities.kt
@@ -1,0 +1,51 @@
+package cx.aswin.boxcast.core.data.ranking.database
+
+import androidx.room.Entity
+
+@Entity(
+    tableName = "adaptive_models",
+    primaryKeys = ["objective"],
+)
+data class AdaptiveModelEntity(
+    val objective: String,
+    val featureSchemaVersion: Int,
+    val dimension: Int,
+    val covariance: ByteArray,
+    val inverseCovariance: ByteArray,
+    val rewardVector: ByteArray,
+    val updateCount: Long,
+    val updatedAt: Long,
+)
+
+@Entity(
+    tableName = "preference_facets",
+    primaryKeys = ["facetType", "facetKey"],
+)
+data class PreferenceFacetEntity(
+    val facetType: String,
+    val facetKey: String,
+    val positiveEvidence: Double,
+    val negativeEvidence: Double,
+    val updatedAt: Long,
+)
+
+@Entity(
+    tableName = "ranking_exposures",
+    primaryKeys = ["exposureId"],
+)
+data class RankingExposureEntity(
+    val exposureId: String,
+    val episodeId: String,
+    val podcastId: String,
+    val objective: String,
+    val surface: String,
+    val source: String,
+    val featureSchemaVersion: Int,
+    val featureVector: ByteArray,
+    val shownAt: Long,
+    val resolvedAt: Long?,
+    val reward: Double?,
+    val listenSeconds: Long,
+    val entryPoint: String?,
+    val online: Boolean,
+)

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -20,6 +20,8 @@ import cx.aswin.boxcast.core.data.service.auto.AutoBrowseContract
 import cx.aswin.boxcast.core.data.service.auto.AutoMediaItemFactory
 import cx.aswin.boxcast.core.data.service.auto.AutoPlayableSpec
 import cx.aswin.boxcast.core.data.playback.PlaybackSkipPolicy
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.toScorable
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -3310,8 +3312,17 @@ class BoxLorePlaybackService : MediaLibraryService() {
         private suspend fun getSubscriptionsChildren(): List<MediaItem> {
             val subscriptions = database.podcastDao().getSubscribedPodcastsList()
             android.util.Log.d("AutoBrowse", "Subscriptions: ${subscriptions.size} podcasts")
-            
-            return subscriptions.map { entity ->
+            val history = database.listeningHistoryDao().getRecentHistoryList(300)
+            val scores = adaptiveCandidateScorer.scorePodcasts(
+                podcasts = subscriptions.map { it.toScorable() },
+                history = history,
+                objective = RankingObjective.YOUR_SHOWS,
+            )
+            val rankedSubscriptions = subscriptions.sortedByDescending {
+                scores[it.podcastId] ?: 0.0
+            }
+
+            return rankedSubscriptions.map { entity ->
                 AutoMediaItemFactory.browsable(
                     id = "$SUBSCRIPTION_PREFIX${entity.podcastId}",
                     title = entity.title,

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -153,6 +153,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
     
     private var playbackSessionBufferingStartTimeMs: Long = 0L
     private var playbackSessionTotalBufferedTimeMs: Long = 0L
+    private var playbackSessionConsumedAudioMs: Long = 0L
+    private var playbackSessionLastPositionMs: Long? = null
+    private var playbackSessionLastPositionSampleMs: Long = 0L
     // Remembers the episode that was paused so a subsequent play() with no explicit source
     // (e.g. from the notification / lock screen / Bluetooth) can be attributed as a resume.
     private var lastPausedEpisodeId: String? = null
@@ -277,6 +280,8 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 reason: Int
             ) {
                 android.util.Log.d("BoxCastPlayer", "onPositionDiscontinuity: reason=$reason, from ${oldPosition.positionMs} to ${newPosition.positionMs}")
+                playbackSessionLastPositionMs = newPosition.positionMs
+                playbackSessionLastPositionSampleMs = android.os.SystemClock.elapsedRealtime()
                 if (reason == Player.DISCONTINUITY_REASON_SEEK) {
                     updateHeartbeatsForPosition(newPosition.positionMs, playbackSessionTotalDurationMs)
                     val source = cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.consumeSeekSource()
@@ -1284,6 +1289,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
         playbackSessionStartTimeMs = System.currentTimeMillis()
         playbackSessionBufferingStartTimeMs = 0L
         playbackSessionTotalBufferedTimeMs = 0L
+        playbackSessionConsumedAudioMs = 0L
+        playbackSessionLastPositionMs = mediaSession?.player?.currentPosition
+        playbackSessionLastPositionSampleMs = android.os.SystemClock.elapsedRealtime()
         playbackSessionEpisodeId = episodeId
         
         val title = currentItem?.mediaMetadata?.title?.toString()
@@ -1465,8 +1473,10 @@ class BoxLorePlaybackService : MediaLibraryService() {
     private fun endPlaybackSession(forceCompleted: Boolean = false, isTransition: Boolean = false) {
         val currentEpisodeId = playbackSessionEpisodeId
         if (playbackSessionStartTimeMs > 0 && currentEpisodeId != null) {
+            mediaSession?.player?.let(::updateConsumedAudio)
             val durationPlayedMs = System.currentTimeMillis() - playbackSessionStartTimeMs
             val durationPlayedSeconds = durationPlayedMs / 1000f
+            val consumedAudioSeconds = playbackSessionConsumedAudioMs / 1000f
             val currentPodcastId = playbackSessionPodcastId
             val currentPodcastName = playbackSessionPodcastName
             val currentPodcastGenre = playbackSessionPodcastGenre
@@ -1566,7 +1576,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 // Track skip if it's a transition skip within 30 seconds for an AUTO_FILL episode.
                 // Also feed local skip memory so the SmartQueueEngine never re-suggests it
                 // and can down-rank the podcast after repeated rejections.
-                if (isTransition && durationPlayedSeconds <= 30f && playbackSessionContextType == "AUTO_FILL") {
+                if (isTransition && consumedAudioSeconds <= 30f && playbackSessionContextType == "AUTO_FILL") {
                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackSmartQueueEpisodeSkipped(
                         episodeId = currentEpisodeId,
                         recommendationSource = playbackSessionContextSourceId ?: "unknown",
@@ -1591,7 +1601,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 else -> null
             }
             val isAdaptiveEarlySkip = isTransition &&
-                durationPlayedSeconds <= 30f &&
+                consumedAudioSeconds <= 30f &&
                 adaptiveSource != null
             serviceScope.launch {
                 rankingFeedbackRepository.recordPlayback(
@@ -1601,7 +1611,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                         genre = currentPodcastGenre,
                         source = adaptiveSource,
                     ),
-                    listenSeconds = durationPlayedSeconds.toLong().coerceAtLeast(0L),
+                    listenSeconds = consumedAudioSeconds.toLong().coerceAtLeast(0L),
                     durationSeconds = (totalDurationMs / 1_000L).coerceAtLeast(0L),
                     completed = isCompleted,
                     earlySkip = isAdaptiveEarlySkip,
@@ -1615,6 +1625,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
             playbackSessionStartTimeMs = 0L
             playbackSessionBufferingStartTimeMs = 0L
             playbackSessionTotalBufferedTimeMs = 0L
+            playbackSessionConsumedAudioMs = 0L
+            playbackSessionLastPositionMs = null
+            playbackSessionLastPositionSampleMs = 0L
             playbackSessionEpisodeId = null
             playbackSessionEpisodeTitle = null
             playbackSessionPodcastId = null
@@ -1847,6 +1860,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
         var tickCount = 0
         while (true) {
             kotlinx.coroutines.delay(1_000)
+            updateConsumedAudio(player)
             
             // Continuous Service-Level Sleep Timer Enforcement (fires even when locked in Doze mode)
             val sleepEnd = cx.aswin.boxcast.core.data.SleepTimerHolder.activeSleepTimerEndMs
@@ -1864,6 +1878,24 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 dispatchHeartbeatTelemetry(player)
             }
         }
+    }
+
+    private fun updateConsumedAudio(player: Player) {
+        val now = android.os.SystemClock.elapsedRealtime()
+        val currentPosition = player.currentPosition.coerceAtLeast(0L)
+        val previousPosition = playbackSessionLastPositionMs
+        val previousSample = playbackSessionLastPositionSampleMs
+        if (player.isPlaying && previousPosition != null && previousSample > 0L) {
+            val positionAdvance = currentPosition - previousPosition
+            val elapsed = (now - previousSample).coerceAtLeast(0L)
+            val maximumNaturalAdvance =
+                (elapsed * player.playbackParameters.speed * 1.5f).toLong() + 1_000L
+            if (positionAdvance in 0..maximumNaturalAdvance) {
+                playbackSessionConsumedAudioMs += positionAdvance
+            }
+        }
+        playbackSessionLastPositionMs = currentPosition
+        playbackSessionLastPositionSampleMs = now
     }
 
     private fun dispatchHeartbeatTelemetry(player: ExoPlayer) {

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -1154,7 +1154,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 var mixtape = cx.aswin.boxcast.core.data.MixtapeEngine.build(
                     subscriptions = subscriptions.map { it.toAutoPodcast() },
                     history = history,
-                    adaptiveScorer = adaptiveCandidateScorer,
+                    adaptiveRanking = cx.aswin.boxcast.core.data.MixtapeEngine.AdaptiveRanking(
+                        adaptiveCandidateScorer,
+                    ),
                 )
                 if (mixtape.episodes.size < 3) {
                     val recommendations = runCatching {
@@ -1172,7 +1174,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
                         subscriptions = subscriptions.map { it.toAutoPodcast() },
                         history = history,
                         recommendations = recommendations,
-                        adaptiveScorer = adaptiveCandidateScorer,
+                        adaptiveRanking = cx.aswin.boxcast.core.data.MixtapeEngine.AdaptiveRanking(
+                            adaptiveCandidateScorer,
+                        ),
                     )
                 }
                 val mixtapeImages = mixtape.podcasts.mapNotNull { podcast ->
@@ -3559,7 +3563,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
             var result = cx.aswin.boxcast.core.data.MixtapeEngine.build(
                 subscriptions = subscriptions,
                 history = history,
-                adaptiveScorer = adaptiveCandidateScorer,
+                adaptiveRanking = cx.aswin.boxcast.core.data.MixtapeEngine.AdaptiveRanking(
+                    adaptiveCandidateScorer,
+                ),
             )
             if (result.episodes.size < 3) {
                 val recommendations = runCatching {
@@ -3579,7 +3585,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     subscriptions = subscriptions,
                     history = history,
                     recommendations = recommendations,
-                    adaptiveScorer = adaptiveCandidateScorer,
+                    adaptiveRanking = cx.aswin.boxcast.core.data.MixtapeEngine.AdaptiveRanking(
+                        adaptiveCandidateScorer,
+                    ),
                 )
             }
             val episodes = result.podcasts.mapNotNull { podcast ->

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -75,6 +75,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
     private val queueSkipMemory by lazy {
         cx.aswin.boxcast.core.data.QueueSkipMemory.fromContext(this)
     }
+    private val rankingFeedbackRepository by lazy {
+        cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository.getInstance(this)
+    }
     private val smartQueueSources by lazy {
         cx.aswin.boxcast.core.data.DefaultSmartQueueSources(
             context = this,
@@ -1565,6 +1568,30 @@ class BoxLorePlaybackService : MediaLibraryService() {
                         android.util.Log.e("AutoQueue", "Failed to record skip memory", e)
                     }
                 }
+            }
+
+            val adaptiveSource = when (playbackSessionContextType) {
+                "AUTO_FILL" -> cx.aswin.boxcast.core.data.ranking.CandidateSource.SERVER_RECOMMENDATION
+                cx.aswin.boxcast.core.data.QueueMath.CONTEXT_TYPE_LORE ->
+                    cx.aswin.boxcast.core.data.ranking.CandidateSource.CURATED_INTENT
+                else -> null
+            }
+            val isAdaptiveEarlySkip = isTransition &&
+                durationPlayedSeconds <= 30f &&
+                adaptiveSource != null
+            serviceScope.launch {
+                rankingFeedbackRepository.recordPlayback(
+                    target = cx.aswin.boxcast.core.data.ranking.FeedbackTarget(
+                        episodeId = currentEpisodeId,
+                        podcastId = currentPodcastId.orEmpty(),
+                        genre = currentPodcastGenre,
+                        source = adaptiveSource,
+                    ),
+                    listenSeconds = durationPlayedSeconds.toLong().coerceAtLeast(0L),
+                    durationSeconds = (totalDurationMs / 1_000L).coerceAtLeast(0L),
+                    completed = isCompleted,
+                    earlySkip = isAdaptiveEarlySkip,
+                )
             }
             
             // Flush events immediately to prevent losses during backgrounding/shutdown

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -78,6 +78,9 @@ class BoxLorePlaybackService : MediaLibraryService() {
     private val rankingFeedbackRepository by lazy {
         cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository.getInstance(this)
     }
+    private val adaptiveCandidateScorer by lazy {
+        cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer.getInstance(this)
+    }
     private val smartQueueSources by lazy {
         cx.aswin.boxcast.core.data.DefaultSmartQueueSources(
             context = this,
@@ -91,6 +94,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
         cx.aswin.boxcast.core.data.DefaultSmartQueueEngine(
             sources = smartQueueSources,
             skipMemory = queueSkipMemory,
+            adaptiveScorer = adaptiveCandidateScorer,
         )
     }
     private val queueRepository by lazy {
@@ -1150,6 +1154,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 var mixtape = cx.aswin.boxcast.core.data.MixtapeEngine.build(
                     subscriptions = subscriptions.map { it.toAutoPodcast() },
                     history = history,
+                    adaptiveScorer = adaptiveCandidateScorer,
                 )
                 if (mixtape.episodes.size < 3) {
                     val recommendations = runCatching {
@@ -1167,6 +1172,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                         subscriptions = subscriptions.map { it.toAutoPodcast() },
                         history = history,
                         recommendations = recommendations,
+                        adaptiveScorer = adaptiveCandidateScorer,
                     )
                 }
                 val mixtapeImages = mixtape.podcasts.mapNotNull { podcast ->
@@ -3553,6 +3559,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
             var result = cx.aswin.boxcast.core.data.MixtapeEngine.build(
                 subscriptions = subscriptions,
                 history = history,
+                adaptiveScorer = adaptiveCandidateScorer,
             )
             if (result.episodes.size < 3) {
                 val recommendations = runCatching {
@@ -3572,6 +3579,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     subscriptions = subscriptions,
                     history = history,
                     recommendations = recommendations,
+                    adaptiveScorer = adaptiveCandidateScorer,
                 )
             }
             val episodes = result.podcasts.mapNotNull { podcast ->

--- a/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
+++ b/core/data/src/main/java/cx/aswin/boxcast/core/data/service/BoxLorePlaybackService.kt
@@ -1157,7 +1157,8 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     subscriptions = subscriptions.map { it.toAutoPodcast() },
                     history = history,
                     adaptiveRanking = cx.aswin.boxcast.core.data.MixtapeEngine.AdaptiveRanking(
-                        adaptiveCandidateScorer,
+                        scorer = adaptiveCandidateScorer,
+                        surface = cx.aswin.boxcast.core.data.ranking.RankingSurface.ANDROID_AUTO,
                     ),
                 )
                 if (mixtape.episodes.size < 3) {
@@ -1177,7 +1178,8 @@ class BoxLorePlaybackService : MediaLibraryService() {
                         history = history,
                         recommendations = recommendations,
                         adaptiveRanking = cx.aswin.boxcast.core.data.MixtapeEngine.AdaptiveRanking(
-                            adaptiveCandidateScorer,
+                            scorer = adaptiveCandidateScorer,
+                            surface = cx.aswin.boxcast.core.data.ranking.RankingSurface.ANDROID_AUTO,
                         ),
                     )
                 }
@@ -3317,6 +3319,7 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 podcasts = subscriptions.map { it.toScorable() },
                 history = history,
                 objective = RankingObjective.YOUR_SHOWS,
+                surface = cx.aswin.boxcast.core.data.ranking.RankingSurface.ANDROID_AUTO,
             )
             val rankedSubscriptions = subscriptions.sortedByDescending {
                 scores[it.podcastId] ?: 0.0
@@ -3575,7 +3578,8 @@ class BoxLorePlaybackService : MediaLibraryService() {
                 subscriptions = subscriptions,
                 history = history,
                 adaptiveRanking = cx.aswin.boxcast.core.data.MixtapeEngine.AdaptiveRanking(
-                    adaptiveCandidateScorer,
+                    scorer = adaptiveCandidateScorer,
+                    surface = cx.aswin.boxcast.core.data.ranking.RankingSurface.ANDROID_AUTO,
                 ),
             )
             if (result.episodes.size < 3) {
@@ -3597,7 +3601,8 @@ class BoxLorePlaybackService : MediaLibraryService() {
                     history = history,
                     recommendations = recommendations,
                     adaptiveRanking = cx.aswin.boxcast.core.data.MixtapeEngine.AdaptiveRanking(
-                        adaptiveCandidateScorer,
+                        scorer = adaptiveCandidateScorer,
+                        surface = cx.aswin.boxcast.core.data.ranking.RankingSurface.ANDROID_AUTO,
                     ),
                 )
             }

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/content/ContentOrchestratorTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/content/ContentOrchestratorTest.kt
@@ -7,10 +7,13 @@ import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.network.model.RecommendationSeedV2
 import cx.aswin.boxcast.core.network.model.RecommendationsV2Request
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class ContentOrchestratorTest {
@@ -79,6 +82,92 @@ class ContentOrchestratorTest {
     }
 
     @Test
+    fun `content section rejects an empty item list`() {
+        try {
+            ContentSection(
+                stableId = "empty",
+                intent = intent("empty"),
+                items = emptyList(),
+                utility = 0.0,
+            )
+            fail("Expected empty section to be rejected")
+        } catch (_: IllegalArgumentException) {
+            // Expected.
+        }
+    }
+
+    @Test
+    fun `ranker failure falls back to retrieval order`() = runTest {
+        val orchestrator = ContentOrchestrator(
+            providers = listOf(
+                provider(CandidateSource.SERVER_RECOMMENDATION) {
+                    listOf(
+                        candidate("low", "show-a", score = 0.2),
+                        candidate("high", "show-b", score = 0.9),
+                    )
+                },
+            ),
+            ranker = ContentCandidateRanker { _, _, _ -> error("ranking unavailable") },
+        )
+
+        val slate = orchestrator.compose(context(), catalog())
+
+        assertEquals(listOf("high", "low"), slate.sections.single().items.map(ContentCandidate::id))
+    }
+
+    @Test
+    fun `provider cancellation is never converted to an empty result`() = runTest {
+        val orchestrator = ContentOrchestrator(
+            providers = listOf(
+                provider(CandidateSource.TRENDING) {
+                    throw CancellationException("cancelled")
+                },
+            ),
+            ranker = ContentCandidateRanker { candidates, _, _ -> candidates },
+        )
+
+        try {
+            orchestrator.compose(context(), catalog())
+            fail("Expected cancellation")
+        } catch (_: CancellationException) {
+            // Expected: structured concurrency must remain cancellable.
+        }
+    }
+
+    @Test
+    fun `daily refresh policy invalidates slate on the next day`() = runTest {
+        var calls = 0
+        val dailyIntent = intent("daily", refreshPolicy = ContentRefreshPolicy.DAILY)
+        val dailyCatalog = ContentCatalogSnapshot(
+            schemaVersion = 1,
+            catalogVersion = "daily-test",
+            validUntil = Long.MAX_VALUE,
+            intents = listOf(dailyIntent),
+        )
+        val orchestrator = ContentOrchestrator(
+            providers = listOf(
+                provider(CandidateSource.TRENDING) {
+                    calls++
+                    listOf(candidate("episode-$calls", "show-$calls", score = 1.0))
+                },
+            ),
+            ranker = ContentCandidateRanker { candidates, _, _ -> candidates },
+        )
+
+        val first = orchestrator.compose(context(), dailyCatalog, now = 1)
+        val cached = orchestrator.compose(context(), dailyCatalog, now = 2)
+        val nextDay = orchestrator.compose(
+            context(),
+            dailyCatalog,
+            now = 24L * 60L * 60L * 1_000L,
+        )
+
+        assertSame(first, cached)
+        assertNotSame(first, nextDay)
+        assertEquals(2, calls)
+    }
+
+    @Test
     fun `recommendation v2 request excludes raw behavioral history`() {
         val request = RecommendationsV2Request(
             country = "us",
@@ -103,12 +192,17 @@ class ContentOrchestratorTest {
         intents = listOf(intent("discover")),
     )
 
-    private fun intent(id: String, protected: Boolean = false): ContentIntent = ContentIntent(
+    private fun intent(
+        id: String,
+        protected: Boolean = false,
+        refreshPolicy: ContentRefreshPolicy = ContentRefreshPolicy.SESSION,
+    ): ContentIntent = ContentIntent(
         id = id,
         objective = RankingObjective.DISCOVERY,
         eligibleSurfaces = setOf(RankingSurface.HOME),
         title = id,
         layout = ContentLayout.PODCAST_RAIL,
+        refreshPolicy = refreshPolicy,
         protected = protected,
     )
 

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/content/ContentOrchestratorTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/content/ContentOrchestratorTest.kt
@@ -1,9 +1,12 @@
 package cx.aswin.boxcast.core.data.content
 
+import com.google.gson.Gson
 import cx.aswin.boxcast.core.data.ranking.CandidateSource
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
 import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import cx.aswin.boxcast.core.model.Podcast
+import cx.aswin.boxcast.core.network.model.RecommendationSeedV2
+import cx.aswin.boxcast.core.network.model.RecommendationsV2Request
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
@@ -73,6 +76,24 @@ class ContentOrchestratorTest {
             listOf("duplicate", "unique"),
             slate.sections.flatMap(ContentSection::items).map(ContentCandidate::id),
         )
+    }
+
+    @Test
+    fun `recommendation v2 request excludes raw behavioral history`() {
+        val request = RecommendationsV2Request(
+            country = "us",
+            seeds = listOf(RecommendationSeedV2(kind = "episode", id = 42, weight = 0.8)),
+            subscribedPodcastIds = listOf(7),
+            excludedEpisodeIds = listOf(9),
+        )
+
+        val json = Gson().toJson(request)
+
+        assertTrue("\"contractVersion\":2" in json)
+        assertTrue("\"seeds\"" in json)
+        assertTrue("\"history\"" !in json)
+        assertTrue("\"progressMs\"" !in json)
+        assertTrue("\"isLiked\"" !in json)
     }
 
     private fun catalog(): ContentCatalogSnapshot = ContentCatalogSnapshot(

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/content/ContentOrchestratorTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/content/ContentOrchestratorTest.kt
@@ -1,0 +1,133 @@
+package cx.aswin.boxcast.core.data.content
+
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
+import cx.aswin.boxcast.core.model.Podcast
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ContentOrchestratorTest {
+    @Test
+    fun `invalid catalog resolves to generic anytime fallback`() {
+        val context = context()
+        val expired = ContentCatalogSnapshot(
+            schemaVersion = 1,
+            catalogVersion = "expired",
+            validUntil = 0,
+            intents = emptyList(),
+        )
+
+        val (version, intents) = ContentIntentResolver().resolve(expired, context, now = 1)
+
+        assertEquals("embedded-anytime-v1", version)
+        assertEquals(listOf("anytime"), intents.map(ContentIntent::id))
+    }
+
+    @Test
+    fun `provider failures are isolated and session slate is stable`() = runTest {
+        var successfulCalls = 0
+        val failing = provider(CandidateSource.TRENDING) { error("offline") }
+        val successful = provider(CandidateSource.SERVER_RECOMMENDATION) {
+            successfulCalls++
+            listOf(candidate("episode-a", "show-a", score = 0.8))
+        }
+        val orchestrator = ContentOrchestrator(
+            providers = listOf(failing, successful),
+            ranker = ContentCandidateRanker { candidates, _, _ ->
+                candidates.sortedByDescending(ContentCandidate::rankingScore)
+            },
+        )
+
+        val first = orchestrator.compose(context(), catalog())
+        val second = orchestrator.compose(context(), catalog())
+
+        assertEquals(listOf("episode-a"), first.sections.single().items.map(ContentCandidate::id))
+        assertSame(first, second)
+        assertEquals(1, successfulCalls)
+    }
+
+    @Test
+    fun `slate keeps protected sections and deduplicates across optional sections`() {
+        val protectedIntent = intent("protected", protected = true)
+        val optionalIntent = intent("optional")
+        val duplicate = candidate("duplicate", "show-a", score = 0.9)
+        val unique = candidate("unique", "show-b", score = 0.8)
+
+        val slate = SlateComposer().compose(
+            context = context(),
+            catalogVersion = "test",
+            rankedByIntent = listOf(
+                protectedIntent to listOf(duplicate),
+                optionalIntent to listOf(duplicate, unique),
+            ),
+            exposureBudget = SharedExposureBudget(),
+            now = 1,
+        )
+
+        assertTrue(slate.sections.first().intent.protected)
+        assertEquals(
+            listOf("duplicate", "unique"),
+            slate.sections.flatMap(ContentSection::items).map(ContentCandidate::id),
+        )
+    }
+
+    private fun catalog(): ContentCatalogSnapshot = ContentCatalogSnapshot(
+        schemaVersion = 1,
+        catalogVersion = "test",
+        validUntil = Long.MAX_VALUE,
+        intents = listOf(intent("discover")),
+    )
+
+    private fun intent(id: String, protected: Boolean = false): ContentIntent = ContentIntent(
+        id = id,
+        objective = RankingObjective.DISCOVERY,
+        eligibleSurfaces = setOf(RankingSurface.HOME),
+        title = id,
+        layout = ContentLayout.PODCAST_RAIL,
+        protected = protected,
+    )
+
+    private fun context(): ContentContext = ContentContext(
+        surface = RankingSurface.HOME,
+        localMinuteOfDay = 600,
+        weekday = 3,
+        daypart = ContentDaypart.MORNING,
+        region = "us",
+        isDriving = false,
+        isOnline = true,
+        availableMinutes = null,
+        currentEpisodeId = null,
+        currentPodcastId = null,
+        historyMaturity = 10,
+        subscriptionCount = 2,
+        sessionId = "session",
+    )
+
+    private fun candidate(id: String, showId: String, score: Double): ContentCandidate {
+        return ContentCandidate(
+            id = id,
+            episode = null,
+            podcast = Podcast(showId, showId, "", ""),
+            source = CandidateSource.SERVER_RECOMMENDATION,
+            intentId = "discover",
+            retrievalScore = score,
+            rankingScore = score,
+        )
+    }
+
+    private fun provider(
+        source: CandidateSource,
+        block: suspend () -> List<ContentCandidate>,
+    ): CandidateProvider = object : CandidateProvider {
+        override val source: CandidateSource = source
+
+        override suspend fun candidates(
+            intent: ContentIntent,
+            context: ContentContext,
+        ): List<ContentCandidate> = block()
+    }
+}

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
@@ -237,4 +237,12 @@ class AdaptiveRankingTest {
         assertEquals(facet, restored.facets!!.single())
         assertArrayEquals(exposure.featureVector, restored.exposures!!.single().featureVector)
     }
+
+    @Test
+    fun `adaptive rollout starts on home only`() {
+        assertTrue(RankingRolloutPolicy.isEnabledByDefault(RankingSurface.HOME))
+        RankingSurface.entries.filterNot { it == RankingSurface.HOME }.forEach { surface ->
+            assertFalse(RankingRolloutPolicy.isEnabledByDefault(surface))
+        }
+    }
 }

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
@@ -1,0 +1,174 @@
+package cx.aswin.boxcast.core.data.ranking
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AdaptiveRankingTest {
+    @Test
+    fun `feature builder returns finite bounded schema`() {
+        val features = CandidateFeatureBuilder.build(
+            CandidateSignals(
+                showAffinity = 4.0,
+                genreAffinity = -2.0,
+                ageHours = 24.0,
+                progressRatio = 2.0,
+                recentExposureCount = 20,
+                explicitPreference = -4.0,
+            ),
+        )
+
+        assertEquals(RankingFeatureSchema.dimension, features.values.size)
+        assertTrue(features.values.all(Double::isFinite))
+        assertEquals(1.0, features.values[FeatureSlot.SHOW_AFFINITY.ordinal], 0.0)
+        assertEquals(0.0, features.values[FeatureSlot.GENRE_AFFINITY.ordinal], 0.0)
+        assertEquals(-1.0, features.values[FeatureSlot.EXPLICIT_PREFERENCE.ordinal], 0.0)
+        assertTrue(features.values[FeatureSlot.EXPOSURE_FATIGUE.ordinal] < 0.0)
+    }
+
+    @Test
+    fun `cold start uses legacy prior and grows learned influence gradually`() {
+        val model = AdaptiveLinearModel()
+        val features = CandidateFeatureBuilder.build(
+            CandidateSignals(showAffinity = 1.0, ageHours = null),
+        )
+        val cold = model.score(
+            objective = RankingObjective.DISCOVERY,
+            features = features,
+            priorScore = 0.7,
+            state = AdaptiveModelState(),
+        )
+
+        assertEquals(0.7, cold.finalScore, 0.0001)
+        assertEquals(0.0, cold.learnedBlend, 0.0)
+
+        var state = AdaptiveModelState()
+        repeat(50) {
+            state = model.update(features, reward = 1.0, state = state)
+        }
+        val learned = model.score(
+            objective = RankingObjective.DISCOVERY,
+            features = features,
+            priorScore = 0.0,
+            state = state,
+        )
+        assertEquals(0.65, learned.learnedBlend, 0.0001)
+        assertTrue(learned.learnedScore > 0.0)
+        assertTrue(learned.explorationBonus > 0.0)
+    }
+
+    @Test
+    fun `offline objective never explores`() {
+        val model = AdaptiveLinearModel()
+        val features = CandidateFeatureBuilder.build(CandidateSignals(isUnseenShow = true))
+        var state = AdaptiveModelState()
+        repeat(60) {
+            state = model.update(features, reward = 0.5, state = state)
+        }
+
+        val score = model.score(RankingObjective.OFFLINE, features, 0.0, state)
+
+        assertEquals(0.0, score.explorationBonus, 0.0)
+    }
+
+    @Test
+    fun `matrix update learns opposite outcomes in opposite directions`() {
+        val model = AdaptiveLinearModel()
+        val liked = CandidateFeatureBuilder.build(CandidateSignals(showAffinity = 1.0))
+        val skipped = CandidateFeatureBuilder.build(CandidateSignals(showAffinity = 0.0))
+        var state = AdaptiveModelState()
+        repeat(30) {
+            state = model.update(liked, 1.0, state)
+            state = model.update(skipped, -1.0, state)
+        }
+
+        val likedScore = model.score(RankingObjective.YOUR_SHOWS, liked, 0.0, state)
+        val skippedScore = model.score(RankingObjective.YOUR_SHOWS, skipped, 0.0, state)
+        assertTrue(likedScore.learnedScore > skippedScore.learnedScore)
+    }
+
+    @Test
+    fun `serialization preserves doubles exactly`() {
+        val values = doubleArrayOf(-1.0, 0.0, 0.25, Math.PI)
+        val restored = RankingSerialization.decode(
+            RankingSerialization.encode(values),
+            values.size,
+        )
+
+        assertTrue(values.contentEquals(restored))
+    }
+
+    @Test
+    fun `bayesian facets decay toward neutral and learn both signs`() {
+        val day = 24L * 60L * 60L * 1_000L
+        val positive = BayesianPreferenceFacet(updatedAt = 0)
+            .update(1.0, now = day)
+        val negative = positive.update(-1.0, now = day * 2)
+
+        assertTrue(positive.affinity(day) > 0.0)
+        assertTrue(negative.affinity(day * 2) < positive.affinity(day))
+        assertTrue(
+            kotlin.math.abs(positive.affinity(day * 365)) <
+                kotlin.math.abs(positive.affinity(day)),
+        )
+    }
+
+    @Test
+    fun `reward is bounded and ignored exposure has no penalty`() {
+        assertEquals(0.0, RankingReward.calculate(RankingOutcome()), 0.0)
+        assertEquals(
+            1.0,
+            RankingReward.calculate(
+                RankingOutcome(
+                    actions = setOf(
+                        RankingAction.LIKE,
+                        RankingAction.SUBSCRIBE,
+                        RankingAction.COMPLETE,
+                    ),
+                    listenSeconds = 3_600,
+                    durationSeconds = 3_600,
+                ),
+            ),
+            0.0,
+        )
+        assertEquals(
+            -1.0,
+            RankingReward.calculate(
+                RankingOutcome(
+                    actions = setOf(
+                        RankingAction.EARLY_SKIP,
+                        RankingAction.REMOVE_AUTOFILLED,
+                    ),
+                ),
+            ),
+            0.0,
+        )
+    }
+
+    @Test
+    fun `diversity reranker removes duplicates caps shows and reserves novelty`() {
+        val candidates = listOf(
+            RankedCandidate("a", "1", "show-a", "news", 1.0),
+            RankedCandidate("duplicate", "1", "show-a", "news", 0.99),
+            RankedCandidate("b", "2", "show-a", "news", 0.9),
+            RankedCandidate("c", "3", "show-b", "news", 0.8),
+            RankedCandidate("novel", "4", "show-c", "science", 0.2, isNovel = true),
+        )
+
+        val ranked = DiversityReranker.rerank(
+            candidates,
+            DiversityPolicy(
+                limit = 3,
+                maxPerShow = 1,
+                reserveNovelSlot = true,
+            ),
+        )
+
+        assertEquals(3, ranked.size)
+        assertEquals(ranked.size, ranked.map { it.episodeId }.distinct().size)
+        assertEquals(ranked.size, ranked.map { it.podcastId }.distinct().size)
+        assertTrue(ranked.any { it.isNovel })
+        assertFalse(ranked.any { it.value == "duplicate" })
+    }
+}

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
@@ -1,5 +1,10 @@
 package cx.aswin.boxcast.core.data.ranking
 
+import com.google.gson.Gson
+import cx.aswin.boxcast.core.data.ranking.database.AdaptiveModelEntity
+import cx.aswin.boxcast.core.data.ranking.database.PreferenceFacetEntity
+import cx.aswin.boxcast.core.data.ranking.database.RankingExposureEntity
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -189,5 +194,47 @@ class AdaptiveRankingTest {
         assertEquals(3, snapshot.topFiveOverlap)
         assertEquals(2.0 / 3.0, snapshot.meanAbsoluteRankShift, 0.0001)
         assertEquals(123L, snapshot.recordedAt)
+    }
+
+    @Test
+    fun `adaptive learning backup survives json round trip`() {
+        val model = AdaptiveModelEntity(
+            objective = RankingObjective.DISCOVERY.name,
+            featureSchemaVersion = RankingFeatureSchema.VERSION,
+            dimension = RankingFeatureSchema.dimension,
+            covariance = byteArrayOf(1, 2, 3),
+            inverseCovariance = byteArrayOf(4, 5, 6),
+            rewardVector = byteArrayOf(7, 8),
+            updateCount = 42,
+            updatedAt = 100,
+        )
+        val facet = PreferenceFacetEntity("GENRE", "science", 3.0, 1.0, 101)
+        val exposure = RankingExposureEntity(
+            exposureId = "exposure",
+            episodeId = "episode",
+            podcastId = "podcast",
+            objective = RankingObjective.DISCOVERY.name,
+            surface = RankingSurface.HOME.name,
+            source = CandidateSource.SERVER_RECOMMENDATION.name,
+            featureSchemaVersion = RankingFeatureSchema.VERSION,
+            featureVector = byteArrayOf(9, 10),
+            shownAt = 102,
+            resolvedAt = null,
+            reward = null,
+            listenSeconds = 0,
+            entryPoint = "home",
+            online = true,
+        )
+        val gson = Gson()
+
+        val restored = gson.fromJson(
+            gson.toJson(AdaptiveRankingBackup(models = listOf(model), facets = listOf(facet), exposures = listOf(exposure))),
+            AdaptiveRankingBackup::class.java,
+        )
+
+        assertEquals(1, restored.version)
+        assertArrayEquals(model.covariance, restored.models!!.single().covariance)
+        assertEquals(facet, restored.facets!!.single())
+        assertArrayEquals(exposure.featureVector, restored.exposures!!.single().featureVector)
     }
 }

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
@@ -33,6 +33,34 @@ class AdaptiveRankingTest {
     }
 
     @Test
+    fun `feature schema preserves exact persisted slot order`() {
+        assertEquals(
+            listOf(
+                "INTERCEPT",
+                "SHOW_AFFINITY",
+                "GENRE_AFFINITY",
+                "SOURCE_AFFINITY",
+                "FRESHNESS",
+                "NOVELTY",
+                "DURATION_FIT",
+                "SUBSCRIBED",
+                "RESUME_PROGRESS",
+                "UNPLAYED",
+                "SERIAL_MATCH",
+                "SERVER_RELEVANCE",
+                "EXPOSURE_FATIGUE",
+                "TIME_CONTEXT",
+                "OFFLINE_SUITABILITY",
+                "EXPLICIT_PREFERENCE",
+                "RECENT_SUBSCRIPTION",
+                "CURRENT_SHOW",
+            ),
+            FeatureSlot.entries.map(FeatureSlot::name),
+        )
+        assertEquals(18, RankingFeatureSchema.dimension)
+    }
+
+    @Test
     fun `cold start uses legacy prior and grows learned influence gradually`() {
         val model = AdaptiveLinearModel()
         val features = CandidateFeatureBuilder.build(
@@ -47,6 +75,9 @@ class AdaptiveRankingTest {
 
         assertEquals(0.7, cold.finalScore, 0.0001)
         assertEquals(0.0, cold.learnedBlend, 0.0)
+        assertFalse(cold.contributions.isInitialized())
+        cold.contributions.value
+        assertTrue(cold.contributions.isInitialized())
 
         var state = AdaptiveModelState()
         repeat(50) {
@@ -175,6 +206,24 @@ class AdaptiveRankingTest {
         assertEquals(ranked.size, ranked.map { it.podcastId }.distinct().size)
         assertTrue(ranked.any { it.isNovel })
         assertFalse(ranked.any { it.value == "duplicate" })
+    }
+
+    @Test
+    fun `novel candidate can replace capped item from the same show`() {
+        val ranked = DiversityReranker.rerank(
+            candidates = listOf(
+                RankedCandidate("top", "1", "show-a", "news", 1.0),
+                RankedCandidate("evicted", "2", "show-b", "science", 0.9),
+                RankedCandidate("novel", "3", "show-b", "science", 0.1, isNovel = true),
+            ),
+            policy = DiversityPolicy(
+                limit = 2,
+                maxPerShow = 1,
+                reserveNovelSlot = true,
+            ),
+        )
+
+        assertEquals(listOf("top", "novel"), ranked.map(RankedCandidate<String>::value))
     }
 
     @Test

--- a/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
+++ b/core/data/src/test/java/cx/aswin/boxcast/core/data/ranking/AdaptiveRankingTest.kt
@@ -171,4 +171,23 @@ class AdaptiveRankingTest {
         assertTrue(ranked.any { it.isNovel })
         assertFalse(ranked.any { it.value == "duplicate" })
     }
+
+    @Test
+    fun `shadow diagnostics retain only aggregate rank movement`() {
+        RankingShadowDiagnostics.clear()
+
+        RankingShadowDiagnostics.record(
+            objective = RankingObjective.DISCOVERY,
+            priorOrder = listOf("episode-a", "episode-b", "episode-c"),
+            adaptiveOrder = listOf("episode-b", "episode-a", "episode-c"),
+            now = 123L,
+        )
+
+        val snapshot = RankingShadowDiagnostics.snapshots().single()
+        assertEquals(RankingObjective.DISCOVERY, snapshot.objective)
+        assertEquals(3, snapshot.candidateCount)
+        assertEquals(3, snapshot.topFiveOverlap)
+        assertEquals(2.0 / 3.0, snapshot.meanAbsoluteRankShift, 0.0001)
+        assertEquals(123L, snapshot.recordedAt)
+    }
 }

--- a/core/model/src/main/java/cx/aswin/boxcast/core/model/Episode.kt
+++ b/core/model/src/main/java/cx/aswin/boxcast/core/model/Episode.kt
@@ -26,5 +26,12 @@ data class Episode(
     val episodeType: String? = null,  // "full", "trailer", "bonus"
     val contextType: String? = null,
     val contextSourceId: String? = null,
-    val enclosureType: String? = null
+    val enclosureType: String? = null,
+    val retrievalScore: Double? = null,
+    val semanticScore: Double? = null,
+    val recommendationSource: String? = null,
+    val recommendationReason: String? = null,
+    val serverRank: Int? = null,
+    val recommendationAlgorithmVersion: String? = null,
+    val language: String? = null,
 )

--- a/core/network/src/main/java/cx/aswin/boxcast/core/network/BoxLoreApi.kt
+++ b/core/network/src/main/java/cx/aswin/boxcast/core/network/BoxLoreApi.kt
@@ -23,6 +23,9 @@ import cx.aswin.boxcast.core.network.model.OnboardingSimilarShowsRequest
 import cx.aswin.boxcast.core.network.model.OnboardingSelectedShowDto
 import cx.aswin.boxcast.core.network.model.BootstrapRequest
 import cx.aswin.boxcast.core.network.model.BootstrapResponse
+import cx.aswin.boxcast.core.network.model.ContentCatalogResponse
+import cx.aswin.boxcast.core.network.model.RecommendationsV2Request
+import cx.aswin.boxcast.core.network.model.RecommendationsV2Response
 import cx.aswin.boxcast.core.network.model.CuratedCuriosityResponseDto
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -144,6 +147,19 @@ interface BoxLoreApi {
         @Header("X-Device-UUID") deviceUuid: String,
         @Body request: RecommendationsRequest
     ): retrofit2.Call<EpisodesResponse>
+
+    @POST("recommendations/v2")
+    fun getPersonalizedRecommendationsV2(
+        @Header("X-App-Key") publicKey: String,
+        @Header("X-Device-UUID") deviceUuid: String,
+        @Body request: RecommendationsV2Request,
+    ): retrofit2.Call<RecommendationsV2Response>
+
+    @GET("content/catalog/v1")
+    fun getContentCatalog(
+        @Header("X-App-Key") publicKey: String,
+        @Header("If-None-Match") etag: String? = null,
+    ): retrofit2.Call<ContentCatalogResponse>
 
     @POST("recommendations/because-you-like")
     fun getBecauseYouLikeRecommendations(

--- a/core/network/src/main/java/cx/aswin/boxcast/core/network/model/PodcastIndexModels.kt
+++ b/core/network/src/main/java/cx/aswin/boxcast/core/network/model/PodcastIndexModels.kt
@@ -200,7 +200,31 @@ data class EpisodeItem(
     val episodeNumber: Int? = null,
 
     @SerialName("episodeType")
-    val episodeType: String? = null  // "full", "trailer", "bonus"
+    val episodeType: String? = null,  // "full", "trailer", "bonus"
+
+    @SerialName("genre")
+    val genre: String? = null,
+
+    @SerialName("language")
+    val language: String? = null,
+
+    @SerialName("retrievalScore")
+    val retrievalScore: Double? = null,
+
+    @SerialName("semanticScore")
+    val semanticScore: Double? = null,
+
+    @SerialName("source")
+    val recommendationSource: String? = null,
+
+    @SerialName("reason")
+    val recommendationReason: String? = null,
+
+    @SerialName("serverRank")
+    val serverRank: Int? = null,
+
+    @SerialName("algorithmVersion")
+    val algorithmVersion: String? = null,
 )
 
 // ============== SINGLE PODCAST ==============

--- a/core/network/src/main/java/cx/aswin/boxcast/core/network/model/SyncModels.kt
+++ b/core/network/src/main/java/cx/aswin/boxcast/core/network/model/SyncModels.kt
@@ -151,6 +151,7 @@ data class ContentIntentDto(
     val dayparts: List<String>,
     val providerQueryRef: String,
     val layout: String,
+    val refreshPolicy: String? = null,
     val minCandidates: Int,
     val maxCandidates: Int,
     val freshnessDays: Int,

--- a/core/network/src/main/java/cx/aswin/boxcast/core/network/model/SyncModels.kt
+++ b/core/network/src/main/java/cx/aswin/boxcast/core/network/model/SyncModels.kt
@@ -44,6 +44,46 @@ data class RecommendationsRequest(
 )
 
 @Serializable
+data class RecommendationSemanticFallback(
+    val episodeTitle: String? = null,
+    val podcastTitle: String? = null,
+    val genre: String? = null,
+    val description: String? = null,
+)
+
+@Serializable
+data class RecommendationSeedV2(
+    val kind: String,
+    val id: Long,
+    val weight: Double,
+    val fallback: RecommendationSemanticFallback? = null,
+)
+
+@Serializable
+data class RecommendationsV2Request(
+    val contractVersion: Int = 2,
+    val country: String,
+    val languages: List<String> = emptyList(),
+    val mode: String = "home",
+    val limit: Int = 60,
+    val seeds: List<RecommendationSeedV2> = emptyList(),
+    val interests: List<String> = emptyList(),
+    val subscribedPodcastIds: List<Long> = emptyList(),
+    val excludedEpisodeIds: List<Long> = emptyList(),
+    val excludedPodcastIds: List<Long> = emptyList(),
+)
+
+@Serializable
+data class RecommendationsV2Response(
+    val status: String = "false",
+    val contractVersion: Int? = null,
+    val algorithmVersion: String? = null,
+    val items: List<EpisodeItem> = emptyList(),
+    val isFallback: Boolean = false,
+    val candidateCount: Int = 0,
+)
+
+@Serializable
 data class HistoryItem(
     val podcastTitle: String,
     val episodeTitle: String,
@@ -62,7 +102,9 @@ data class BootstrapRequest(
     val country: String,
     val vibeIds: List<String>,
     val deviceUuid: String? = null,
-    val recommendationsRequest: RecommendationsRequest? = null
+    val recommendationsRequest: RecommendationsRequest? = null,
+    val contractVersion: Int? = null,
+    val intentIds: List<String> = emptyList(),
 )
 
 @Serializable
@@ -72,7 +114,71 @@ data class BootstrapResponse(
     val trending: List<TrendingFeed> = emptyList(),
     val curatedVibes: Map<String, List<TrendingFeed>> = emptyMap(),
     val recommendations: List<EpisodeItem> = emptyList(),
-    val isRecommendationsFallback: Boolean? = null
+    val isRecommendationsFallback: Boolean? = null,
+    val contractVersion: Int? = null,
+    val catalogVersion: Int? = null,
+    val intentCandidates: Map<String, List<TrendingFeed>> = emptyMap(),
+    val recommendationAlgorithmVersion: String? = null,
+)
+
+@Serializable
+data class ContentCatalogResponse(
+    val schemaVersion: Int,
+    val catalogVersion: Int,
+    val validForSeconds: Long,
+    val dayparts: List<ContentDaypartDto> = emptyList(),
+    val safeLayouts: List<String> = emptyList(),
+    val intents: List<ContentIntentDto> = emptyList(),
+    val fallbackIntent: ContentFallbackIntentDto? = null,
+)
+
+@Serializable
+data class ContentDaypartDto(
+    val id: String,
+    val startMinute: Int,
+    val endMinute: Int,
+)
+
+@Serializable
+data class ContentIntentDto(
+    val id: String,
+    val titleKey: String,
+    val titleFallback: String,
+    val subtitleKey: String,
+    val subtitleFallback: String,
+    val icon: String,
+    val surfaces: List<String>,
+    val dayparts: List<String>,
+    val providerQueryRef: String,
+    val layout: String,
+    val minCandidates: Int,
+    val maxCandidates: Int,
+    val freshnessDays: Int,
+    val durationMinutes: ContentDurationRangeDto? = null,
+    val diversity: ContentDiversityDto,
+)
+
+@Serializable
+data class ContentDurationRangeDto(
+    val min: Int,
+    val max: Int,
+)
+
+@Serializable
+data class ContentDiversityDto(
+    val maxPerShow: Int,
+    val minDistinctShows: Int,
+)
+
+@Serializable
+data class ContentFallbackIntentDto(
+    val id: String,
+    val titleKey: String,
+    val titleFallback: String,
+    val subtitleKey: String,
+    val subtitleFallback: String,
+    val icon: String,
+    val layout: String,
 )
 
 @Serializable

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreViewModel.kt
@@ -6,6 +6,11 @@ import androidx.lifecycle.viewModelScope
 import cx.aswin.boxcast.core.data.PodcastRepository
 import cx.aswin.boxcast.core.data.SearchResult
 import cx.aswin.boxcast.core.data.SubscriptionRepository
+import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
+import cx.aswin.boxcast.core.data.ranking.PodcastRankingInput
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
 import cx.aswin.boxcast.core.model.Podcast
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -64,6 +69,7 @@ class ExploreViewModel(
     initialCategory: String? = null,
     initialTab: String? = null
 ) : androidx.lifecycle.AndroidViewModel(application) {
+    private val adaptiveScorer = AdaptiveCandidateScorer.getInstance(application)
 
     private val _uiState = MutableStateFlow<ExploreUiState>(
         ExploreUiState.Success(
@@ -136,6 +142,7 @@ class ExploreViewModel(
     // Pagination State
     private var currentOffset = 0
     private val PAGE_SIZE = 20
+    private val searchTieWindow = 4
     private val _isLoadingMore = MutableStateFlow(false)
     private val _hasMorePages = MutableStateFlow(true)
 
@@ -501,7 +508,7 @@ class ExploreViewModel(
             try {
                 val searchResult = podcastRepository.searchPodcastsWithCorrection(query)
                 if (searchJob == myJob) {
-                    _searchResults.value = searchResult.podcasts
+                    _searchResults.value = rankPodcastSearchTies(searchResult.podcasts)
                     searchResult.podcasts.forEach { _seenPodcasts[it.id] = it }
                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackExploreSearchPerformed(query, searchResult.podcasts.size)
                 }
@@ -534,7 +541,7 @@ class ExploreViewModel(
                 val region = userPrefs.regionStream.first()
                 val results = podcastRepository.searchEpisodesSemantic(query, region)
                 if (semanticSearchJob == myJob) {
-                    _semanticSearchResults.value = results
+                    _semanticSearchResults.value = rankEpisodeSearchTies(results)
                     _hasPerformedSemanticSearch.value = true
                 }
             } catch (e: Exception) {
@@ -553,6 +560,53 @@ class ExploreViewModel(
         }
         semanticSearchJob = myJob
     }
+
+    private suspend fun rankPodcastSearchTies(results: List<Podcast>): List<Podcast> {
+        val history = playbackRepository.getAllHistory().first()
+        return results.chunked(searchTieWindow).flatMap { window ->
+            adaptiveScorer.rankPodcasts(
+                inputs = window.map { podcast ->
+                    PodcastRankingInput(
+                        podcast = podcast,
+                        priorScore = 1.0,
+                        source = CandidateSource.SERVER_RECOMMENDATION,
+                        isNovel = podcast.subscribedAt <= 0L,
+                    )
+                },
+                history = history,
+                objective = RankingObjective.DISCOVERY,
+            )
+        }
+    }
+
+    private suspend fun rankEpisodeSearchTies(results: List<Episode>): List<Episode> {
+        val history = playbackRepository.getAllHistory().first()
+        return results.chunked(searchTieWindow).flatMap { window ->
+            val scores = adaptiveScorer.scoreEpisodes(
+                inputs = window.map { episode ->
+                    EpisodeRankingInput(
+                        episode = episode,
+                        podcast = episode.toSearchPodcast(),
+                        priorScore = 1.0,
+                        source = CandidateSource.SERVER_RECOMMENDATION,
+                        isNovel = true,
+                    )
+                },
+                history = history,
+                objective = RankingObjective.DISCOVERY,
+            )
+            window.sortedByDescending { scores[it.id] ?: 0.0 }
+        }
+    }
+
+    private fun Episode.toSearchPodcast(): Podcast = Podcast(
+        id = podcastId.orEmpty(),
+        title = podcastTitle.orEmpty(),
+        artist = podcastArtist.orEmpty(),
+        imageUrl = podcastImageUrl ?: imageUrl.orEmpty(),
+        genre = podcastGenre.orEmpty(),
+        latestEpisode = this,
+    )
 
     fun setSearchTab(tab: SearchTab) {
         if (_searchTab.value == tab) return

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreViewModel.kt
@@ -11,6 +11,7 @@ import cx.aswin.boxcast.core.data.ranking.CandidateSource
 import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
 import cx.aswin.boxcast.core.data.ranking.PodcastRankingInput
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import cx.aswin.boxcast.core.model.Podcast
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -575,6 +576,7 @@ class ExploreViewModel(
                 },
                 history = history,
                 objective = RankingObjective.DISCOVERY,
+                surface = RankingSurface.EXPLORE,
             )
         }
     }
@@ -594,6 +596,7 @@ class ExploreViewModel(
                 },
                 history = history,
                 objective = RankingObjective.DISCOVERY,
+                surface = RankingSurface.EXPLORE,
             )
             window.sortedByDescending { scores[it.id] ?: 0.0 }
         }

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreViewModel.kt
@@ -509,20 +509,13 @@ class ExploreViewModel(
             try {
                 val searchResult = podcastRepository.searchPodcastsWithCorrection(query)
                 if (searchJob == myJob) {
-                    _searchResults.value = try {
-                        rankPodcastSearchTies(searchResult.podcasts)
-                    } catch (error: kotlinx.coroutines.CancellationException) {
-                        throw error
-                    } catch (_: Exception) {
-                        searchResult.podcasts
-                    }
+                    _searchResults.value = rankPodcastsOrOriginal(searchResult.podcasts)
                     searchResult.podcasts.forEach { _seenPodcasts[it.id] = it }
                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackExploreSearchPerformed(query, searchResult.podcasts.size)
                 }
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) {
-                    throw e
-                }
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (_: Exception) {
                 if (searchJob == myJob) {
                     _searchResults.value = emptyList()
                 }
@@ -548,19 +541,12 @@ class ExploreViewModel(
                 val region = userPrefs.regionStream.first()
                 val results = podcastRepository.searchEpisodesSemantic(query, region)
                 if (semanticSearchJob == myJob) {
-                    _semanticSearchResults.value = try {
-                        rankEpisodeSearchTies(results)
-                    } catch (error: kotlinx.coroutines.CancellationException) {
-                        throw error
-                    } catch (_: Exception) {
-                        results
-                    }
+                    _semanticSearchResults.value = rankEpisodesOrOriginal(results)
                     _hasPerformedSemanticSearch.value = true
                 }
-            } catch (e: Exception) {
-                if (e is kotlinx.coroutines.CancellationException) {
-                    throw e
-                }
+            } catch (error: kotlinx.coroutines.CancellationException) {
+                throw error
+            } catch (_: Exception) {
                 if (semanticSearchJob == myJob) {
                     _semanticSearchResults.value = emptyList()
                     _hasPerformedSemanticSearch.value = true
@@ -572,6 +558,26 @@ class ExploreViewModel(
             }
         }
         semanticSearchJob = myJob
+    }
+
+    private suspend fun rankPodcastsOrOriginal(results: List<Podcast>): List<Podcast> {
+        return try {
+            rankPodcastSearchTies(results)
+        } catch (error: kotlinx.coroutines.CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            results
+        }
+    }
+
+    private suspend fun rankEpisodesOrOriginal(results: List<Episode>): List<Episode> {
+        return try {
+            rankEpisodeSearchTies(results)
+        } catch (error: kotlinx.coroutines.CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            results
+        }
     }
 
     private suspend fun rankPodcastSearchTies(results: List<Podcast>): List<Podcast> {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/ExploreViewModel.kt
@@ -509,7 +509,13 @@ class ExploreViewModel(
             try {
                 val searchResult = podcastRepository.searchPodcastsWithCorrection(query)
                 if (searchJob == myJob) {
-                    _searchResults.value = rankPodcastSearchTies(searchResult.podcasts)
+                    _searchResults.value = try {
+                        rankPodcastSearchTies(searchResult.podcasts)
+                    } catch (error: kotlinx.coroutines.CancellationException) {
+                        throw error
+                    } catch (_: Exception) {
+                        searchResult.podcasts
+                    }
                     searchResult.podcasts.forEach { _seenPodcasts[it.id] = it }
                     cx.aswin.boxcast.core.data.analytics.AnalyticsHelper.trackExploreSearchPerformed(query, searchResult.podcasts.size)
                 }
@@ -542,7 +548,13 @@ class ExploreViewModel(
                 val region = userPrefs.regionStream.first()
                 val results = podcastRepository.searchEpisodesSemantic(query, region)
                 if (semanticSearchJob == myJob) {
-                    _semanticSearchResults.value = rankEpisodeSearchTies(results)
+                    _semanticSearchResults.value = try {
+                        rankEpisodeSearchTies(results)
+                    } catch (error: kotlinx.coroutines.CancellationException) {
+                        throw error
+                    } catch (_: Exception) {
+                        results
+                    }
                     _hasPerformedSemanticSearch.value = true
                 }
             } catch (e: Exception) {

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnScreen.kt
@@ -194,27 +194,31 @@ fun LearnScreen(
                         }
                     }
                     is LearnUiState.Success -> {
+                        val visibleCard = state.questionsStack.firstOrNull()
+                        LaunchedEffect(visibleCard?.episode?.id) {
+                            visibleCard?.let(viewModel::trackCardVisible)
+                        }
                         val handleLearnCardAction: (String, DailyCuriosityDto) -> Unit = { action, daily ->
                             val mappedEpisode = daily.episode.toEpisode()
                             when (action) {
                                 "dismiss" -> {
-                                    viewModel.trackCardDismissed()
+                                    viewModel.trackCardDismissed(daily)
                                     trackLearnCardAction("dismiss", mappedEpisode)
                                     viewModel.dismissCuriosity(daily, LearnHistoryAction.DISMISS)
                                 }
                                 "queue" -> {
-                                    viewModel.trackCardQueued()
+                                    viewModel.trackCardQueued(daily)
                                     trackLearnCardAction("queue", mappedEpisode)
                                     onQueueEpisode(mappedEpisode)
                                     viewModel.dismissCuriosity(daily, LearnHistoryAction.QUEUE)
                                 }
                                 "info" -> {
-                                    viewModel.trackInfoClicked()
+                                    viewModel.trackInfoClicked(daily)
                                     trackLearnCardAction("info", mappedEpisode)
                                     onEpisodeClick(mappedEpisode)
                                 }
                                 "play" -> {
-                                    viewModel.trackPlayClicked()
+                                    viewModel.trackPlayClicked(daily)
                                     trackLearnCardAction("play", mappedEpisode)
                                     val isCurrent = playerState.currentEpisode?.id == mappedEpisode.id
                                     if (isCurrent) {
@@ -237,7 +241,7 @@ fun LearnScreen(
                                     }
                                 }
                                 "podcast" -> {
-                                    viewModel.trackPodcastClicked()
+                                    viewModel.trackPodcastClicked(daily)
                                     trackLearnCardAction("podcast", mappedEpisode)
                                     onPodcastClick(
                                         mappedEpisode.podcastId?.toLongOrNull(),

--- a/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxcast/feature/explore/LearnViewModel.kt
@@ -4,6 +4,15 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import cx.aswin.boxcast.core.data.PodcastRepository
+import cx.aswin.boxcast.core.data.ranking.CandidateFeatureBuilder
+import cx.aswin.boxcast.core.data.ranking.CandidateSignals
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.FeedbackTarget
+import cx.aswin.boxcast.core.data.ranking.RankingAction
+import cx.aswin.boxcast.core.data.ranking.RankingExposure
+import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -43,6 +52,8 @@ class LearnViewModel(
     private var playsCount = 0
     private var podcastsClickedCount = 0
     private var infosClickedCount = 0
+    private val rankingFeedback = RankingFeedbackRepository.getInstance(application)
+    private val visibleSince = mutableMapOf<Long, Long>()
 
     fun onScreenResume() {
         applyPendingRestores()
@@ -91,24 +102,72 @@ class LearnViewModel(
         )
     }
 
-    fun trackCardDismissed() {
+    fun trackCardVisible(daily: DailyCuriosityDto) {
+        if (visibleSince.putIfAbsent(daily.episode.id, System.currentTimeMillis()) != null) return
+        viewModelScope.launch {
+            rankingFeedback.recordExposure(
+                RankingExposure(
+                    episodeId = daily.episode.id.toString(),
+                    podcastId = daily.episode.feedId?.toString().orEmpty(),
+                    objective = RankingObjective.DISCOVERY,
+                    surface = RankingSurface.EXPLORE,
+                    source = CandidateSource.CURATED_INTENT,
+                    features = CandidateFeatureBuilder.build(
+                        CandidateSignals(
+                            isUnseenShow = true,
+                            serverRelevance = (daily.curiosityScore ?: 0) / 10.0,
+                            isUnplayed = true,
+                        ),
+                    ),
+                    entryPoint = "lore",
+                    online = true,
+                ),
+            )
+        }
+    }
+
+    fun trackCardDismissed(daily: DailyCuriosityDto) {
         cardsDismissedCount++
+        val dwellMillis = System.currentTimeMillis() - (visibleSince.remove(daily.episode.id) ?: return)
+        if (dwellMillis < MEANINGFUL_LORE_DWELL_MILLIS) return
+        recordLoreAction(daily, RankingAction.DISMISS)
     }
 
-    fun trackCardQueued() {
+    fun trackCardQueued(daily: DailyCuriosityDto) {
         cardsQueuedCount++
+        visibleSince.remove(daily.episode.id)
+        recordLoreAction(daily, RankingAction.EXPLICIT_QUEUE)
     }
 
-    fun trackPlayClicked() {
+    fun trackPlayClicked(daily: DailyCuriosityDto) {
         playsCount++
+        recordLoreAction(daily, RankingAction.OPEN_DETAILS)
     }
 
-    fun trackPodcastClicked() {
+    fun trackPodcastClicked(daily: DailyCuriosityDto) {
         podcastsClickedCount++
+        recordLoreAction(daily, RankingAction.OPEN_DETAILS)
     }
 
-    fun trackInfoClicked() {
+    fun trackInfoClicked(daily: DailyCuriosityDto) {
         infosClickedCount++
+        recordLoreAction(daily, RankingAction.OPEN_DETAILS)
+    }
+
+    private fun recordLoreAction(
+        daily: DailyCuriosityDto,
+        action: RankingAction,
+    ) {
+        viewModelScope.launch {
+            rankingFeedback.recordAction(
+                target = FeedbackTarget(
+                    episodeId = daily.episode.id.toString(),
+                    podcastId = daily.episode.feedId?.toString().orEmpty(),
+                    source = CandidateSource.CURATED_INTENT,
+                ),
+                action = action,
+            )
+        }
     }
 
     private var currentPage = 1
@@ -301,5 +360,9 @@ class LearnViewModel(
                 }
             }
         }
+    }
+
+    companion object {
+        private const val MEANINGFUL_LORE_DWELL_MILLIS = 3_000L
     }
 }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items as lazyRowItems
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -42,6 +43,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
 import androidx.navigation.NavController
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -164,7 +166,7 @@ data class HomeFeedCallbacks(
     val onEpisodeClick: ((Episode, Podcast, String?) -> Unit)?,
     val onCuratedEpisodeClick: ((Episode, Podcast, String, Int) -> Unit)?,
     val onCuratedImpression: (String, List<String>) -> Unit,
-    val onAdaptiveSectionVisible: (ContentSection) -> Unit,
+    val onAdaptiveSectionVisible: (ContentSection, Set<String>) -> Unit,
     val onPlayClick: ((Podcast, android.os.Bundle?) -> Unit)?,
     val onNavigateToLibrary: (() -> Unit)?,
     val onNavigateToExplore: ((String?, String, String?) -> Unit)?,
@@ -590,7 +592,7 @@ private fun PodcastFeed(
     subscribedItems: StablePodcastList,
     timeBlock: CuratedTimeBlock?,
     adaptiveSections: StableContentSectionList,
-    onAdaptiveSectionVisible: (ContentSection) -> Unit,
+    onAdaptiveSectionVisible: (ContentSection, Set<String>) -> Unit,
     gridItems: StablePodcastList,
     selectedCategory: String?,
     currentPlayingPodcastId: String?,
@@ -965,8 +967,25 @@ private fun PodcastFeed(
                 key = "adaptive_${section.stableId}",
                 contentType = "adaptive_section",
             ) {
-                LaunchedEffect(section.stableId) {
-                    onAdaptiveSectionVisible(section)
+                val rowState = rememberLazyListState()
+                val sectionKey = "adaptive_${section.stableId}"
+                LaunchedEffect(section, gridState, rowState) {
+                    snapshotFlow {
+                        val sectionVisible = gridState.layoutInfo.visibleItemsInfo.any {
+                            it.key == sectionKey
+                        }
+                        if (sectionVisible) {
+                            rowState.layoutInfo.visibleItemsInfo
+                                .mapNotNull { it.key as? String }
+                                .toSet()
+                        } else {
+                            emptySet()
+                        }
+                    }.distinctUntilChanged().collect { visibleCandidateIds ->
+                        if (visibleCandidateIds.isNotEmpty()) {
+                            onAdaptiveSectionVisible(section, visibleCandidateIds)
+                        }
+                    }
                 }
                 Column(
                     verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -988,7 +1007,10 @@ private fun PodcastFeed(
                             )
                         }
                     }
-                    LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    LazyRow(
+                        state = rowState,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
                         lazyRowItems(
                             items = section.items,
                             key = { candidate -> candidate.id },

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items as lazyRowItems
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
@@ -78,6 +79,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Briefing
+import cx.aswin.boxcast.core.data.content.ContentSection
 import cx.aswin.boxcast.feature.home.components.DailyBriefingCard
 
 import androidx.compose.material.icons.Icons
@@ -111,6 +113,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.CircleShape
 
 import cx.aswin.boxcast.feature.home.components.HeroCarousel
+import cx.aswin.boxcast.feature.home.components.CuratedEpisodeCard
 import cx.aswin.boxcast.feature.home.components.PodcastCard
 import cx.aswin.boxcast.feature.home.components.timeBlockItems
 import cx.aswin.boxcast.feature.home.CuratedTimeBlock
@@ -128,6 +131,9 @@ data class StablePodcastList(val list: List<Podcast>)
 
 @androidx.compose.runtime.Stable
 data class StableEpisodeList(val list: List<Episode>)
+
+@androidx.compose.runtime.Stable
+data class StableContentSectionList(val list: List<ContentSection>)
 
 @androidx.compose.runtime.Stable
 data class StablePlaybackStateMap(val map: Map<String, Pair<EpisodeStatus, Float>>)
@@ -158,6 +164,7 @@ data class HomeFeedCallbacks(
     val onEpisodeClick: ((Episode, Podcast, String?) -> Unit)?,
     val onCuratedEpisodeClick: ((Episode, Podcast, String, Int) -> Unit)?,
     val onCuratedImpression: (String, List<String>) -> Unit,
+    val onAdaptiveSectionVisible: (ContentSection) -> Unit,
     val onPlayClick: ((Podcast, android.os.Bundle?) -> Unit)?,
     val onNavigateToLibrary: (() -> Unit)?,
     val onNavigateToExplore: ((String?, String, String?) -> Unit)?,
@@ -302,6 +309,7 @@ fun HomeRoute(
                 onEpisodeClick = onEpisodeClick,
                 onCuratedEpisodeClick = onCuratedEpisodeClick,
                 onCuratedImpression = viewModel::trackCuratedImpressionOnce,
+                onAdaptiveSectionVisible = viewModel::trackAdaptiveSectionVisible,
                 onPlayClick = onPlayClick,
                 onNavigateToLibrary = onNavigateToLibrary,
                 onNavigateToExplore = onNavigateToExplore,
@@ -392,6 +400,8 @@ private fun HomeScreenFeedContent(
         latestItems = StablePodcastList(uiState.latestEpisodes),
         subscribedItems = StablePodcastList(uiState.subscribedPodcasts),
         timeBlock = uiState.timeBlock,
+        adaptiveSections = StableContentSectionList(uiState.adaptiveSections),
+        onAdaptiveSectionVisible = callbacks.onAdaptiveSectionVisible,
         briefing = uiState.briefing,
         briefingChapters = uiState.briefingChapters,
         gridItems = StablePodcastList(uiState.discoverPodcasts),
@@ -579,6 +589,8 @@ private fun PodcastFeed(
     latestItems: StablePodcastList,
     subscribedItems: StablePodcastList,
     timeBlock: CuratedTimeBlock?,
+    adaptiveSections: StableContentSectionList,
+    onAdaptiveSectionVisible: (ContentSection) -> Unit,
     gridItems: StablePodcastList,
     selectedCategory: String?,
     currentPlayingPodcastId: String?,
@@ -944,6 +956,79 @@ private fun PodcastFeed(
                     showTasteHeader = hasBecauseYouLike,
                     isFallback = isRecommendationsFallback
                 )
+            }
+        }
+
+        adaptiveSections.list.forEach { section ->
+            item(
+                span = StaggeredGridItemSpan.FullLine,
+                key = "adaptive_${section.stableId}",
+                contentType = "adaptive_section",
+            ) {
+                LaunchedEffect(section.stableId) {
+                    onAdaptiveSectionVisible(section)
+                }
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    modifier = Modifier.padding(bottom = 12.dp),
+                ) {
+                    Column {
+                        Text(
+                            text = section.intent.title,
+                            style = MaterialTheme.typography.headlineSmall.copy(
+                                fontFamily = SectionHeaderFontFamily,
+                                fontWeight = FontWeight.Bold,
+                            ),
+                        )
+                        section.intent.subtitle?.let { subtitle ->
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                    LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        lazyRowItems(
+                            items = section.items,
+                            key = { candidate -> candidate.id },
+                        ) { candidate ->
+                            val episode = candidate.episode
+                            val onCandidateClick: () -> Unit = {
+                                if (episode == null) {
+                                        onPodcastClick(
+                                            candidate.podcast,
+                                            "home_adaptive_${section.intent.id}",
+                                            null,
+                                            null,
+                                        )
+                                } else {
+                                    onEpisodeClick?.invoke(
+                                        episode,
+                                        candidate.podcast,
+                                        "home_adaptive_${section.intent.id}",
+                                    )
+                                }
+                                Unit
+                            }
+                            if (episode == null) {
+                                PodcastCard(
+                                    podcast = candidate.podcast,
+                                    onClick = onCandidateClick,
+                                    modifier = Modifier.width(156.dp),
+                                    showGenreChip = false,
+                                )
+                            } else {
+                                CuratedEpisodeCard(
+                                    podcast = candidate.podcast,
+                                    episode = episode,
+                                    onClick = onCandidateClick,
+                                    modifier = Modifier.width(156.dp),
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -1139,6 +1139,7 @@ class HomeViewModel(
                             },
                             history = allHistory,
                             objective = RankingObjective.DISCOVERY,
+                            surface = RankingSurface.HOME,
                             diversityPolicy = DiversityPolicy(
                                 limit = wrapper.trending.size,
                                 maxPerShow = 1,
@@ -1158,6 +1159,7 @@ class HomeViewModel(
                             },
                             history = allHistory,
                             objective = RankingObjective.DISCOVERY,
+                            surface = RankingSurface.HOME,
                             diversityPolicy = DiversityPolicy(
                                 limit = wrapper.recommendations.size,
                                 maxPerShow = 2,
@@ -1397,6 +1399,7 @@ class HomeViewModel(
                                 podcasts = subs.map { it.toScorable() },
                                 history = allHistory,
                                 objective = RankingObjective.YOUR_SHOWS,
+                                surface = RankingSurface.HOME,
                             )
                         } else {
                             emptyMap()
@@ -1466,7 +1469,10 @@ class HomeViewModel(
                                 resolvedSerialEpisodes = _resolvedSerialEpisodes.value,
                                 recommendations = rankedRecommendations,
                                 podcastScores = podScoresMap,
-                                adaptiveRanking = MixtapeEngine.AdaptiveRanking(adaptiveScorer),
+                                adaptiveRanking = MixtapeEngine.AdaptiveRanking(
+                                    scorer = adaptiveScorer,
+                                    surface = RankingSurface.HOME,
+                                ),
                             )
                             mixtapePodcasts = result.podcasts
                             mixtapeCount = result.unplayedCount
@@ -1859,6 +1865,7 @@ class HomeViewModel(
                 },
                 history = history,
                 objective = RankingObjective.SLATE,
+                surface = RankingSurface.HOME,
                 diversityPolicy = DiversityPolicy(
                     limit = 10,
                     maxPerShow = 1,
@@ -2252,11 +2259,13 @@ class HomeViewModel(
             podcastInputs,
             history,
             RankingObjective.DISCOVERY,
+            RankingSurface.HOME,
         )
         val episodeScores = adaptiveScorer.scoreEpisodes(
             episodeInputs,
             history,
             RankingObjective.DISCOVERY,
+            RankingSurface.HOME,
         )
         return podcasts.sortedByDescending { podcastScores[it.latestEpisode?.id] ?: 0.0 } to
             episodes.sortedByDescending { episodeScores[it.id] ?: 0.0 }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -1362,7 +1362,7 @@ class HomeViewModel(
                                 resolvedSerialEpisodes = _resolvedSerialEpisodes.value,
                                 recommendations = wrapper.recommendations,
                                 podcastScores = podScoresMap,
-                                adaptiveScorer = adaptiveScorer,
+                                adaptiveRanking = MixtapeEngine.AdaptiveRanking(adaptiveScorer),
                             )
                             mixtapePodcasts = result.podcasts
                             mixtapeCount = result.unplayedCount

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import cx.aswin.boxcast.core.data.HomeBootstrapData
 import cx.aswin.boxcast.core.data.toScorable
 import cx.aswin.boxcast.core.data.content.AdaptiveContentCandidateRanker
 import cx.aswin.boxcast.core.data.content.ContentContextEngine
+import cx.aswin.boxcast.core.data.content.ContentContextInput
 import cx.aswin.boxcast.core.data.content.ContentOrchestrator
 import cx.aswin.boxcast.core.data.content.ContentSection
 import cx.aswin.boxcast.core.data.content.PodcastCandidateProvider
@@ -859,16 +860,18 @@ class HomeViewModel(
                 val history = playbackRepository.getAllHistory().first()
                 val latestHistory = history.maxByOrNull(ListeningHistoryEntity::lastPlayedAt)
                 val context = contentContextEngine.create(
-                    surface = RankingSurface.HOME,
-                    region = region,
-                    isDriving = false,
-                    isOnline = true,
-                    availableMinutes = null,
-                    currentEpisodeId = latestHistory?.episodeId,
-                    currentPodcastId = latestHistory?.podcastId,
-                    historyMaturity = history.size,
-                    subscriptionCount = subscriptions.size,
-                    sessionId = adaptiveContentSessionId,
+                    ContentContextInput(
+                        surface = RankingSurface.HOME,
+                        region = region,
+                        isDriving = false,
+                        isOnline = true,
+                        availableMinutes = null,
+                        currentEpisodeId = latestHistory?.episodeId,
+                        currentPodcastId = latestHistory?.podcastId,
+                        historyMaturity = history.size,
+                        subscriptionCount = subscriptions.size,
+                        sessionId = adaptiveContentSessionId,
+                    ),
                 )
                 contentOrchestrator.compose(
                     context = context,

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -12,8 +12,11 @@ import androidx.lifecycle.viewModelScope
 import cx.aswin.boxcast.core.data.MixtapeEngine
 import cx.aswin.boxcast.core.data.PodcastRepository
 import cx.aswin.boxcast.core.data.HomeBootstrapData
-import cx.aswin.boxcast.core.data.PodcastScoring
 import cx.aswin.boxcast.core.data.toScorable
+import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.model.EpisodeStatus
 import kotlinx.coroutines.CancellationException
@@ -161,6 +164,7 @@ class HomeViewModel(
     
     val podcastRepository = PodcastRepository(baseUrl = apiBaseUrl, publicKey = publicKey, context = application)
     private val database = cx.aswin.boxcast.core.data.database.BoxLoreDatabase.getDatabase(application)
+    private val adaptiveScorer = AdaptiveCandidateScorer.getInstance(application)
     private val subscriptionRepository = cx.aswin.boxcast.core.data.SubscriptionRepository(database.podcastDao())
     private val rssRepository =
         cx.aswin.boxcast.core.data.RssPodcastRepository.getInstance(application)
@@ -1285,9 +1289,10 @@ class HomeViewModel(
 
                         // Calculate score map for all subscribed podcasts using the shared utility (only on first calculation)
                         val podScoresMap = if (stablePodcastOrder == null || stableMixtapePodcasts == null) {
-                            PodcastScoring.calculateScores(
+                            adaptiveScorer.scorePodcasts(
                                 podcasts = subs.map { it.toScorable() },
-                                allHistory = allHistory
+                                history = allHistory,
+                                objective = RankingObjective.YOUR_SHOWS,
                             )
                         } else {
                             emptyMap()
@@ -1357,6 +1362,7 @@ class HomeViewModel(
                                 resolvedSerialEpisodes = _resolvedSerialEpisodes.value,
                                 recommendations = wrapper.recommendations,
                                 podcastScores = podScoresMap,
+                                adaptiveScorer = adaptiveScorer,
                             )
                             mixtapePodcasts = result.podcasts
                             mixtapeCount = result.unplayedCount
@@ -2045,17 +2051,18 @@ class HomeViewModel(
                 val distinctEpisodes = data.episodes
                     .distinctBy { it.id }
                     .distinctBy { it.title.lowercase().trim() }
+                val ranked = rankBecauseYouLike(distinctPodcasts, distinctEpisodes)
                 
                 android.util.Log.d("HomeViewModel", "Fetched because-you-like: podcasts count = ${distinctPodcasts.size}, episodes count = ${distinctEpisodes.size}")
                 
-                _becauseYouLikePodcasts.value = distinctPodcasts
-                _becauseYouLikeRecommendations.value = distinctEpisodes
+                _becauseYouLikePodcasts.value = ranked.first
+                _becauseYouLikeRecommendations.value = ranked.second
                 
                 try {
                     val prefs = getApplication<Application>().getSharedPreferences("boxcast_prefs", Context.MODE_PRIVATE)
                     val json = Json { ignoreUnknownKeys = true }
-                    val serializedEpisodes = json.encodeToString(distinctEpisodes)
-                    val serializedPodcasts = json.encodeToString(distinctPodcasts)
+                    val serializedEpisodes = json.encodeToString(ranked.second)
+                    val serializedPodcasts = json.encodeToString(ranked.first)
                     prefs.edit()
                         .putString("cached_byl_recommendations", serializedEpisodes)
                         .putString("cached_byl_podcasts", serializedPodcasts)
@@ -2071,6 +2078,54 @@ class HomeViewModel(
             }
         }
     }
+
+    private suspend fun rankBecauseYouLike(
+        podcasts: List<Podcast>,
+        episodes: List<Episode>,
+    ): Pair<List<Podcast>, List<Episode>> {
+        val history = database.listeningHistoryDao().getRecentHistoryList(300)
+        val podcastById = podcasts.associateBy(Podcast::id)
+        val podcastInputs = podcasts.mapIndexedNotNull { index, candidate ->
+            candidate.latestEpisode?.let { episode ->
+                EpisodeRankingInput(
+                    episode = episode,
+                    podcast = candidate,
+                    priorScore = (podcasts.size - index).toDouble(),
+                    source = CandidateSource.SERVER_RECOMMENDATION,
+                    isNovel = true,
+                )
+            }
+        }
+        val episodeInputs = episodes.mapIndexed { index, episode ->
+            EpisodeRankingInput(
+                episode = episode,
+                podcast = podcastById[episode.podcastId] ?: episode.toRecommendationPodcast(),
+                priorScore = (episodes.size - index).toDouble(),
+                source = CandidateSource.SERVER_RECOMMENDATION,
+                isNovel = episode.podcastId !in podcastById,
+            )
+        }
+        val podcastScores = adaptiveScorer.scoreEpisodes(
+            podcastInputs,
+            history,
+            RankingObjective.DISCOVERY,
+        )
+        val episodeScores = adaptiveScorer.scoreEpisodes(
+            episodeInputs,
+            history,
+            RankingObjective.DISCOVERY,
+        )
+        return podcasts.sortedByDescending { podcastScores[it.latestEpisode?.id] ?: 0.0 } to
+            episodes.sortedByDescending { episodeScores[it.id] ?: 0.0 }
+    }
+
+    private fun Episode.toRecommendationPodcast(): Podcast = Podcast(
+        id = podcastId.orEmpty(),
+        title = podcastTitle.orEmpty(),
+        artist = podcastArtist.orEmpty(),
+        imageUrl = podcastImageUrl ?: imageUrl.orEmpty(),
+        latestEpisode = this,
+    )
 
     override fun onCleared() {
         super.onCleared()

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -16,7 +16,9 @@ import cx.aswin.boxcast.core.data.toScorable
 import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
 import cx.aswin.boxcast.core.data.ranking.CandidateSource
 import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
+import cx.aswin.boxcast.core.data.ranking.PodcastRankingInput
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.DiversityPolicy
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.model.EpisodeStatus
 import kotlinx.coroutines.CancellationException
@@ -336,20 +338,7 @@ class HomeViewModel(
                     val json = Json { ignoreUnknownKeys = true }
                     val cachedVibesMap = json.decodeFromString<Map<String, List<Podcast>>>(cachedVibesJson)
                     val blockConfig = getTimeBlockConfig()
-                    val daySeed = java.time.LocalDate.now().toEpochDay()
-                    val resolvedSections = blockConfig.genres.map { genre ->
-                        val list = cachedVibesMap[genre.id] ?: emptyList()
-                        val filtered = list
-                            .filter { it.latestEpisode != null }
-                            .shuffled(kotlin.random.Random(daySeed.toInt() + genre.title.hashCode()))
-                            .take(10)
-                        if (filtered.isNotEmpty()) {
-                            CuratedSectionData(genre.title, genre.id, filtered)
-                        } else null
-                    }.filterNotNull()
-
-                    if (resolvedSections.isNotEmpty()) {
-                        val block = CuratedTimeBlock(blockConfig.title, blockConfig.subtitle, blockConfig.icon, resolvedSections)
+                    buildRankedTimeBlock(blockConfig, cachedVibesMap)?.let { block ->
                         _timeBlockState.value = block
                         cachedTimeBlock = block
                         _isCuratedLoaded.value = true
@@ -924,22 +913,7 @@ class HomeViewModel(
                         val blockConfig = getTimeBlockConfig()
                         val vibeIds = blockConfig.genres.map { it.id }
                         val curatedVibesMap = podcastRepository.getCuratedVibes(vibeIds, region)
-                        
-                        val daySeed = java.time.LocalDate.now().toEpochDay()
-                        val resolvedSections = blockConfig.genres.map { genre ->
-                            val list = curatedVibesMap[genre.id] ?: emptyList()
-                            val filtered = list
-                                .filter { it.latestEpisode != null }
-                                .shuffled(kotlin.random.Random(daySeed.toInt() + genre.title.hashCode()))
-                                .take(10)
-                            if (filtered.isNotEmpty()) {
-                                CuratedSectionData(genre.title, genre.id, filtered)
-                            } else null
-                        }.filterNotNull()
-                        
-                        val block = if (resolvedSections.isNotEmpty()) {
-                            CuratedTimeBlock(blockConfig.title, blockConfig.subtitle, blockConfig.icon, resolvedSections)
-                        } else null
+                        val block = buildRankedTimeBlock(blockConfig, curatedVibesMap)
                         
                         _timeBlockState.value = block
                         cachedTimeBlock = block
@@ -1058,10 +1032,46 @@ class HomeViewModel(
                     )
                 }.debounce(100L).collect { wrapper ->
                     kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
-                        val trendingList = wrapper.trending
+                        val allHistory = wrapper.history
+                        val subscribedIds = wrapper.subs.map(Podcast::id).toSet()
+                        val trendingList = adaptiveScorer.rankPodcasts(
+                            inputs = wrapper.trending.mapIndexed { index, podcast ->
+                                PodcastRankingInput(
+                                    podcast = podcast,
+                                    priorScore = (wrapper.trending.size - index).toDouble(),
+                                    source = CandidateSource.TRENDING,
+                                    isNovel = podcast.id !in subscribedIds,
+                                )
+                            },
+                            history = allHistory,
+                            objective = RankingObjective.DISCOVERY,
+                            diversityPolicy = DiversityPolicy(
+                                limit = wrapper.trending.size,
+                                maxPerShow = 1,
+                                reserveNovelSlot = true,
+                            ),
+                        )
+                        val rankedRecommendations = adaptiveScorer.rankEpisodes(
+                            inputs = wrapper.recommendations.mapIndexed { index, episode ->
+                                val podcast = episode.toRecommendationPodcast()
+                                EpisodeRankingInput(
+                                    episode = episode,
+                                    podcast = podcast,
+                                    priorScore = (wrapper.recommendations.size - index).toDouble(),
+                                    source = CandidateSource.SERVER_RECOMMENDATION,
+                                    isNovel = podcast.id !in subscribedIds,
+                                )
+                            },
+                            history = allHistory,
+                            objective = RankingObjective.DISCOVERY,
+                            diversityPolicy = DiversityPolicy(
+                                limit = wrapper.recommendations.size,
+                                maxPerShow = 2,
+                                reserveNovelSlot = true,
+                            ),
+                        )
                         val resumeList = wrapper.resume
                         val subs = wrapper.subs
-                        val allHistory = wrapper.history
                         val resolvedSerial = wrapper.resolvedSerial
                         val completedEpisodeIds = wrapper.completedEpisodeIds
                     
@@ -1360,7 +1370,7 @@ class HomeViewModel(
                                 subscriptions = subs,
                                 history = allHistory,
                                 resolvedSerialEpisodes = _resolvedSerialEpisodes.value,
-                                recommendations = wrapper.recommendations,
+                                recommendations = rankedRecommendations,
                                 podcastScores = podScoresMap,
                                 adaptiveRanking = MixtapeEngine.AdaptiveRanking(adaptiveScorer),
                             )
@@ -1539,7 +1549,7 @@ class HomeViewModel(
                             selectedCategory = _selectedCategory.value,
                             timeBlock = timeBlock,
                             discoverPodcasts = discover,
-                            recommendations = wrapper.recommendations,
+                            recommendations = rankedRecommendations,
                             isLoading = initialLoading,
                             isFilterLoading = trendingList.isEmpty(),
                             isError = false,
@@ -1730,6 +1740,44 @@ class HomeViewModel(
     // --- Helper Logic ---
     data class TimeBlockConfig(val title: String, val subtitle: String, val icon: ImageVector, val genres: List<GenreConfig>)
     data class GenreConfig(val id: String, val title: String)
+
+    private suspend fun buildRankedTimeBlock(
+        config: TimeBlockConfig,
+        candidatesByIntent: Map<String, List<Podcast>>,
+    ): CuratedTimeBlock? {
+        val history = database.listeningHistoryDao().getRecentHistoryList(300)
+        val daySeed = java.time.LocalDate.now().toEpochDay().toInt()
+        val sections = config.genres.mapNotNull { genre ->
+            val candidates = candidatesByIntent[genre.id]
+                .orEmpty()
+                .filter { it.latestEpisode != null }
+                .shuffled(kotlin.random.Random(daySeed + genre.title.hashCode()))
+            val ranked = adaptiveScorer.rankPodcasts(
+                inputs = candidates.mapIndexed { index, podcast ->
+                    PodcastRankingInput(
+                        podcast = podcast,
+                        priorScore = (candidates.size - index).toDouble(),
+                        source = CandidateSource.CURATED_INTENT,
+                        isNovel = podcast.subscribedAt <= 0L,
+                        timeContextMatch = 1.0,
+                    )
+                },
+                history = history,
+                objective = RankingObjective.SLATE,
+                diversityPolicy = DiversityPolicy(
+                    limit = 10,
+                    maxPerShow = 1,
+                    reserveNovelSlot = true,
+                ),
+            )
+            ranked.takeIf { it.isNotEmpty() }?.let {
+                CuratedSectionData(genre.title, genre.id, it)
+            }
+        }
+        return sections.takeIf { it.isNotEmpty() }?.let {
+            CuratedTimeBlock(config.title, config.subtitle, config.icon, it)
+        }
+    }
 
     /**
      * Warms episode data for shows subscribed *during* this session so a freshly added show has

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -168,6 +168,13 @@ object ModeSwitchState {
     fun finish() { _isSwitching.value = false }
 }
 
+private data class AdaptiveContentTrigger(
+    val region: String,
+    val subscriptionIds: Set<String>,
+    val latestEpisodeId: String?,
+    val latestPodcastId: String?,
+    val historyMaturity: Int,
+)
 
 @Suppress("kotlin:S6310")
 class HomeViewModel(
@@ -231,7 +238,7 @@ class HomeViewModel(
     private val _isRecommendationsFallback = MutableStateFlow(true)
     private val _adaptiveSections = MutableStateFlow<List<ContentSection>>(emptyList())
     private val adaptiveContentSessionId = java.util.UUID.randomUUID().toString()
-    private val exposedAdaptiveSections = mutableSetOf<String>()
+    private val exposedAdaptiveCandidates = mutableSetOf<String>()
     private val contentContextEngine = ContentContextEngine()
     private val contentOrchestrator = ContentOrchestrator(
         providers = listOf(
@@ -854,42 +861,65 @@ class HomeViewModel(
 
     private fun loadAdaptiveContent() {
         viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
-            runCatching {
-                val region = userPrefs.regionStream.first()
-                val subscriptions = subscriptionRepository.subscribedPodcasts.first()
-                val history = playbackRepository.getAllHistory().first()
+            combine(
+                userPrefs.regionStream,
+                subscriptionRepository.subscribedPodcasts,
+                playbackRepository.getAllHistory(),
+            ) { region, subscriptions, history ->
                 val latestHistory = history.maxByOrNull(ListeningHistoryEntity::lastPlayedAt)
-                val context = contentContextEngine.create(
-                    ContentContextInput(
-                        surface = RankingSurface.HOME,
-                        region = region,
-                        isDriving = false,
-                        isOnline = true,
-                        availableMinutes = null,
-                        currentEpisodeId = latestHistory?.episodeId,
-                        currentPodcastId = latestHistory?.podcastId,
-                        historyMaturity = history.size,
-                        subscriptionCount = subscriptions.size,
-                        sessionId = adaptiveContentSessionId,
-                    ),
+                AdaptiveContentTrigger(
+                    region = region,
+                    subscriptionIds = subscriptions.map(Podcast::id).toSet(),
+                    latestEpisodeId = latestHistory?.episodeId,
+                    latestPodcastId = latestHistory?.podcastId,
+                    historyMaturity = history.size,
                 )
-                contentOrchestrator.compose(
-                    context = context,
-                    catalog = podcastRepository.getContentCatalog(),
-                )
-            }.onSuccess { slate ->
-                _adaptiveSections.value = slate.sections
-            }.onFailure { error ->
-                if (error is CancellationException) throw error
-                android.util.Log.w("HomeViewModel", "Adaptive content composition failed", error)
+            }.distinctUntilChanged().collectLatest { trigger ->
+                try {
+                    val context = contentContextEngine.create(
+                        ContentContextInput(
+                            surface = RankingSurface.HOME,
+                            region = trigger.region,
+                            isDriving = false,
+                            isOnline = true,
+                            availableMinutes = null,
+                            currentEpisodeId = trigger.latestEpisodeId,
+                            currentPodcastId = trigger.latestPodcastId,
+                            historyMaturity = trigger.historyMaturity,
+                            subscriptionCount = trigger.subscriptionIds.size,
+                            sessionId = adaptiveContentSessionId,
+                        ),
+                    )
+                    val slate = contentOrchestrator.compose(
+                        context = context,
+                        catalog = podcastRepository.getContentCatalog(),
+                        forceRefresh = true,
+                    )
+                    _adaptiveSections.value = slate.sections
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Exception) {
+                    android.util.Log.w(
+                        "HomeViewModel",
+                        "Adaptive content composition failed",
+                        error,
+                    )
+                }
             }
         }
     }
 
-    fun trackAdaptiveSectionVisible(section: ContentSection) {
-        if (!exposedAdaptiveSections.add(section.stableId)) return
+    fun trackAdaptiveSectionVisible(
+        section: ContentSection,
+        visibleCandidateIds: Set<String>,
+    ) {
+        val newlyVisible = section.items.filter { candidate ->
+            candidate.id in visibleCandidateIds &&
+                exposedAdaptiveCandidates.add("${section.stableId}:${candidate.id}")
+        }
+        if (newlyVisible.isEmpty()) return
         viewModelScope.launch {
-            section.items.forEach { candidate ->
+            newlyVisible.forEach { candidate ->
                 rankingFeedback.recordExposure(
                     RankingExposure(
                         episodeId = candidate.id,
@@ -2234,6 +2264,7 @@ class HomeViewModel(
         episodes: List<Episode>,
     ): Pair<List<Podcast>, List<Episode>> {
         val history = database.listeningHistoryDao().getRecentHistoryList(300)
+        val subscribedIds = subscriptionRepository.subscribedPodcastIds.first()
         val podcastById = podcasts.associateBy(Podcast::id)
         val podcastInputs = podcasts.mapIndexedNotNull { index, candidate ->
             candidate.latestEpisode?.let { episode ->
@@ -2242,7 +2273,7 @@ class HomeViewModel(
                     podcast = candidate,
                     priorScore = (podcasts.size - index).toDouble(),
                     source = CandidateSource.SERVER_RECOMMENDATION,
-                    isNovel = true,
+                    isNovel = candidate.id !in subscribedIds,
                 )
             }
         }
@@ -2252,7 +2283,7 @@ class HomeViewModel(
                 podcast = podcastById[episode.podcastId] ?: episode.toRecommendationPodcast(),
                 priorScore = (episodes.size - index).toDouble(),
                 source = CandidateSource.SERVER_RECOMMENDATION,
-                isNovel = episode.podcastId !in podcastById,
+                isNovel = episode.podcastId !in subscribedIds,
             )
         }
         val podcastScores = adaptiveScorer.scoreEpisodes(

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeViewModel.kt
@@ -13,11 +13,22 @@ import cx.aswin.boxcast.core.data.MixtapeEngine
 import cx.aswin.boxcast.core.data.PodcastRepository
 import cx.aswin.boxcast.core.data.HomeBootstrapData
 import cx.aswin.boxcast.core.data.toScorable
+import cx.aswin.boxcast.core.data.content.AdaptiveContentCandidateRanker
+import cx.aswin.boxcast.core.data.content.ContentContextEngine
+import cx.aswin.boxcast.core.data.content.ContentOrchestrator
+import cx.aswin.boxcast.core.data.content.ContentSection
+import cx.aswin.boxcast.core.data.content.PodcastCandidateProvider
+import cx.aswin.boxcast.core.data.content.ServerIntentCandidateProvider
 import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
 import cx.aswin.boxcast.core.data.ranking.CandidateSource
 import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
 import cx.aswin.boxcast.core.data.ranking.PodcastRankingInput
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
+import cx.aswin.boxcast.core.data.ranking.CandidateFeatureBuilder
+import cx.aswin.boxcast.core.data.ranking.CandidateSignals
+import cx.aswin.boxcast.core.data.ranking.RankingExposure
+import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
 import cx.aswin.boxcast.core.data.ranking.DiversityPolicy
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.model.EpisodeStatus
@@ -109,7 +120,8 @@ data class HomeUiState(
     val becauseYouLikeRecommendations: List<Episode> = emptyList(),
     val becauseYouLikePodcasts: List<Podcast> = emptyList(),
     val isBecauseYouLikeLoading: Boolean = false,
-    val isRecommendationsFallback: Boolean = true
+    val isRecommendationsFallback: Boolean = true,
+    val adaptiveSections: List<ContentSection> = emptyList(),
 )
 
 private data class SelectedPodcastSignal(
@@ -139,7 +151,8 @@ data class HomeDataWrapper(
     val becauseYouLikeRecommendations: List<Episode> = emptyList(),
     val becauseYouLikePodcasts: List<Podcast> = emptyList(),
     val isBecauseYouLikeLoading: Boolean = false,
-    val isRecommendationsFallback: Boolean = true
+    val isRecommendationsFallback: Boolean = true,
+    val adaptiveSections: List<ContentSection> = emptyList(),
 )
 
 /**
@@ -167,6 +180,7 @@ class HomeViewModel(
     val podcastRepository = PodcastRepository(baseUrl = apiBaseUrl, publicKey = publicKey, context = application)
     private val database = cx.aswin.boxcast.core.data.database.BoxLoreDatabase.getDatabase(application)
     private val adaptiveScorer = AdaptiveCandidateScorer.getInstance(application)
+    private val rankingFeedback = RankingFeedbackRepository.getInstance(application)
     private val subscriptionRepository = cx.aswin.boxcast.core.data.SubscriptionRepository(database.podcastDao())
     private val rssRepository =
         cx.aswin.boxcast.core.data.RssPodcastRepository.getInstance(application)
@@ -214,6 +228,21 @@ class HomeViewModel(
     private val _becauseYouLikePodcasts = MutableStateFlow<List<Podcast>>(emptyList())
     private val _isBecauseYouLikeLoading = MutableStateFlow(false)
     private val _isRecommendationsFallback = MutableStateFlow(true)
+    private val _adaptiveSections = MutableStateFlow<List<ContentSection>>(emptyList())
+    private val adaptiveContentSessionId = java.util.UUID.randomUUID().toString()
+    private val exposedAdaptiveSections = mutableSetOf<String>()
+    private val contentContextEngine = ContentContextEngine()
+    private val contentOrchestrator = ContentOrchestrator(
+        providers = listOf(
+            ServerIntentCandidateProvider(podcastRepository),
+            PodcastCandidateProvider(CandidateSource.SUBSCRIPTION) { _, _ ->
+                subscriptionRepository.subscribedPodcasts.first()
+            },
+        ),
+        ranker = AdaptiveContentCandidateRanker(adaptiveScorer) {
+            playbackRepository.getAllHistory().first()
+        },
+    )
 
     // Cached base data (For You)
     private var cachedRegion: String? = null
@@ -817,8 +846,68 @@ class HomeViewModel(
         observeSelectedPodcast()
         manageFilterSelectionOnSubscriptionChange()
         loadData()
+        loadAdaptiveContent()
         startBackgroundSync()
         eagerlyLoadNewSubscriptions()
+    }
+
+    private fun loadAdaptiveContent() {
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            runCatching {
+                val region = userPrefs.regionStream.first()
+                val subscriptions = subscriptionRepository.subscribedPodcasts.first()
+                val history = playbackRepository.getAllHistory().first()
+                val latestHistory = history.maxByOrNull(ListeningHistoryEntity::lastPlayedAt)
+                val context = contentContextEngine.create(
+                    surface = RankingSurface.HOME,
+                    region = region,
+                    isDriving = false,
+                    isOnline = true,
+                    availableMinutes = null,
+                    currentEpisodeId = latestHistory?.episodeId,
+                    currentPodcastId = latestHistory?.podcastId,
+                    historyMaturity = history.size,
+                    subscriptionCount = subscriptions.size,
+                    sessionId = adaptiveContentSessionId,
+                )
+                contentOrchestrator.compose(
+                    context = context,
+                    catalog = podcastRepository.getContentCatalog(),
+                )
+            }.onSuccess { slate ->
+                _adaptiveSections.value = slate.sections
+            }.onFailure { error ->
+                if (error is CancellationException) throw error
+                android.util.Log.w("HomeViewModel", "Adaptive content composition failed", error)
+            }
+        }
+    }
+
+    fun trackAdaptiveSectionVisible(section: ContentSection) {
+        if (!exposedAdaptiveSections.add(section.stableId)) return
+        viewModelScope.launch {
+            section.items.forEach { candidate ->
+                rankingFeedback.recordExposure(
+                    RankingExposure(
+                        episodeId = candidate.id,
+                        podcastId = candidate.podcast.id,
+                        objective = section.intent.objective,
+                        surface = RankingSurface.HOME,
+                        source = candidate.source,
+                        features = CandidateFeatureBuilder.build(
+                            CandidateSignals(
+                                isUnseenShow = candidate.isNovel,
+                                serverRelevance = candidate.retrievalScore.coerceIn(0.0, 1.0),
+                                isUnplayed = true,
+                                timeContextMatch = 1.0,
+                            ),
+                        ),
+                        entryPoint = "home_adaptive_${section.intent.id}",
+                        online = true,
+                    ),
+                )
+            }
+        }
     }
 
     private fun fetchPersonalizedRecommendations(region: String) {
@@ -1004,7 +1093,8 @@ class HomeViewModel(
                     _becauseYouLikeRecommendations,
                     _becauseYouLikePodcasts,
                     _isBecauseYouLikeLoading,
-                    _isRecommendationsFallback
+                    _isRecommendationsFallback,
+                    _adaptiveSections,
                 ) { array ->
                     val dismissedDate = array[13] as String
                     val dismissedForever = array[15] as Boolean
@@ -1028,7 +1118,8 @@ class HomeViewModel(
                         becauseYouLikeRecommendations = array[17] as List<Episode>,
                         becauseYouLikePodcasts = array[18] as List<Podcast>,
                         isBecauseYouLikeLoading = array[19] as Boolean,
-                        isRecommendationsFallback = array[20] as Boolean
+                        isRecommendationsFallback = array[20] as Boolean,
+                        adaptiveSections = array[21] as List<ContentSection>,
                     )
                 }.debounce(100L).collect { wrapper ->
                     kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
@@ -1567,7 +1658,8 @@ class HomeViewModel(
                             becauseYouLikeRecommendations = wrapper.becauseYouLikeRecommendations,
                             becauseYouLikePodcasts = wrapper.becauseYouLikePodcasts,
                             isBecauseYouLikeLoading = wrapper.isBecauseYouLikeLoading,
-                            isRecommendationsFallback = wrapper.isRecommendationsFallback
+                            isRecommendationsFallback = wrapper.isRecommendationsFallback,
+                            adaptiveSections = wrapper.adaptiveSections,
                         )
                     }
                 }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/SettingsScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/SettingsScreen.kt
@@ -51,6 +51,7 @@ import cx.aswin.boxcast.feature.home.settings.pages.PlaybackActions
 import cx.aswin.boxcast.feature.home.settings.pages.PlaybackSettingsPage
 import cx.aswin.boxcast.feature.home.settings.pages.PlaybackUiState
 import cx.aswin.boxcast.feature.home.settings.pages.PrivacySettingsPage
+import cx.aswin.boxcast.feature.home.settings.pages.PrivacySettingsActions
 import cx.aswin.boxcast.feature.home.settings.pages.SettingsHub
 
 /** Where to send the user for the two Downloads settings sub-screens. */
@@ -235,11 +236,15 @@ fun SettingsScreen(
             ProfileSettingsDestination.Privacy -> PrivacySettingsPage(
                 deletionId = deletionId,
                 isDeletionExpanded = isDeletionExpanded,
-                onDeletionExpandedChange = { isDeletionExpanded = it },
-                onResetIdentityClick = { showResetDialog = true },
-                onResetRecommendationsClick = settingsViewModel::resetRecommendations,
-                onCopyDeletionId = { copyDeletionId(context, deletionId) },
-                onEmailDeletionRequest = { requestAnalyticsDeletionByEmail(context, deletionId) },
+                actions = PrivacySettingsActions(
+                    onDeletionExpandedChange = { isDeletionExpanded = it },
+                    onResetIdentityClick = { showResetDialog = true },
+                    onResetRecommendationsClick = settingsViewModel::resetRecommendations,
+                    onCopyDeletionId = { copyDeletionId(context, deletionId) },
+                    onEmailDeletionRequest = {
+                        requestAnalyticsDeletionByEmail(context, deletionId)
+                    },
+                ),
                 onBack = returnToHub,
             )
 

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/SettingsScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/SettingsScreen.kt
@@ -237,6 +237,7 @@ fun SettingsScreen(
                 isDeletionExpanded = isDeletionExpanded,
                 onDeletionExpandedChange = { isDeletionExpanded = it },
                 onResetIdentityClick = { showResetDialog = true },
+                onResetRecommendationsClick = settingsViewModel::resetRecommendations,
                 onCopyDeletionId = { copyDeletionId(context, deletionId) },
                 onEmailDeletionRequest = { requestAnalyticsDeletionByEmail(context, deletionId) },
                 onBack = returnToHub,

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/SettingsViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/SettingsViewModel.kt
@@ -54,8 +54,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun resetRecommendations() {
         viewModelScope.launch {
-            rankingFeedbackRepository.reset()
-            _events.emit(SettingsEvent.ShowToast("Recommendations reset"))
+            val reset = rankingFeedbackRepository.reset()
+            _events.emit(
+                SettingsEvent.ShowToast(
+                    if (reset) "Recommendations reset" else "Couldn't reset recommendations",
+                ),
+            )
         }
     }
 

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/SettingsViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import cx.aswin.boxcast.core.data.RssPodcastRepository
 import cx.aswin.boxcast.core.data.RssSubscriptionResult
+import cx.aswin.boxcast.core.data.ranking.RankingFeedbackRepository
 import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -37,6 +38,9 @@ sealed interface SettingsEvent {
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
 
     private val rssRepository by lazy { RssPodcastRepository.getInstance(getApplication()) }
+    private val rankingFeedbackRepository by lazy {
+        RankingFeedbackRepository.getInstance(getApplication())
+    }
 
     private val _uiState = MutableStateFlow(SettingsRssUiState())
     val uiState: StateFlow<SettingsRssUiState> = _uiState.asStateFlow()
@@ -46,6 +50,13 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun openAddRssDialog() {
         _uiState.value = _uiState.value.copy(showAddRssDialog = true)
+    }
+
+    fun resetRecommendations() {
+        viewModelScope.launch {
+            rankingFeedbackRepository.reset()
+            _events.emit(SettingsEvent.ShowToast("Recommendations reset"))
+        }
     }
 
     fun dismissAddRssDialog() {

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/pages/PrivacySettingsPage.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/pages/PrivacySettingsPage.kt
@@ -50,15 +50,19 @@ import cx.aswin.boxcast.feature.home.settings.components.SettingsScaffold
 
 private const val GroqOnboardingModel = "openai/gpt-oss-120b"
 
+internal data class PrivacySettingsActions(
+    val onDeletionExpandedChange: (Boolean) -> Unit,
+    val onResetIdentityClick: () -> Unit,
+    val onResetRecommendationsClick: () -> Unit,
+    val onCopyDeletionId: () -> Unit,
+    val onEmailDeletionRequest: () -> Unit,
+)
+
 @Composable
 internal fun PrivacySettingsPage(
     deletionId: String,
     isDeletionExpanded: Boolean,
-    onDeletionExpandedChange: (Boolean) -> Unit,
-    onResetIdentityClick: () -> Unit,
-    onResetRecommendationsClick: () -> Unit,
-    onCopyDeletionId: () -> Unit,
-    onEmailDeletionRequest: () -> Unit,
+    actions: PrivacySettingsActions,
     onBack: () -> Unit,
 ) {
     SettingsScaffold(
@@ -170,7 +174,7 @@ internal fun PrivacySettingsPage(
                     icon = Icons.Rounded.Refresh,
                     destructive = false,
                     actionLabel = "Reset",
-                    onAction = onResetRecommendationsClick,
+                    onAction = actions.onResetRecommendationsClick,
                     expansion = null,
                 )
             }
@@ -190,7 +194,7 @@ internal fun PrivacySettingsPage(
                         icon = Icons.Rounded.Refresh,
                         destructive = false,
                         actionLabel = "Reset ID",
-                        onAction = onResetIdentityClick,
+                        onAction = actions.onResetIdentityClick,
                         expansion = null,
                     )
 
@@ -200,15 +204,19 @@ internal fun PrivacySettingsPage(
                         icon = Icons.Rounded.DeleteForever,
                         destructive = true,
                         actionLabel = if (isDeletionExpanded) "Hide" else "Show ID",
-                        onAction = { onDeletionExpandedChange(!isDeletionExpanded) },
+                        onAction = {
+                            actions.onDeletionExpandedChange(!isDeletionExpanded)
+                        },
                         expansion = AnalyticsCardExpansion(
                             expanded = isDeletionExpanded,
-                            onToggleExpand = { onDeletionExpandedChange(!isDeletionExpanded) },
+                            onToggleExpand = {
+                                actions.onDeletionExpandedChange(!isDeletionExpanded)
+                            },
                             content = {
                                 DeletionRequestPanel(
                                     deletionId = deletionId,
-                                    onCopyDeletionId = onCopyDeletionId,
-                                    onEmailDeletionRequest = onEmailDeletionRequest,
+                                    onCopyDeletionId = actions.onCopyDeletionId,
+                                    onEmailDeletionRequest = actions.onEmailDeletionRequest,
                                 )
                             },
                         ),

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/pages/PrivacySettingsPage.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/pages/PrivacySettingsPage.kt
@@ -56,6 +56,7 @@ internal fun PrivacySettingsPage(
     isDeletionExpanded: Boolean,
     onDeletionExpandedChange: (Boolean) -> Unit,
     onResetIdentityClick: () -> Unit,
+    onResetRecommendationsClick: () -> Unit,
     onCopyDeletionId: () -> Unit,
     onEmailDeletionRequest: () -> Unit,
     onBack: () -> Unit,
@@ -153,6 +154,25 @@ internal fun PrivacySettingsPage(
                 reason = "Pretty obvious — if the app breaks, we need to know so we can fix it.",
                 example = null,
             )
+        }
+
+        SettingsGroup(
+            title = "On-device recommendations",
+            footer = "Your learned taste profile and ranking model stay on this device. " +
+                "They are not uploaded or included in backups.",
+        ) {
+            SettingsContent {
+                AnalyticsControlCard(
+                    title = "Reset recommendations",
+                    body = "Forget inferred tastes and start learning again. " +
+                        "This does not remove subscriptions, downloads, likes, or listening history.",
+                    icon = Icons.Rounded.Refresh,
+                    destructive = false,
+                    actionLabel = "Reset",
+                    onAction = onResetRecommendationsClick,
+                    expansion = null,
+                )
+            }
         }
 
         SettingsGroup(

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/pages/PrivacySettingsPage.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/settings/pages/PrivacySettingsPage.kt
@@ -159,7 +159,8 @@ internal fun PrivacySettingsPage(
         SettingsGroup(
             title = "On-device recommendations",
             footer = "Your learned taste profile and ranking model stay on this device. " +
-                "They are not uploaded or included in backups.",
+                "They are not uploaded. JSON backups you create include this state so an " +
+                "imported install can continue with the same learning.",
         ) {
             SettingsContent {
                 AnalyticsControlCard(

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
@@ -8,8 +8,11 @@ import cx.aswin.boxcast.core.data.database.ListeningHistoryEntity
 import cx.aswin.boxcast.core.model.EpisodeStatus
 import cx.aswin.boxcast.core.model.Podcast
 import cx.aswin.boxcast.core.model.Episode
-import cx.aswin.boxcast.core.data.PodcastScoring
 import cx.aswin.boxcast.core.data.toScorable
+import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
+import cx.aswin.boxcast.core.data.ranking.CandidateSource
+import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
+import cx.aswin.boxcast.core.data.ranking.RankingObjective
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.SharingStarted
@@ -41,7 +44,8 @@ class LibraryViewModel(
     private val subscriptionRepository: SubscriptionRepository,
     private val playbackRepository: PlaybackRepository,
     private val downloadRepository: cx.aswin.boxcast.core.data.DownloadRepository,
-    private val userPreferencesRepository: cx.aswin.boxcast.core.data.UserPreferencesRepository
+    private val userPreferencesRepository: cx.aswin.boxcast.core.data.UserPreferencesRepository,
+    private val adaptiveScorer: AdaptiveCandidateScorer,
 ) : ViewModel() {
 
     val lastSeenEpisodes: StateFlow<Map<String, String>> = userPreferencesRepository.lastSeenEpisodesStream
@@ -91,6 +95,27 @@ class LibraryViewModel(
         viewModelScope.launch {
             userPreferencesRepository.setLatestEpisodesSortUseSmart(useSmart)
         }
+    }
+
+    suspend fun scoreLatestEpisodes(
+        podcasts: List<Podcast>,
+        history: List<ListeningHistoryEntity>,
+    ): Map<String, Double> {
+        val inputs = podcasts.mapNotNull { podcast ->
+            podcast.latestEpisode?.let { episode ->
+                EpisodeRankingInput(
+                    episode = episode,
+                    podcast = podcast,
+                    priorScore = episode.publishedDate.toDouble().coerceAtLeast(0.0),
+                    source = CandidateSource.SUBSCRIPTION,
+                )
+            }
+        }
+        return adaptiveScorer.scoreEpisodes(
+            inputs = inputs,
+            history = history,
+            objective = RankingObjective.YOUR_SHOWS,
+        )
     }
 
     val hideCompletedInSubs: StateFlow<Boolean> = userPreferencesRepository.hideCompletedInSubsStream
@@ -143,9 +168,10 @@ class LibraryViewModel(
         // Apply sorting
         val sortedPodcasts = when (sort) {
             SubscriptionSort.SmartRank -> {
-                val podScoresMap = PodcastScoring.calculateScores(
+                val podScoresMap = adaptiveScorer.scorePodcasts(
                     podcasts = enrichedPodcasts.map { it.toScorable() },
-                    allHistory = allHistory
+                    history = allHistory,
+                    objective = RankingObjective.YOUR_SHOWS,
                 )
 
                 enrichedPodcasts.map { pod ->

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
@@ -13,6 +13,7 @@ import cx.aswin.boxcast.core.data.ranking.AdaptiveCandidateScorer
 import cx.aswin.boxcast.core.data.ranking.CandidateSource
 import cx.aswin.boxcast.core.data.ranking.EpisodeRankingInput
 import cx.aswin.boxcast.core.data.ranking.RankingObjective
+import cx.aswin.boxcast.core.data.ranking.RankingSurface
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.SharingStarted
@@ -115,6 +116,7 @@ class LibraryViewModel(
             inputs = inputs,
             history = history,
             objective = RankingObjective.YOUR_SHOWS,
+            surface = RankingSurface.LIBRARY,
         )
     }
 
@@ -172,6 +174,7 @@ class LibraryViewModel(
                     podcasts = enrichedPodcasts.map { it.toScorable() },
                     history = allHistory,
                     objective = RankingObjective.YOUR_SHOWS,
+                    surface = RankingSurface.LIBRARY,
                 )
 
                 enrichedPodcasts.map { pod ->

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
@@ -191,7 +191,8 @@ class LibraryViewModel(
                 }
 
                 enrichedPodcasts.map { pod ->
-                    pod to (podScoresMap[pod.id] ?: pod.latestEpisode?.publishedDate?.toDouble() ?: 0.0)
+                    val fallbackScore = pod.latestEpisode?.let { it.publishedDate.toDouble() } ?: 0.0
+                    pod to (podScoresMap[pod.id] ?: fallbackScore)
                 }.sortedWith(
                     compareByDescending<Pair<Podcast, Double>> { it.second }
                         .thenBy { it.first.title }

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/LibraryViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 enum class SubscriptionSort { SmartRank, RecentlyUpdated, Alphabetical, MostListened }
@@ -112,12 +113,18 @@ class LibraryViewModel(
                 )
             }
         }
-        return adaptiveScorer.scoreEpisodes(
-            inputs = inputs,
-            history = history,
-            objective = RankingObjective.YOUR_SHOWS,
-            surface = RankingSurface.LIBRARY,
-        )
+        return try {
+            adaptiveScorer.scoreEpisodes(
+                inputs = inputs,
+                history = history,
+                objective = RankingObjective.YOUR_SHOWS,
+                surface = RankingSurface.LIBRARY,
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (_: Exception) {
+            inputs.associate { it.episode.id to it.priorScore }
+        }
     }
 
     val hideCompletedInSubs: StateFlow<Boolean> = userPreferencesRepository.hideCompletedInSubsStream
@@ -170,15 +177,21 @@ class LibraryViewModel(
         // Apply sorting
         val sortedPodcasts = when (sort) {
             SubscriptionSort.SmartRank -> {
-                val podScoresMap = adaptiveScorer.scorePodcasts(
-                    podcasts = enrichedPodcasts.map { it.toScorable() },
-                    history = allHistory,
-                    objective = RankingObjective.YOUR_SHOWS,
-                    surface = RankingSurface.LIBRARY,
-                )
+                val podScoresMap = try {
+                    adaptiveScorer.scorePodcasts(
+                        podcasts = enrichedPodcasts.map { it.toScorable() },
+                        history = allHistory,
+                        objective = RankingObjective.YOUR_SHOWS,
+                        surface = RankingSurface.LIBRARY,
+                    )
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (_: Exception) {
+                    emptyMap()
+                }
 
                 enrichedPodcasts.map { pod ->
-                    pod to (podScoresMap[pod.id] ?: 0.0)
+                    pod to (podScoresMap[pod.id] ?: pod.latestEpisode?.publishedDate?.toDouble() ?: 0.0)
                 }.sortedWith(
                     compareByDescending<Pair<Podcast, Double>> { it.second }
                         .thenBy { it.first.title }

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
@@ -3,9 +3,6 @@ package cx.aswin.boxcast.feature.library
 import cx.aswin.boxcast.core.designsystem.components.optimizedImageUrl
 import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
 import cx.aswin.boxcast.core.designsystem.components.NewEpisodeBadge
-import cx.aswin.boxcast.core.data.PodcastScoring
-import cx.aswin.boxcast.core.data.toScorable
-
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.Spring
@@ -74,6 +71,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -472,6 +470,7 @@ fun SubscriptionsScreen(
                                     podcasts = latestPodcasts,
                                     allHistory = (uiState as LibraryUiState.Success).allHistory,
                                     useSmartRank = useSmartRank,
+                                    scoreEpisodes = viewModel::scoreLatestEpisodes,
                                     onExploreClick = onExploreClick,
                                     onEpisodeClick = { ep, pod, entry ->
                                         viewModel.subEpisodesClickedCount++
@@ -831,6 +830,10 @@ private fun LatestTabContent(
     podcasts: List<Podcast>,
     allHistory: List<ListeningHistoryEntity>,
     useSmartRank: Boolean,
+    scoreEpisodes: suspend (
+        List<Podcast>,
+        List<ListeningHistoryEntity>,
+    ) -> Map<String, Double>,
     onExploreClick: () -> Unit,
     onEpisodeClick: ((Episode, Podcast, String?) -> Unit)?,
     onPlayEpisode: ((Episode, Podcast) -> Unit)?,
@@ -874,27 +877,19 @@ private fun LatestTabContent(
             }
         }
 
-        val episodeScores = remember(filteredEpisodePodcasts, allHistory) {
-            val podScoresMap = PodcastScoring.calculateScores(
-                podcasts = filteredEpisodePodcasts.map { it.toScorable() },
-                allHistory = allHistory
-            )
-            filteredEpisodePodcasts.associate { pod ->
-                val latestEp = pod.latestEpisode
-                val episodeRecencyBoost = if (latestEp != null) {
-                    val hoursSinceRelease = (System.currentTimeMillis() / 1000.0 - latestEp.publishedDate) / 3600.0
-                    500.0 / (1.0 + hoursSinceRelease.coerceAtLeast(0.0) / 24.0)
-                } else {
-                    0.0
-                }
-                val podScore = podScoresMap[pod.id] ?: 0.0
-                pod.id to (podScore + episodeRecencyBoost)
-            }
+        val episodeScores by produceState<Map<String, Double>>(
+            initialValue = emptyMap(),
+            filteredEpisodePodcasts,
+            allHistory,
+        ) {
+            value = scoreEpisodes(filteredEpisodePodcasts, allHistory)
         }
 
         val displayPodcasts = remember(filteredEpisodePodcasts, useSmartRank, episodeScores) {
             if (useSmartRank) {
-                filteredEpisodePodcasts.sortedByDescending { episodeScores[it.id] ?: 0.0 }
+                filteredEpisodePodcasts.sortedByDescending {
+                    episodeScores[it.latestEpisode?.id] ?: 0.0
+                }
             } else {
                 filteredEpisodePodcasts.sortedByDescending { it.latestEpisode!!.publishedDate }
             }

--- a/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
+++ b/feature/library/src/main/java/cx/aswin/boxcast/feature/library/SubscriptionsScreen.kt
@@ -881,8 +881,13 @@ private fun LatestTabContent(
             initialValue = emptyMap(),
             filteredEpisodePodcasts,
             allHistory,
+            useSmartRank,
         ) {
-            value = scoreEpisodes(filteredEpisodePodcasts, allHistory)
+            value = if (useSmartRank) {
+                scoreEpisodes(filteredEpisodePodcasts, allHistory)
+            } else {
+                emptyMap()
+            }
         }
 
         val displayPodcasts = remember(filteredEpisodePodcasts, useSmartRank, episodeScores) {

--- a/feature/player/src/main/java/cx/aswin/boxcast/feature/player/SeekDurationIcon.kt
+++ b/feature/player/src/main/java/cx/aswin/boxcast/feature/player/SeekDurationIcon.kt
@@ -32,8 +32,8 @@ data class SeekControlDurations(
 @Composable
 internal fun seekDurationContentDescription(seconds: Int, forward: Boolean): String =
     pluralStringResource(
-        id = if (forward) R.plurals.seek_forward_seconds else R.plurals.seek_back_seconds,
-        count = seconds,
+        if (forward) R.plurals.seek_forward_seconds else R.plurals.seek_back_seconds,
+        seconds,
         seconds,
     )
 


### PR DESCRIPTION
## Summary
- build a private, on-device adaptive ranking foundation with versioned model storage
- learn bounded preference signals while retaining deterministic legacy fallbacks
- progressively integrate consistent ranking and content composition across listener surfaces

## Listener impact
### What changes in the user's life
BoxLore will learn which shows and episodes are useful on this device, keep important subscription and resume content protected, and make Home, discovery, queue, and downloads feel more relevant without requiring an account or uploading the learned taste profile.

## Privacy
- learned coefficients, preference facets, and exposure history remain on-device
- adaptive state is isolated from the library database and excluded from backup
- existing released API behavior remains available as a fallback

## Test plan
- [x] compile the adaptive ranking foundation
- [x] run deterministic ranking unit tests
- [x] install the debug build on a connected device
- [ ] wire local feedback and migrate shared scorers
- [ ] integrate content orchestration across all planned surfaces
- [ ] verify backward-compatible network and catalog fallbacks
- [ ] clear SonarCloud, CodeRabbit, and Qodo findings after every checkpoint
- [ ] complete manual listener verification before merge