### PR TITLE
feat(ui): redesign episode details and home curation

### DIFF
--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/ExpressivePlayButton.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/ExpressivePlayButton.kt
@@ -17,16 +17,20 @@ import androidx.compose.ui.unit.dp
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.designsystem.theme.contrastColor
 
+data class ExpressivePlayButtonState(
+    val isPlaying: Boolean,
+    val isResume: Boolean,
+    val isLoading: Boolean = false,
+    val progress: Float = 0f,
+    val timeText: String? = null,
+)
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ExpressivePlayButton(
     onClick: () -> Unit,
-    isPlaying: Boolean,
-    isResume: Boolean,
+    state: ExpressivePlayButtonState,
     accentColor: Color,
-    isLoading: Boolean = false,
-    progress: Float = 0f,
-    timeText: String? = null,
     modifier: Modifier = Modifier
 ) {
     Surface(
@@ -35,32 +39,36 @@ fun ExpressivePlayButton(
         shape = CircleShape,
         modifier = modifier
             .widthIn(min = 160.dp)
-            .expressiveClickable(enabled = !isLoading, isolate = true, onClick = onClick)
+            .expressiveClickable(enabled = !state.isLoading, isolate = true, onClick = onClick)
     ) {
         Box(contentAlignment = Alignment.Center) {
-            PlayButtonProgressStrip(isResume = isResume, progress = progress, accentColor = accentColor)
+            PlayButtonProgressStrip(
+                isResume = state.isResume,
+                progress = state.progress,
+                accentColor = accentColor,
+            )
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center,
                 modifier = Modifier.padding(horizontal = 14.dp)
             ) {
-                if (isLoading) {
+                if (state.isLoading) {
                     BoxLoreLoader.CircularWavy(
                         size = 24.dp,
                         color = accentColor.contrastColor(),
                     )
                 } else {
                     Icon(
-                        imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
+                        imageVector = if (state.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                        contentDescription = if (state.isPlaying) "Pause" else "Play",
                         modifier = Modifier.size(24.dp)
                     )
                 }
                 Spacer(modifier = Modifier.width(6.dp))
                 
                 Text(
-                    text = getPlayButtonDisplayText(isLoading, isPlaying, isResume, timeText),
+                    text = getPlayButtonDisplayText(state),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     maxLines = 1,
@@ -99,16 +107,13 @@ private fun PlayButtonProgressStrip(
 }
 
 private fun getPlayButtonDisplayText(
-    isLoading: Boolean,
-    isPlaying: Boolean,
-    isResume: Boolean,
-    timeText: String?
+    state: ExpressivePlayButtonState,
 ): String {
     return when {
-        isLoading -> "Loading"
-        isPlaying -> "Pause"
-        isResume && timeText != null -> "Resume • $timeText"
-        isResume -> "Resume"
+        state.isLoading -> "Loading"
+        state.isPlaying -> "Pause"
+        state.isResume && state.timeText != null -> "Resume • ${state.timeText}"
+        state.isResume -> "Resume"
         else -> "Play"
     }
 }

--- a/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/ExpressivePlayButton.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxcast/core/designsystem/components/ExpressivePlayButton.kt
@@ -24,6 +24,7 @@ fun ExpressivePlayButton(
     isPlaying: Boolean,
     isResume: Boolean,
     accentColor: Color,
+    isLoading: Boolean = false,
     progress: Float = 0f,
     timeText: String? = null,
     modifier: Modifier = Modifier
@@ -34,7 +35,7 @@ fun ExpressivePlayButton(
         shape = CircleShape,
         modifier = modifier
             .widthIn(min = 160.dp)
-            .expressiveClickable(isolate = true, onClick = onClick)
+            .expressiveClickable(enabled = !isLoading, isolate = true, onClick = onClick)
     ) {
         Box(contentAlignment = Alignment.Center) {
             PlayButtonProgressStrip(isResume = isResume, progress = progress, accentColor = accentColor)
@@ -44,15 +45,22 @@ fun ExpressivePlayButton(
                 horizontalArrangement = Arrangement.Center,
                 modifier = Modifier.padding(horizontal = 14.dp)
             ) {
-                Icon(
-                    imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                    contentDescription = if (isPlaying) "Pause" else "Play",
-                    modifier = Modifier.size(24.dp)
-                )
+                if (isLoading) {
+                    BoxLoreLoader.CircularWavy(
+                        size = 24.dp,
+                        color = accentColor.contrastColor(),
+                    )
+                } else {
+                    Icon(
+                        imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                        contentDescription = if (isPlaying) "Pause" else "Play",
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
                 Spacer(modifier = Modifier.width(6.dp))
                 
                 Text(
-                    text = getPlayButtonDisplayText(isPlaying, isResume, timeText),
+                    text = getPlayButtonDisplayText(isLoading, isPlaying, isResume, timeText),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
                     maxLines = 1,
@@ -91,11 +99,13 @@ private fun PlayButtonProgressStrip(
 }
 
 private fun getPlayButtonDisplayText(
+    isLoading: Boolean,
     isPlaying: Boolean,
     isResume: Boolean,
     timeText: String?
 ): String {
     return when {
+        isLoading -> "Loading"
         isPlaying -> "Pause"
         isResume && timeText != null -> "Resume • $timeText"
         isResume -> "Resume"

--- a/feature/briefing/src/main/java/cx/aswin/boxcast/feature/briefing/BriefingScreen.kt
+++ b/feature/briefing/src/main/java/cx/aswin/boxcast/feature/briefing/BriefingScreen.kt
@@ -104,6 +104,7 @@ import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
 import cx.aswin.boxcast.core.designsystem.components.ExpressivePlayButton
+import cx.aswin.boxcast.core.designsystem.components.ExpressivePlayButtonState
 import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
 import cx.aswin.boxcast.core.designsystem.theme.SectionHeaderFontFamily
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
@@ -765,11 +766,13 @@ fun BriefingContent(
             // Prominent Play Briefing Button
             ExpressivePlayButton(
                 onClick = { onPlayPauseClick(null) },
-                isPlaying = isPlaying,
-                isResume = isResume,
+                state = ExpressivePlayButtonState(
+                    isPlaying = isPlaying,
+                    isResume = isResume,
+                    progress = progress,
+                    timeText = timeText,
+                ),
                 accentColor = accentColor,
-                progress = progress,
-                timeText = timeText,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp)

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -1154,7 +1154,7 @@ private fun AdaptiveSectionVisibilityEffect(
     onAdaptiveSectionVisible: (ContentSection, Set<String>) -> Unit,
 ) {
     val sectionKey = "adaptive_${section.stableId}"
-    val currentOnAdaptiveSectionVisible by rememberUpdatedState(onAdaptiveSectionVisible)
+    val currentOnAdaptiveSectionVisible = rememberUpdatedState(onAdaptiveSectionVisible)
     LaunchedEffect(section, gridState, rowState) {
         snapshotFlow {
             val sectionVisible = gridState.layoutInfo.visibleItemsInfo.any {
@@ -1169,7 +1169,7 @@ private fun AdaptiveSectionVisibilityEffect(
             }
         }.distinctUntilChanged().collect { visibleCandidateIds ->
             if (visibleCandidateIds.isNotEmpty()) {
-                currentOnAdaptiveSectionVisible(section, visibleCandidateIds)
+                currentOnAdaptiveSectionVisible.value(section, visibleCandidateIds)
             }
         }
     }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Briefing
+import cx.aswin.boxcast.core.data.content.ContentCandidate
 import cx.aswin.boxcast.core.data.content.ContentSection
 import cx.aswin.boxcast.feature.home.components.DailyBriefingCard
 
@@ -1091,92 +1092,136 @@ private fun LazyStaggeredGridScope.adaptiveSectionItem(
         key = "adaptive_${section.stableId}",
         contentType = "adaptive_section",
     ) {
-        val rowState = rememberLazyListState()
-        val sectionKey = "adaptive_${section.stableId}"
-        LaunchedEffect(section, gridState, rowState) {
-            snapshotFlow {
-                val sectionVisible = gridState.layoutInfo.visibleItemsInfo.any {
-                    it.key == sectionKey
-                }
-                if (sectionVisible) {
-                    rowState.layoutInfo.visibleItemsInfo
-                        .mapNotNull { it.key as? String }
-                        .toSet()
-                } else {
-                    emptySet()
-                }
-            }.distinctUntilChanged().collect { visibleCandidateIds ->
-                if (visibleCandidateIds.isNotEmpty()) {
-                    onAdaptiveSectionVisible(section, visibleCandidateIds)
-                }
-            }
+        AdaptiveSectionContent(
+            section = section,
+            gridState = gridState,
+            showHeader = showHeader,
+            onAdaptiveSectionVisible = onAdaptiveSectionVisible,
+            onPodcastClick = onPodcastClick,
+            onEpisodeClick = onEpisodeClick,
+        )
+    }
+}
+
+@Composable
+private fun AdaptiveSectionContent(
+    section: ContentSection,
+    gridState: LazyStaggeredGridState,
+    showHeader: Boolean,
+    onAdaptiveSectionVisible: (ContentSection, Set<String>) -> Unit,
+    onPodcastClick: (Podcast, String, String?, Int?) -> Unit,
+    onEpisodeClick: ((Episode, Podcast, String?) -> Unit)?,
+) {
+    val rowState = rememberLazyListState()
+    AdaptiveSectionVisibilityEffect(
+        section = section,
+        gridState = gridState,
+        rowState = rowState,
+        onAdaptiveSectionVisible = onAdaptiveSectionVisible,
+    )
+    Column(
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier.padding(bottom = 12.dp),
+    ) {
+        if (showHeader) {
+            AdaptiveSectionHeader(section)
         }
-        Column(
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-            modifier = Modifier.padding(bottom = 12.dp),
+        LazyRow(
+            state = rowState,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            if (showHeader) {
-                Column {
-                    Text(
-                        text = section.intent.title,
-                        style = MaterialTheme.typography.headlineSmall.copy(
-                            fontFamily = SectionHeaderFontFamily,
-                            fontWeight = FontWeight.Bold,
-                        ),
-                    )
-                    section.intent.subtitle?.let { subtitle ->
-                        Text(
-                            text = subtitle,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
-            LazyRow(
-                state = rowState,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                lazyRowItems(
-                    items = section.items,
-                    key = { candidate -> candidate.id },
-                ) { candidate ->
-                    val episode = candidate.episode
-                    val onCandidateClick: () -> Unit = {
-                        if (episode == null) {
-                            onPodcastClick(
-                                candidate.podcast,
-                                "home_adaptive_${section.intent.id}",
-                                null,
-                                null,
-                            )
-                        } else {
-                            onEpisodeClick?.invoke(
-                                episode,
-                                candidate.podcast,
-                                "home_adaptive_${section.intent.id}",
-                            )
-                        }
-                        Unit
-                    }
-                    if (episode == null) {
-                        PodcastCard(
-                            podcast = candidate.podcast,
-                            onClick = onCandidateClick,
-                            modifier = Modifier.width(156.dp),
-                            showGenreChip = false,
-                        )
-                    } else {
-                        CuratedEpisodeCard(
-                            podcast = candidate.podcast,
-                            episode = episode,
-                            onClick = onCandidateClick,
-                            modifier = Modifier.width(156.dp),
-                        )
-                    }
-                }
+            lazyRowItems(
+                items = section.items,
+                key = ContentCandidate::id,
+            ) { candidate ->
+                AdaptiveCandidateCard(
+                    candidate = candidate,
+                    source = "home_adaptive_${section.intent.id}",
+                    onPodcastClick = onPodcastClick,
+                    onEpisodeClick = onEpisodeClick,
+                )
             }
         }
+    }
+}
+
+@Composable
+private fun AdaptiveSectionVisibilityEffect(
+    section: ContentSection,
+    gridState: LazyStaggeredGridState,
+    rowState: androidx.compose.foundation.lazy.LazyListState,
+    onAdaptiveSectionVisible: (ContentSection, Set<String>) -> Unit,
+) {
+    val sectionKey = "adaptive_${section.stableId}"
+    LaunchedEffect(section, gridState, rowState) {
+        snapshotFlow {
+            val sectionVisible = gridState.layoutInfo.visibleItemsInfo.any {
+                it.key == sectionKey
+            }
+            if (sectionVisible) {
+                rowState.layoutInfo.visibleItemsInfo
+                    .mapNotNull { it.key as? String }
+                    .toSet()
+            } else {
+                emptySet()
+            }
+        }.distinctUntilChanged().collect { visibleCandidateIds ->
+            if (visibleCandidateIds.isNotEmpty()) {
+                onAdaptiveSectionVisible(section, visibleCandidateIds)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AdaptiveSectionHeader(section: ContentSection) {
+    Column {
+        Text(
+            text = section.intent.title,
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontFamily = SectionHeaderFontFamily,
+                fontWeight = FontWeight.Bold,
+            ),
+        )
+        section.intent.subtitle?.let { subtitle ->
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AdaptiveCandidateCard(
+    candidate: ContentCandidate,
+    source: String,
+    onPodcastClick: (Podcast, String, String?, Int?) -> Unit,
+    onEpisodeClick: ((Episode, Podcast, String?) -> Unit)?,
+) {
+    val episode = candidate.episode
+    val onCandidateClick: () -> Unit = {
+        if (episode == null) {
+            onPodcastClick(candidate.podcast, source, null, null)
+        } else {
+            onEpisodeClick?.invoke(episode, candidate.podcast, source)
+        }
+    }
+    if (episode == null) {
+        PodcastCard(
+            podcast = candidate.podcast,
+            onClick = onCandidateClick,
+            modifier = Modifier.width(156.dp),
+            showGenreChip = false,
+        )
+    } else {
+        CuratedEpisodeCard(
+            podcast = candidate.podcast,
+            episode = episode,
+            onClick = onCandidateClick,
+            modifier = Modifier.width(156.dp),
+        )
     }
 }
 

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.navigation.NavController
 import kotlinx.coroutines.flow.map
@@ -1153,6 +1154,7 @@ private fun AdaptiveSectionVisibilityEffect(
     onAdaptiveSectionVisible: (ContentSection, Set<String>) -> Unit,
 ) {
     val sectionKey = "adaptive_${section.stableId}"
+    val currentOnAdaptiveSectionVisible by rememberUpdatedState(onAdaptiveSectionVisible)
     LaunchedEffect(section, gridState, rowState) {
         snapshotFlow {
             val sectionVisible = gridState.layoutInfo.visibleItemsInfo.any {
@@ -1167,7 +1169,7 @@ private fun AdaptiveSectionVisibilityEffect(
             }
         }.distinctUntilChanged().collect { visibleCandidateIds ->
             if (visibleCandidateIds.isNotEmpty()) {
-                onAdaptiveSectionVisible(section, visibleCandidateIds)
+                currentOnAdaptiveSectionVisible(section, visibleCandidateIds)
             }
         }
     }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/HomeScreen.kt
@@ -22,8 +22,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items as lazyRowItems
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.items
@@ -658,6 +659,25 @@ private fun PodcastFeed(
     }
     val showDiscoverContent = !isLoading && !isFilterLoading && discoverItems.isNotEmpty()
     val discoverGenreChip = selectedCategory == null
+    val primaryAdaptiveSection = remember(adaptiveSections.list, timeBlock) {
+        timeBlock?.let {
+            adaptiveSections.list.firstOrNull { section -> section.intent.protected }
+                ?: adaptiveSections.list.firstOrNull()
+        }
+    }
+    val standaloneAdaptiveSections = remember(adaptiveSections.list, primaryAdaptiveSection) {
+        adaptiveSections.list.filterNot { it.stableId == primaryAdaptiveSection?.stableId }
+    }
+    val adaptiveTimeBlock = remember(timeBlock, primaryAdaptiveSection) {
+        timeBlock?.let { block ->
+            primaryAdaptiveSection?.let { section ->
+                block.copy(
+                    title = section.intent.title,
+                    subtitle = section.intent.subtitle ?: block.subtitle,
+                )
+            } ?: block
+        }
+    }
 
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Fixed(2),
@@ -961,97 +981,15 @@ private fun PodcastFeed(
             }
         }
 
-        adaptiveSections.list.forEach { section ->
-            item(
-                span = StaggeredGridItemSpan.FullLine,
-                key = "adaptive_${section.stableId}",
-                contentType = "adaptive_section",
-            ) {
-                val rowState = rememberLazyListState()
-                val sectionKey = "adaptive_${section.stableId}"
-                LaunchedEffect(section, gridState, rowState) {
-                    snapshotFlow {
-                        val sectionVisible = gridState.layoutInfo.visibleItemsInfo.any {
-                            it.key == sectionKey
-                        }
-                        if (sectionVisible) {
-                            rowState.layoutInfo.visibleItemsInfo
-                                .mapNotNull { it.key as? String }
-                                .toSet()
-                        } else {
-                            emptySet()
-                        }
-                    }.distinctUntilChanged().collect { visibleCandidateIds ->
-                        if (visibleCandidateIds.isNotEmpty()) {
-                            onAdaptiveSectionVisible(section, visibleCandidateIds)
-                        }
-                    }
-                }
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                    modifier = Modifier.padding(bottom = 12.dp),
-                ) {
-                    Column {
-                        Text(
-                            text = section.intent.title,
-                            style = MaterialTheme.typography.headlineSmall.copy(
-                                fontFamily = SectionHeaderFontFamily,
-                                fontWeight = FontWeight.Bold,
-                            ),
-                        )
-                        section.intent.subtitle?.let { subtitle ->
-                            Text(
-                                text = subtitle,
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                    LazyRow(
-                        state = rowState,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    ) {
-                        lazyRowItems(
-                            items = section.items,
-                            key = { candidate -> candidate.id },
-                        ) { candidate ->
-                            val episode = candidate.episode
-                            val onCandidateClick: () -> Unit = {
-                                if (episode == null) {
-                                        onPodcastClick(
-                                            candidate.podcast,
-                                            "home_adaptive_${section.intent.id}",
-                                            null,
-                                            null,
-                                        )
-                                } else {
-                                    onEpisodeClick?.invoke(
-                                        episode,
-                                        candidate.podcast,
-                                        "home_adaptive_${section.intent.id}",
-                                    )
-                                }
-                                Unit
-                            }
-                            if (episode == null) {
-                                PodcastCard(
-                                    podcast = candidate.podcast,
-                                    onClick = onCandidateClick,
-                                    modifier = Modifier.width(156.dp),
-                                    showGenreChip = false,
-                                )
-                            } else {
-                                CuratedEpisodeCard(
-                                    podcast = candidate.podcast,
-                                    episode = episode,
-                                    onClick = onCandidateClick,
-                                    modifier = Modifier.width(156.dp),
-                                )
-                            }
-                        }
-                    }
-                }
-            }
+        standaloneAdaptiveSections.forEach { section ->
+            adaptiveSectionItem(
+                section = section,
+                gridState = gridState,
+                showHeader = true,
+                onAdaptiveSectionVisible = onAdaptiveSectionVisible,
+                onPodcastClick = onPodcastClick,
+                onEpisodeClick = onEpisodeClick,
+            )
         }
 
         // 3. Time-Based Curated Block — flattened so the header and each vibe rail are
@@ -1061,14 +999,26 @@ private fun PodcastFeed(
             item(span = StaggeredGridItemSpan.FullLine, key = "time_block_skeleton", contentType = "time_block_skeleton") {
                 TimeBlockSkeleton()
             }
-        } else if (timeBlock != null) {
+        } else if (adaptiveTimeBlock != null) {
             timeBlockItems(
-                data = timeBlock,
+                data = adaptiveTimeBlock,
                 onCuratedEpisodeClick = { episode, podcast, vibeId, pos -> onCuratedEpisodeClick?.invoke(episode, podcast, vibeId, pos) },
                 onImpression = onCuratedImpression,
                 onSeeAllClick = {
                     onNavigateToExplore?.invoke(null, "home_time_block_see_all", "foryou")
-                }
+                },
+                leadingContent = {
+                    primaryAdaptiveSection?.let { section ->
+                        adaptiveSectionItem(
+                            section = section,
+                            gridState = gridState,
+                            showHeader = false,
+                            onAdaptiveSectionVisible = onAdaptiveSectionVisible,
+                            onPodcastClick = onPodcastClick,
+                            onEpisodeClick = onEpisodeClick,
+                        )
+                    }
+                },
             )
         }
 
@@ -1123,6 +1073,108 @@ private fun PodcastFeed(
             // Skeleton cards — also individual staggered items so they animate cheaply.
             items(6, key = { "discover_skel_$it" }, contentType = { "discover_skel" }) {
                 GridSkeletonItem()
+            }
+        }
+    }
+}
+
+private fun LazyStaggeredGridScope.adaptiveSectionItem(
+    section: ContentSection,
+    gridState: LazyStaggeredGridState,
+    showHeader: Boolean,
+    onAdaptiveSectionVisible: (ContentSection, Set<String>) -> Unit,
+    onPodcastClick: (Podcast, String, String?, Int?) -> Unit,
+    onEpisodeClick: ((Episode, Podcast, String?) -> Unit)?,
+) {
+    item(
+        span = StaggeredGridItemSpan.FullLine,
+        key = "adaptive_${section.stableId}",
+        contentType = "adaptive_section",
+    ) {
+        val rowState = rememberLazyListState()
+        val sectionKey = "adaptive_${section.stableId}"
+        LaunchedEffect(section, gridState, rowState) {
+            snapshotFlow {
+                val sectionVisible = gridState.layoutInfo.visibleItemsInfo.any {
+                    it.key == sectionKey
+                }
+                if (sectionVisible) {
+                    rowState.layoutInfo.visibleItemsInfo
+                        .mapNotNull { it.key as? String }
+                        .toSet()
+                } else {
+                    emptySet()
+                }
+            }.distinctUntilChanged().collect { visibleCandidateIds ->
+                if (visibleCandidateIds.isNotEmpty()) {
+                    onAdaptiveSectionVisible(section, visibleCandidateIds)
+                }
+            }
+        }
+        Column(
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.padding(bottom = 12.dp),
+        ) {
+            if (showHeader) {
+                Column {
+                    Text(
+                        text = section.intent.title,
+                        style = MaterialTheme.typography.headlineSmall.copy(
+                            fontFamily = SectionHeaderFontFamily,
+                            fontWeight = FontWeight.Bold,
+                        ),
+                    )
+                    section.intent.subtitle?.let { subtitle ->
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+            LazyRow(
+                state = rowState,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                lazyRowItems(
+                    items = section.items,
+                    key = { candidate -> candidate.id },
+                ) { candidate ->
+                    val episode = candidate.episode
+                    val onCandidateClick: () -> Unit = {
+                        if (episode == null) {
+                            onPodcastClick(
+                                candidate.podcast,
+                                "home_adaptive_${section.intent.id}",
+                                null,
+                                null,
+                            )
+                        } else {
+                            onEpisodeClick?.invoke(
+                                episode,
+                                candidate.podcast,
+                                "home_adaptive_${section.intent.id}",
+                            )
+                        }
+                        Unit
+                    }
+                    if (episode == null) {
+                        PodcastCard(
+                            podcast = candidate.podcast,
+                            onClick = onCandidateClick,
+                            modifier = Modifier.width(156.dp),
+                            showGenreChip = false,
+                        )
+                    } else {
+                        CuratedEpisodeCard(
+                            podcast = candidate.podcast,
+                            episode = episode,
+                            onClick = onCandidateClick,
+                            modifier = Modifier.width(156.dp),
+                        )
+                    }
+                }
             }
         }
     }

--- a/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/TimeBlockSection.kt
+++ b/feature/home/src/main/java/cx/aswin/boxcast/feature/home/components/TimeBlockSection.kt
@@ -50,7 +50,8 @@ fun LazyStaggeredGridScope.timeBlockItems(
     data: CuratedTimeBlock,
     onCuratedEpisodeClick: (Episode, Podcast, String, Int) -> Unit,
     onImpression: (String, List<String>) -> Unit = { _, _ -> },
-    onSeeAllClick: () -> Unit = {}
+    onSeeAllClick: () -> Unit = {},
+    leadingContent: LazyStaggeredGridScope.() -> Unit = {},
 ) {
     item(span = StaggeredGridItemSpan.FullLine, key = "time_block_header", contentType = "time_block_header") {
         LaunchedEffect(data.title) {
@@ -58,6 +59,7 @@ fun LazyStaggeredGridScope.timeBlockItems(
         }
         TimeBlockHeader(data = data, onSeeAllClick = onSeeAllClick)
     }
+    leadingContent()
     data.sections.forEachIndexed { index, section ->
         item(
             span = StaggeredGridItemSpan.FullLine,
@@ -96,14 +98,23 @@ private fun TimeBlockHeader(
                 fallbackIcon = data.icon
             )
             Spacer(modifier = Modifier.width(10.dp))
-            Text(
-                text = data.title,
-                style = MaterialTheme.typography.headlineSmall.copy(
-                    fontFamily = SectionHeaderFontFamily,
-                    fontWeight = FontWeight.Bold
-                ),
-                color = MaterialTheme.colorScheme.onSurface
-            )
+            Column {
+                Text(
+                    text = data.title,
+                    style = MaterialTheme.typography.headlineSmall.copy(
+                        fontFamily = SectionHeaderFontFamily,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                data.subtitle.takeIf(String::isNotBlank)?.let { subtitle ->
+                    Text(
+                        text = subtitle,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
         }
 
         // Action chevron decorator

--- a/feature/info/build.gradle.kts
+++ b/feature/info/build.gradle.kts
@@ -50,4 +50,6 @@ dependencies {
     implementation(libs.androidx.palette.ktx)
     implementation(libs.smooth.corner.rect)
     implementation(libs.posthog.android)
+
+    testImplementation(libs.junit)
 }

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/CrossPromotionCard.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/CrossPromotionCard.kt
@@ -1,7 +1,6 @@
 package cx.aswin.boxcast.feature.info
 
 import android.text.Html
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.*
@@ -32,22 +31,17 @@ fun CrossPromotionCard(
 ) {
     val podcast = crossPromotion.targetPodcast ?: return
 
-    val primaryColor = MaterialTheme.colorScheme.primary
-    val surfaceColor = MaterialTheme.colorScheme.surfaceContainerLow
+    val primaryColor = MaterialTheme.colorScheme.tertiary
+    val surfaceColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.42f)
 
-    OutlinedCard(
-        shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.outlinedCardColors(
-            containerColor = surfaceColor
-        ),
-        border = BorderStroke(
-            width = 1.dp,
-            color = MaterialTheme.colorScheme.outlineVariant
-        ),
+    Surface(
+        shape = MaterialTheme.shapes.extraLarge,
+        color = surfaceColor,
+        tonalElevation = 2.dp,
         modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
-            .expressiveClickable { onPodcastClick(podcast.id) }
+            .expressiveClickable { onPodcastClick(podcast.id) },
     ) {
         Column(
             modifier = Modifier
@@ -59,17 +53,24 @@ fun CrossPromotionCard(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp)
             ) {
-                Icon(
-                    imageVector = Icons.Rounded.Podcasts,
-                    contentDescription = null,
-                    tint = primaryColor,
-                    modifier = Modifier.size(16.dp)
-                )
+                Surface(
+                    modifier = Modifier.size(34.dp),
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = primaryColor,
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = Icons.Rounded.Podcasts,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
                 Text(
-                    text = "FEATURED SHOW",
-                    style = MaterialTheme.typography.labelMedium.copy(
+                    text = "Featured show",
+                    style = MaterialTheme.typography.titleSmall.copy(
                         fontWeight = FontWeight.Bold,
-                        letterSpacing = 0.5.sp
                     ),
                     color = primaryColor
                 )
@@ -145,15 +146,14 @@ fun CrossPromotionCard(
 
                 Spacer(modifier = Modifier.width(12.dp))
 
-                // View Arrow Button
-                IconButton(
-                    onClick = { onPodcastClick(podcast.id) },
+                Box(
                     modifier = Modifier
                         .size(36.dp)
                         .background(
                             color = MaterialTheme.colorScheme.primaryContainer,
                             shape = CircleShape
-                        )
+                        ),
+                    contentAlignment = Alignment.Center,
                 ) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeDescriptionCard.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeDescriptionCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -31,6 +32,7 @@ import androidx.compose.ui.unit.sp
 import cx.aswin.boxcast.core.designsystem.component.HtmlText
 import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
 import cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes
+import cx.aswin.boxcast.core.designsystem.theme.contrastColor
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.model.Person
 
@@ -363,6 +365,8 @@ internal fun EpisodeDescriptionCard(
 
             if (isLong) {
                 Spacer(modifier = Modifier.height(8.dp))
+                val readMoreContainerColor = accentColor.copy(alpha = 0.14f)
+                    .compositeOver(MaterialTheme.colorScheme.surfaceContainerLow)
                 Surface(
                     modifier = Modifier
                         .align(Alignment.CenterHorizontally)
@@ -371,8 +375,8 @@ internal fun EpisodeDescriptionCard(
                             onClick = { expanded = !expanded },
                         ),
                     shape = ExpressiveShapes.Pill,
-                    color = accentColor.copy(alpha = 0.14f),
-                    contentColor = accentColor,
+                    color = readMoreContainerColor,
+                    contentColor = readMoreContainerColor.contrastColor(),
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp),

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeDescriptionCard.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeDescriptionCard.kt
@@ -6,13 +6,12 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.Notes
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
@@ -214,13 +213,13 @@ internal fun EpisodeDescriptionCard(
             .padding(horizontal = 16.dp)
             .expressiveClickable(enabled = isLong) { expanded = !expanded },
         color = MaterialTheme.colorScheme.surfaceContainerLow,
-        shape = MaterialTheme.shapes.large,
-        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant)
+        shape = MaterialTheme.shapes.extraLarge,
+        tonalElevation = 2.dp,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp)
+                .padding(20.dp)
                 .animateContentSize(
                     animationSpec = spring(
                         dampingRatio = Spring.DampingRatioNoBouncy,
@@ -228,13 +227,26 @@ internal fun EpisodeDescriptionCard(
                     )
                 )
         ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = "Episode notes",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Black,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+            Spacer(modifier = Modifier.height(22.dp))
+
             // --- Cast & Crew (Person chips) ---
             if (!persons.isNullOrEmpty()) {
-                Text(
+                DescriptionSectionTitle(
                     text = "Cast & Crew",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    icon = Icons.Rounded.Groups,
+                    accentColor = accentColor,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
 
@@ -267,11 +279,10 @@ internal fun EpisodeDescriptionCard(
 
             // --- Social Links ---
             if (socialLinks.isNotEmpty()) {
-                Text(
+                DescriptionSectionTitle(
                     text = "Episode Resources",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    icon = Icons.Rounded.Link,
+                    accentColor = accentColor,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
 
@@ -302,11 +313,10 @@ internal fun EpisodeDescriptionCard(
             }
 
             // --- Description ---
-            Text(
+            DescriptionSectionTitle(
                 text = "About this episode",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurface,
+                icon = Icons.AutoMirrored.Rounded.Notes,
+                accentColor = accentColor,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
 
@@ -353,27 +363,34 @@ internal fun EpisodeDescriptionCard(
 
             if (isLong) {
                 Spacer(modifier = Modifier.height(8.dp))
-                Row(
+                Surface(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .expressiveClickable(shape = RoundedCornerShape(8.dp)) { expanded = !expanded }
-                        .padding(vertical = 4.dp),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
+                        .align(Alignment.CenterHorizontally)
+                        .expressiveClickable(
+                            shape = ExpressiveShapes.Pill,
+                            onClick = { expanded = !expanded },
+                        ),
+                    shape = ExpressiveShapes.Pill,
+                    color = accentColor.copy(alpha = 0.14f),
+                    contentColor = accentColor,
                 ) {
-                    Text(
-                        text = if (expanded) "Show less" else "Read more",
-                        style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Bold,
-                        color = accentColor.copy(alpha = 0.9f)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Icon(
-                        imageVector = if (expanded) Icons.Rounded.KeyboardArrowUp else Icons.Rounded.KeyboardArrowDown,
-                        contentDescription = null,
-                        tint = accentColor.copy(alpha = 0.9f),
-                        modifier = Modifier.size(16.dp)
-                    )
+                    Row(
+                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = if (expanded) "Show less" else "Read more",
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Icon(
+                            imageVector = if (expanded) Icons.Rounded.KeyboardArrowUp else Icons.Rounded.KeyboardArrowDown,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
                 }
             }
 
@@ -439,6 +456,33 @@ internal fun EpisodeDescriptionCard(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun DescriptionSectionTitle(
+    text: String,
+    icon: ImageVector,
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = accentColor,
+            modifier = Modifier.size(19.dp),
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
     }
 }
 

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoScreen.kt
@@ -1,21 +1,21 @@
 package cx.aswin.boxcast.feature.info
 
+import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
+import android.os.Bundle
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,46 +26,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.animation.animateContentSize
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.blur
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.ArrowBack
-import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.rounded.Podcasts
-import androidx.compose.material.icons.rounded.Subscriptions
-import androidx.compose.material.icons.rounded.AutoAwesome
-import androidx.compose.ui.res.painterResource
-import androidx.compose.material.icons.automirrored.rounded.QueueMusic
-import androidx.compose.material.icons.automirrored.rounded.Label
-import androidx.compose.material.icons.outlined.Download
-import androidx.compose.material.icons.outlined.Favorite
-import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Share
-import androidx.compose.material.icons.rounded.Schedule
-import androidx.compose.material.icons.rounded.CalendarToday
-import androidx.compose.material.icons.rounded.Tag
-import androidx.compose.material.icons.rounded.Label
-import androidx.compose.material.icons.rounded.Videocam
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.Subscriptions
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -80,11 +48,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
@@ -92,35 +57,30 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.lerp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.palette.graphics.Palette
 import coil.compose.AsyncImagePainter
-import coil.compose.SubcomposeAsyncImage
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
-import cx.aswin.boxcast.core.designsystem.component.HtmlText
-import cx.aswin.boxcast.core.designsystem.components.AnimatedShapesFallback
+import cx.aswin.boxcast.core.data.ShareManager
 import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
-import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import cx.aswin.boxcast.core.designsystem.components.ShareBottomSheet
 import cx.aswin.boxcast.core.designsystem.theme.ExpressiveMotion
 import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
-import cx.aswin.boxcast.core.designsystem.theme.m3Shimmer
-import cx.aswin.boxcast.core.designsystem.components.ControlStyle
-import racra.compose.smooth_corner_rect_library.AbsoluteSmoothCornerShape
-import kotlinx.coroutines.delay
-import androidx.compose.ui.layout.layout
+import cx.aswin.boxcast.core.model.Episode
+import cx.aswin.boxcast.feature.info.components.CompactEpisodeActionRail
+import cx.aswin.boxcast.feature.info.components.EpisodeActionRail
+import cx.aswin.boxcast.feature.info.components.EpisodeActionRailCallbacks
+import cx.aswin.boxcast.feature.info.components.EpisodeActionRailState
+import cx.aswin.boxcast.feature.info.components.EpisodeArtworkBackdrop
+import cx.aswin.boxcast.feature.info.components.EpisodeInfoHero
+import cx.aswin.boxcast.feature.info.components.EpisodeRecommendationSection
 
-// Color extraction helper
-private fun extractDominantColor(bitmap: android.graphics.Bitmap): Color {
-    val palette = Palette.from(bitmap).generate()
-    val vibrant = palette.vibrantSwatch?.rgb
-    val muted = palette.mutedSwatch?.rgb
-    val dominant = palette.dominantSwatch?.rgb
-    val colorInt = vibrant ?: muted ?: dominant ?: 0xFF6200EE.toInt()
-    return Color(colorInt)
-}
+private const val HERO_ITEM_KEY = "episode_hero"
+private const val ACTION_RAIL_ITEM_KEY = "episode_action_rail"
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun EpisodeInfoScreen(
     episodeId: String,
@@ -132,45 +92,36 @@ fun EpisodeInfoScreen(
     podcastId: String,
     podcastTitle: String,
     viewModel: EpisodeInfoViewModel,
-    onBack: () -> Unit,
+    @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
     onPodcastClick: (String) -> Unit,
-    onEpisodeClick: (cx.aswin.boxcast.core.model.Episode) -> Unit,
-    onPlay: () -> Unit,
-    entryPointContext: android.os.Bundle? = null,
+    onEpisodeClick: (Episode) -> Unit,
+    @Suppress("UNUSED_PARAMETER") onPlay: () -> Unit,
+    entryPointContext: Bundle? = null,
     showMarkPlayedTip: Boolean = false,
     onMarkPlayedTipDismissed: () -> Unit = {},
     bottomContentPadding: Dp = 0.dp,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val likedEpisodeIds by viewModel.likedEpisodeIds.collectAsState()
     val completedEpisodeIds by viewModel.completedEpisodeIds.collectAsState()
     val queuedEpisodeIds by viewModel.queuedEpisodeIds.collectAsState()
-    val listState = rememberLazyListState()
-    val context = LocalContext.current
-    val density = LocalDensity.current
+    val isDownloaded by viewModel.isDownloaded(episodeId).collectAsState(initial = false)
+    val isDownloading by viewModel.isDownloading(episodeId).collectAsState(initial = false)
+    val lifecycleOwner = LocalLifecycleOwner.current
 
-    // Dynamic color extraction
-    var extractedColor by remember { mutableStateOf(Color.Transparent) }
-    val accentColor by animateColorAsState(
-        targetValue = if (extractedColor != Color.Transparent) extractedColor else MaterialTheme.colorScheme.primary,
-        animationSpec = spring(stiffness = Spring.StiffnessLow),
-        label = "accent_color"
-    )
-
-    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
-        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+        val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                androidx.lifecycle.Lifecycle.Event.ON_STOP -> viewModel.trackScreenExit()
-                androidx.lifecycle.Lifecycle.Event.ON_START -> viewModel.onScreenResume()
-                else -> {}
+                Lifecycle.Event.ON_STOP -> viewModel.trackScreenExit()
+                Lifecycle.Event.ON_START -> viewModel.onScreenResume()
+                else -> Unit
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose {
             lifecycleOwner.lifecycle.removeObserver(observer)
-            viewModel.trackScreenExit() // Fallback if disposed directly
+            viewModel.trackScreenExit()
         }
     }
 
@@ -184,948 +135,406 @@ fun EpisodeInfoScreen(
             episodeDuration = episodeDuration,
             podcastId = podcastId,
             podcastTitle = podcastTitle,
-            entryPointContext = entryPointContext
+            entryPointContext = entryPointContext,
         )
     }
 
-    // Download State
-    val isDownloaded by viewModel.isDownloaded(episodeId).collectAsState(initial = false)
-    val isDownloading by viewModel.isDownloading(episodeId).collectAsState(initial = false)
+    when (val state = uiState) {
+        EpisodeInfoUiState.Loading -> EpisodeInfoLoading(modifier)
+        EpisodeInfoUiState.Error -> EpisodeInfoError(modifier)
+        is EpisodeInfoUiState.Success -> EpisodeInfoSuccess(
+            state = state,
+            liked = state.episode.id in likedEpisodeIds,
+            completed = state.episode.id in completedEpisodeIds,
+            queued = state.episode.id in queuedEpisodeIds,
+            downloaded = isDownloaded,
+            downloading = isDownloading,
+            viewModel = viewModel,
+            entryPointContext = entryPointContext,
+            onPodcastClick = onPodcastClick,
+            onEpisodeClick = onEpisodeClick,
+            showMarkPlayedTip = showMarkPlayedTip,
+            onMarkPlayedTipDismissed = onMarkPlayedTipDismissed,
+            bottomContentPadding = bottomContentPadding,
+            modifier = modifier,
+        )
+    }
+}
 
-    // Scroll-driven animation state
+@Composable
+private fun EpisodeInfoSuccess(
+    state: EpisodeInfoUiState.Success,
+    liked: Boolean,
+    completed: Boolean,
+    queued: Boolean,
+    downloaded: Boolean,
+    downloading: Boolean,
+    viewModel: EpisodeInfoViewModel,
+    entryPointContext: Bundle?,
+    onPodcastClick: (String) -> Unit,
+    onEpisodeClick: (Episode) -> Unit,
+    showMarkPlayedTip: Boolean,
+    onMarkPlayedTipDismissed: () -> Unit,
+    bottomContentPadding: Dp,
+    modifier: Modifier,
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val listState = rememberLazyListState()
+    var showShareSheet by remember { mutableStateOf(false) }
+    var extractedColor by remember(state.episode.id) { mutableStateOf(Color.Unspecified) }
+    val artworkUrl = state.episode.imageUrl?.ifBlank { state.episode.podcastImageUrl }
+    val podcastArtworkUrl = state.episode.podcastImageUrl?.ifBlank { state.episode.imageUrl }
+    val palettePainter = rememberAsyncImagePainter(
+        model = ImageRequest.Builder(context)
+            .data(podcastArtworkUrl)
+            .allowHardware(false)
+            .build(),
+    )
+
+    LaunchedEffect(palettePainter.state) {
+        val painterState = palettePainter.state
+        if (painterState is AsyncImagePainter.State.Success) {
+            val bitmap = (painterState.result.drawable as? BitmapDrawable)?.bitmap
+            if (bitmap != null) extractedColor = extractArtworkColor(bitmap)
+        }
+    }
+
+    val paletteColor = if (extractedColor == Color.Unspecified) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        extractedColor
+    }
+    val accentColor by animateColorAsState(
+        targetValue = lerp(paletteColor, MaterialTheme.colorScheme.primary, 0.14f),
+        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        label = "episode_accent",
+    )
+    val collapseThresholdPx = with(density) { 320.dp.toPx() }
     val scrollOffset by remember {
         derivedStateOf {
             if (listState.firstVisibleItemIndex == 0) {
                 listState.firstVisibleItemScrollOffset.toFloat()
-            } else 1000f // Fully collapsed
+            } else {
+                collapseThresholdPx
+            }
         }
     }
-    
-    val morphThreshold = with(density) { 180.dp.toPx() }
-    val scrollFraction = (scrollOffset / morphThreshold).coerceIn(0f, 1f)
-
-    // Header dimensions
+    val collapseFraction = (scrollOffset / collapseThresholdPx).coerceIn(0f, 1f)
+    val stickyRailVisible by remember {
+        derivedStateOf {
+            listState.firstVisibleItemIndex >= 2 &&
+                listState.layoutInfo.visibleItemsInfo.none { it.key == ACTION_RAIL_ITEM_KEY }
+        }
+    }
     val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
-    val collapsedHeaderHeight = 64.dp + statusBarHeight
-
-    // Header background: transparent → surfaceContainer
-    // NOTE: Don't lerp from Color.Transparent - it has RGB=0,0,0 causing black flash
-    val surfaceColor = MaterialTheme.colorScheme.surfaceContainer
-    val headerColor by animateColorAsState(
-        targetValue = surfaceColor.copy(alpha = scrollFraction),
-        animationSpec = spring(stiffness = Spring.StiffnessLow),
-        label = "headerColor"
+    val appBarHeight = statusBarHeight + 64.dp
+    val progress = if (state.durationMs > 0L) {
+        (state.resumePositionMs.toFloat() / state.durationMs).coerceIn(0f, 1f)
+    } else {
+        0f
+    }
+    val actionState = EpisodeActionRailState(
+        title = state.episode.title,
+        imageUrl = artworkUrl,
+        isPlaying = state.isPlaying,
+        isPlaybackLoading = state.isPlaybackLoading,
+        isResume = state.resumePositionMs > 0L,
+        isLiked = liked,
+        isDownloaded = downloaded,
+        isDownloading = downloading,
+        isQueued = queued,
+        isCompleted = completed,
+        progress = progress,
+        remainingTimeText = formatRemainingTime(state.durationMs - state.resumePositionMs),
     )
+    val callbacks = remember(viewModel, state.episode, entryPointContext) {
+        EpisodeActionRailCallbacks(
+            onMainActionClick = { viewModel.onMainActionClick(entryPointContext) },
+            onLikeClick = { viewModel.onToggleLike(state.episode) },
+            onDownloadClick = { viewModel.toggleDownload(state.episode) },
+            onQueueClick = viewModel::toggleQueue,
+            onMarkPlayedClick = viewModel::onToggleCompletion,
+        )
+    }
 
-    // Title animation - header only fade-in
-    val titleSizeStart = MaterialTheme.typography.titleLarge.fontSize
-    val titleSizeEnd = MaterialTheme.typography.titleMedium.fontSize
-    val titleFontSize = androidx.compose.ui.unit.lerp(titleSizeStart, titleSizeEnd, scrollFraction)
-    
-    // Y position fixed in header
-    val headerTitleYPx = with(density) { (statusBarHeight + 18.dp).toPx() }
-    val titleTranslationY by animateFloatAsState(
-        targetValue = headerTitleYPx,
-        animationSpec = spring(stiffness = Spring.StiffnessMedium, dampingRatio = 0.85f),
-        label = "titleY"
-    )
-    
-    // MaxLines: 1 when in header
-    val titleMaxLines = 1
-    // Fade in only when header collapses
-    val titleAlpha = if (scrollFraction > 0.8f) (scrollFraction - 0.8f) / 0.2f else 0f
-    
-    // Horizontal padding in header
-    val titleHorizontalPadding by animateDpAsState(
-        targetValue = 64.dp,
-        animationSpec = spring(stiffness = Spring.StiffnessMedium),
-        label = "titlePadding"
-    )
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+    ) {
+        EpisodeArtworkBackdrop(
+            imageUrl = podcastArtworkUrl,
+            scrollOffset = scrollOffset,
+            collapseFraction = collapseFraction,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(appBarHeight + 240.dp),
+        )
 
-    when (val state = uiState) {
-        is EpisodeInfoUiState.Loading -> {
-            Box(
-                modifier = modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                BoxLoreLoader.Expressive(size = 80.dp)
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                top = appBarHeight + 8.dp,
+                bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() +
+                    bottomContentPadding +
+                    160.dp,
+            ),
+            verticalArrangement = Arrangement.spacedBy(18.dp),
+        ) {
+            item(key = HERO_ITEM_KEY) {
+                EpisodeInfoHero(
+                    episode = state.episode,
+                    podcastTitle = state.podcastTitle,
+                    accentColor = accentColor,
+                    collapseFraction = collapseFraction,
+                    onPodcastClick = {
+                        viewModel.onPodcastLinkClicked()
+                        onPodcastClick(state.podcastId)
+                    },
+                )
             }
-        }
-        is EpisodeInfoUiState.Error -> {
-            Box(
-                modifier = modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                Text("Failed to load episode", color = MaterialTheme.colorScheme.error)
+            item(key = ACTION_RAIL_ITEM_KEY) {
+                EpisodeActionRail(
+                    state = actionState,
+                    callbacks = callbacks,
+                    accentColor = accentColor,
+                    showMarkPlayedTip = showMarkPlayedTip,
+                    onMarkPlayedTipDismissed = onMarkPlayedTipDismissed,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
             }
-        }
-        is EpisodeInfoUiState.Success -> {
-            // Color extraction
-            val painter = rememberAsyncImagePainter(
-                model = ImageRequest.Builder(context)
-                    .data(state.episode.podcastImageUrl?.ifEmpty { state.episode.imageUrl?.ifEmpty { null } })
-                    .allowHardware(false)
-                    .build()
-            )
-            LaunchedEffect(painter.state) {
-                val painterState = painter.state
-                if (painterState is AsyncImagePainter.State.Success) {
-                    val bitmap = (painterState.result.drawable as? BitmapDrawable)?.bitmap
-                    if (bitmap != null) {
-                        extractedColor = extractDominantColor(bitmap)
-                    }
-                }
-            }
-
-            Box(modifier = modifier.fillMaxSize()) {
-                // Blurred Background Header
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(collapsedHeaderHeight + 240.dp)
-                        .graphicsLayer {
-                            translationY = -scrollOffset * 0.5f
-                            alpha = 1f - scrollFraction
-                        }
-                ) {
-                    OptimizedImage(
-                        url = state.episode.imageUrl?.ifEmpty { state.episode.podcastImageUrl },
-                        proxyWidth = 200,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .alpha(0.5f)
-                            .blur(50.dp, edgeTreatment = androidx.compose.ui.draw.BlurredEdgeTreatment.Unbounded),
-                        contentScale = ContentScale.Crop
-                    )
-                    // Gradient overlay to blend into the background
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(
-                                androidx.compose.ui.graphics.Brush.verticalGradient(
-                                    colors = listOf(
-                                        androidx.compose.ui.graphics.Color.Transparent,
-                                        MaterialTheme.colorScheme.background
-                                    )
-                                )
-                            )
+            state.crossPromotion?.let { crossPromotion ->
+                item(key = "cross_promotion") {
+                    CrossPromotionCard(
+                        crossPromotion = crossPromotion,
+                        onPodcastClick = onPodcastClick,
+                        modifier = Modifier.padding(horizontal = 16.dp),
                     )
                 }
-                // Content List
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        top = collapsedHeaderHeight + 16.dp,
-                        bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + bottomContentPadding + 160.dp // Extra for miniplayer
-                    ),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    // HERO SECTION (Artwork + Title + Podcast Link + Metadata)
-                    item {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            // Artwork
-                            Box(modifier = Modifier.size(180.dp)) {
-                                Surface(
-                                    modifier = Modifier.fillMaxSize(),
-                                    shape = MaterialTheme.shapes.extraLarge, // Match PodcastInfoScreen
-                                    shadowElevation = 8.dp
-                                ) {
-                                    OptimizedImage(
-                                        url = state.episode.imageUrl?.ifEmpty { null },
-                                        proxyWidth = 600, // 180dp * ~3x density
-                                        contentDescription = state.episode.title,
-                                        modifier = Modifier.fillMaxSize(),
-                                        contentScale = ContentScale.Crop
-                                    )
-                                }
-
-                                if (state.episode.enclosureType?.startsWith("video/") == true) {
-                                    Surface(
-                                        shape = CircleShape,
-                                        color = Color.Black.copy(alpha = 0.55f),
-                                        modifier = Modifier
-                                            .padding(8.dp)
-                                            .align(Alignment.TopEnd)
-                                    ) {
-                                        Box(
-                                            modifier = Modifier.padding(6.dp),
-                                            contentAlignment = Alignment.Center
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Rounded.Videocam,
-                                                contentDescription = "Video",
-                                                tint = Color.White,
-                                                modifier = Modifier.size(16.dp)
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-
-                            Spacer(modifier = Modifier.height(20.dp))
-                            
-                            // Episode Title
-                            Text(
-                                text = state.episode.title,
-                                style = MaterialTheme.typography.titleLarge,
-                                color = MaterialTheme.colorScheme.onBackground,
-                                fontWeight = FontWeight.Bold,
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.padding(horizontal = 16.dp)
-                            )
-                            
-                            Spacer(modifier = Modifier.height(8.dp))
-
-                            // Podcast Title (clickable)
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.Center,
-                                modifier = Modifier
-                                    .expressiveClickable { 
-                                        viewModel.onPodcastLinkClicked()
-                                        onPodcastClick(state.podcastId) 
-                                    }
-                                    .padding(vertical = 4.dp, horizontal = 8.dp)
-                            ) {
-                                Text(
-                                    text = state.podcastTitle,
-                                    style = MaterialTheme.typography.titleMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    fontWeight = FontWeight.Medium,
-                                    maxLines = 1,
-                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f, fill = false) // shrink text, never push > off screen
-                                )
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                                    contentDescription = "Go to podcast",
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.size(18.dp)
-                                )
-                            }
-
-                            Spacer(modifier = Modifier.height(12.dp))
-
-                            // Metadata Row (Chips matching PodcastInfoScreen)
-                            fun formatDuration(seconds: Int): String {
-                                val hours = seconds / 3600
-                                val minutes = (seconds % 3600) / 60
-                                return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
-                            }
-                            
-                            fun formatRelativeDate(timestampSeconds: Long): String {
-                                if (timestampSeconds == 0L) return ""
-                                val now = System.currentTimeMillis() / 1000
-                                val diff = now - timestampSeconds
-                                return when {
-                                    diff < 3600 -> "${diff / 60}m ago"
-                                    diff < 86400 -> "${diff / 3600}h ago"
-                                    diff < 604800 -> "${diff / 86400}d ago"
-                                    diff < 2592000 -> "${diff / 604800}w ago"
-                                    diff < 31536000 -> "${diff / 2592000}mo ago"
-                                    else -> "${diff / 31536000}y ago"
-                                }
-                            }
-
-                            androidx.compose.foundation.lazy.LazyRow(
-                                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-                                contentPadding = PaddingValues(horizontal = 0.dp),
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                // Video Pill
-                                if (state.episode.enclosureType?.startsWith("video/") == true) {
-                                    item {
-                                        Surface(
-                                            shape = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.Pill,
-                                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                        ) {
-                                            Box(
-                                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                                                contentAlignment = Alignment.Center
-                                            ) {
-                                                Icon(
-                                                    imageVector = Icons.Rounded.Videocam,
-                                                    contentDescription = "Video",
-                                                    modifier = Modifier.size(16.dp),
-                                                    tint = accentColor
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-
-                                // Duration Pill
-                                item {
-                                    Surface(
-                                        shape = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.Pill,
-                                        color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                    ) {
-                                        Row(
-                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                            verticalAlignment = Alignment.CenterVertically
-                                        ) {
-                                            Icon(
-                                                imageVector = androidx.compose.material.icons.Icons.Rounded.Schedule,
-                                                contentDescription = null,
-                                                modifier = Modifier.size(16.dp),
-                                                tint = MaterialTheme.colorScheme.primary
-                                            )
-                                            Text(
-                                                text = formatDuration(episodeDuration),
-                                                style = MaterialTheme.typography.labelMedium,
-                                                color = MaterialTheme.colorScheme.primary,
-                                                fontWeight = FontWeight.Medium
-                                            )
-                                        }
-                                    }
-                                }
-
-                                // Date Pill
-                                val dateText = formatRelativeDate(state.episode.publishedDate)
-                                if (dateText.isNotEmpty()) {
-                                    item {
-                                        Surface(
-                                            shape = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.Pill,
-                                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                        ) {
-                                            Row(
-                                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                                                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                                verticalAlignment = Alignment.CenterVertically
-                                            ) {
-                                                Icon(
-                                                    imageVector = androidx.compose.material.icons.Icons.Rounded.CalendarToday,
-                                                    contentDescription = null,
-                                                    modifier = Modifier.size(16.dp),
-                                                    tint = MaterialTheme.colorScheme.primary
-                                                )
-                                                Text(
-                                                    text = dateText,
-                                                    style = MaterialTheme.typography.labelMedium,
-                                                    color = MaterialTheme.colorScheme.primary,
-                                                    fontWeight = FontWeight.Medium
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-
-                                // Season/Episode Pill
-                                val season = state.episode.seasonNumber
-                                val episode = state.episode.episodeNumber
-                                val seLabel = buildString {
-                                    if (season != null && season > 0) {
-                                        append("S$season ")
-                                    }
-                                    if (episode != null && episode > 0) {
-                                        append("E$episode")
-                                    }
-                                }.trim()
-                                if (seLabel.isNotEmpty()) {
-                                    item {
-                                        Surface(
-                                            shape = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.Pill,
-                                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                        ) {
-                                            Row(
-                                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                                                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                                verticalAlignment = Alignment.CenterVertically
-                                            ) {
-                                                Icon(
-                                                    imageVector = androidx.compose.material.icons.Icons.Rounded.Tag,
-                                                    contentDescription = null,
-                                                    modifier = Modifier.size(16.dp),
-                                                    tint = MaterialTheme.colorScheme.primary
-                                                )
-                                                Text(
-                                                    text = seLabel,
-                                                    style = MaterialTheme.typography.labelMedium,
-                                                    color = MaterialTheme.colorScheme.primary,
-                                                    fontWeight = FontWeight.Medium
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-
-                                // Type Pill
-                                if (state.episode.episodeType != null && state.episode.episodeType != "full") {
-                                    item {
-                                        Surface(
-                                            shape = cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes.Pill,
-                                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                        ) {
-                                            Row(
-                                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                                                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                                                verticalAlignment = Alignment.CenterVertically
-                                            ) {
-                                                Icon(
-                                                    imageVector = androidx.compose.material.icons.Icons.AutoMirrored.Rounded.Label,
-                                                    contentDescription = null,
-                                                    modifier = Modifier.size(16.dp),
-                                                    tint = MaterialTheme.colorScheme.primary
-                                                )
-                                                Text(
-                                                    text = state.episode.episodeType!!.replaceFirstChar { it.uppercase() },
-                                                    style = MaterialTheme.typography.labelMedium,
-                                                    color = MaterialTheme.colorScheme.primary,
-                                                    fontWeight = FontWeight.Medium
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // ACTION ROW (Play Button + Progress) - Flat design
-                    item {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 24.dp)
-                                .padding(top = 16.dp)
-                        ) {
-                            // Prepare Progress Data
-                            val progress = if (state.durationMs > 0) (state.resumePositionMs.toFloat() / state.durationMs).coerceIn(0f, 1f) else 0f
-                            val remainingSeconds = if (state.durationMs > 0) (state.durationMs - state.resumePositionMs) / 1000 else 0
-                            
-                            fun formatRemaining(totalSeconds: Long): String? {
-                                if (totalSeconds <= 0) return null
-                                val hours = totalSeconds / 3600
-                                val minutes = (totalSeconds % 3600) / 60
-                                return if (hours > 0) "${hours}h ${minutes}m left" else "${minutes}m left"
-                            }
-
-                            val isPlaying = state.isPlaying
-                            val isLiked = likedEpisodeIds.contains(state.episode.id)
-                            val isCompleted = completedEpisodeIds.contains(state.episode.id)
-
-                            // Single Elegant Row Layout (M3 standard: actions left, FAB right)
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.SpaceBetween,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                            ) {
-                                // Action Buttons Row (Material3 Tonal) on the Left
-                                cx.aswin.boxcast.core.designsystem.components.AdvancedPlayerControls(
-                                    isLiked = isLiked,
-                                    isDownloaded = isDownloaded, 
-                                    isDownloading = isDownloading,
-                                    colorScheme = MaterialTheme.colorScheme,
-                                    onLikeClick = { viewModel.onToggleLike(state.episode) },
-                                    onDownloadClick = { viewModel.toggleDownload(state.episode) },
-                                    onQueueClick = { viewModel.toggleQueue() },
-                                    style = cx.aswin.boxcast.core.designsystem.components.ControlStyle.Material3, // Circular M3
-                                    overrideColor = accentColor, // Enforce accent color for active states
-                                    horizontalArrangement = Arrangement.spacedBy(4.dp), // Tighter spacing
-                                    showAddQueueIcon = true,
-                                    isQueued = queuedEpisodeIds.contains(state.episode.id),
-                                    showShareButton = false,
-                                    isPlayed = isCompleted,
-                                    onMarkPlayedClick = { viewModel.onToggleCompletion() },
-                                    controlSize = 40.dp, // Smaller size to fit all 4 buttons + Play button
-                                    modifier = Modifier.wrapContentWidth(unbounded = true) // Guarantee it won't shrink
-                                )
-                                
-                                Spacer(modifier = Modifier.width(12.dp))
-
-                                // Prominent Play Button (Right)
-                                cx.aswin.boxcast.core.designsystem.components.ExpressivePlayButton(
-                                    onClick = { viewModel.onMainActionClick(entryPointContext) },
-                                    isPlaying = isPlaying, 
-                                    isResume = state.resumePositionMs > 0,
-                                    accentColor = accentColor, // Use extracted album art color
-                                    progress = progress,
-                                    timeText = formatRemaining(remainingSeconds),
-                                    modifier = Modifier
-                                        .height(56.dp)
-                                        .weight(1f) // Takes up remaining width (lots of area for Resume text)
-                                )
-                            }
-                        }
-                    }
-
-                    // One-time mark-played tooltip
-                    if (showMarkPlayedTip) {
-                        item {
-                            var tipVisible by remember { mutableStateOf(true) }
-                            
-                            LaunchedEffect(Unit) {
-                                delay(4000)
-                                tipVisible = false
-                                onMarkPlayedTipDismissed()
-                            }
-                            
-                            androidx.compose.animation.AnimatedVisibility(
-                                visible = tipVisible,
-                                enter = androidx.compose.animation.fadeIn(androidx.compose.animation.core.tween(300)) + 
-                                        androidx.compose.animation.slideInVertically(initialOffsetY = { -it/2 }),
-                                exit = androidx.compose.animation.fadeOut(androidx.compose.animation.core.tween(500))
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(start = 24.dp, bottom = 8.dp), // Align with the controls on the left
-                                    contentAlignment = Alignment.CenterStart
-                                ) {
-                                    Surface(
-                                        shape = MaterialTheme.shapes.small,
-                                        color = MaterialTheme.colorScheme.primaryContainer,
-                                        shadowElevation = 4.dp
-                                    ) {
-                                        Text(
-                                            text = "↑ Tap to mark completed",
-                                            style = MaterialTheme.typography.labelSmall,
-                                            fontWeight = FontWeight.Bold,
-                                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // CROSS-PROMOTION CARD
-                    state.crossPromotion?.let { crossPromo ->
-                        item {
-                            CrossPromotionCard(
-                                crossPromotion = crossPromo,
-                                onPodcastClick = onPodcastClick,
-                                modifier = Modifier
-                                    .padding(horizontal = 16.dp)
-                            )
-                        }
-                    }
-
-                    // DESCRIPTION CARD with Social Links
-                    if (state.episode.description.isNotEmpty()) {
-                        item {
-                            EpisodeDescriptionCard(
-                                description = state.episode.description,
-                                accentColor = accentColor,
-                                location = state.location,
-                                license = state.license,
-                                persons = state.episode.persons,
-                                onSeekTo = viewModel::seekToPosition
-                            )
-                        }
-                    }
-
-                    // Contextual "MORE LIKE THIS" RECOMMENDATIONS SECTION -> Card
-                    if (state.similarEpisodesLoading || state.similarEpisodes.isNotEmpty()) {
-                        item {
-                            androidx.compose.material3.OutlinedCard(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp),
-                                colors = androidx.compose.material3.CardDefaults.outlinedCardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-                                ),
-                                border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-                                shape = MaterialTheme.shapes.extraLarge
-                            ) {
-                                Column(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = 16.dp)
-                                ) {
-                                    Row(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(horizontal = 20.dp)
-                                            .padding(bottom = 12.dp),
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Rounded.AutoAwesome,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(22.dp)
-                                        )
-                                        Spacer(modifier = Modifier.width(10.dp))
-                                        Text(
-                                            text = "More Like This",
-                                            style = MaterialTheme.typography.titleMedium.copy(
-                                                fontWeight = FontWeight.Bold,
-                                                letterSpacing = (-0.1).sp
-                                            ),
-                                            color = MaterialTheme.colorScheme.onSurface,
-                                            modifier = Modifier.weight(1f),
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis
-                                        )
-                                    }
-                                    
-                                    val similarListState = rememberLazyListState()
-                                    LazyRow(
-                                        state = similarListState,
-                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                        contentPadding = PaddingValues(horizontal = 16.dp)
-                                    ) {
-                                        if (state.similarEpisodesLoading) {
-                                            items(4) {
-                                                val baseColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                                                val highlightColor = MaterialTheme.colorScheme.surfaceContainerHighest
-                                                
-                                                Column(
-                                                    modifier = Modifier.width(120.dp),
-                                                    horizontalAlignment = Alignment.CenterHorizontally
-                                                ) {
-                                                    Box(
-                                                        modifier = Modifier
-                                                            .size(120.dp)
-                                                            .clip(MaterialTheme.shapes.medium)
-                                                            .background(baseColor)
-                                                            .m3Shimmer(baseColor, highlightColor)
-                                                    )
-                                                    Spacer(modifier = Modifier.height(8.dp))
-                                                    Box(
-                                                        modifier = Modifier
-                                                            .fillMaxWidth()
-                                                            .height(14.dp)
-                                                            .clip(MaterialTheme.shapes.small)
-                                                            .background(baseColor)
-                                                            .m3Shimmer(baseColor, highlightColor)
-                                                    )
-                                                    Spacer(modifier = Modifier.height(4.dp))
-                                                    Box(
-                                                        modifier = Modifier
-                                                            .fillMaxWidth(0.7f)
-                                                            .height(14.dp)
-                                                            .clip(MaterialTheme.shapes.small)
-                                                            .background(baseColor)
-                                                            .m3Shimmer(baseColor, highlightColor)
-                                                    )
-                                                }
-                                            }
-                                        } else {
-                                            items(state.similarEpisodes) { episode ->
-                                                androidx.compose.material3.OutlinedCard(
-                                                    shape = RoundedCornerShape(16.dp),
-                                                    colors = androidx.compose.material3.CardDefaults.outlinedCardColors(
-                                                        containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
-                                                    ),
-                                                    border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-                                                    modifier = Modifier
-                                                        .width(140.dp)
-                                                        .expressiveClickable { 
-                                                            onEpisodeClick(episode) 
-                                                        }
-                                                ) {
-                                                    Column {
-                                                        OptimizedImage(
-                                                            url = episode.imageUrl?.ifEmpty { episode.podcastImageUrl },
-                                                            proxyWidth = 300,
-                                                            contentDescription = episode.title,
-                                                            modifier = Modifier
-                                                                .size(140.dp)
-                                                                .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
-                                                            contentScale = ContentScale.Crop
-                                                        )
-                                                        Column(
-                                                            modifier = Modifier.padding(10.dp),
-                                                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                                                        ) {
-                                                            Text(
-                                                                text = episode.title,
-                                                                style = MaterialTheme.typography.labelMedium.copy(
-                                                                    fontWeight = FontWeight.Bold,
-                                                                    lineHeight = 14.sp
-                                                                ),
-                                                                color = MaterialTheme.colorScheme.onSurface,
-                                                                minLines = 2,
-                                                                maxLines = 2,
-                                                                overflow = TextOverflow.Ellipsis
-                                                            )
-                                                            val podTitle = episode.podcastTitle
-                                                            if (!podTitle.isNullOrEmpty()) {
-                                                                Text(
-                                                                    text = podTitle,
-                                                                    style = MaterialTheme.typography.bodySmall.copy(
-                                                                        fontSize = 11.sp,
-                                                                        fontWeight = FontWeight.Medium
-                                                                    ),
-                                                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                                    maxLines = 1,
-                                                                    overflow = TextOverflow.Ellipsis
-                                                                )
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // UNIFIED "MORE FROM PODCAST" SECTION -> Card
-                    item {
-                        androidx.compose.material3.OutlinedCard(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
-                            colors = androidx.compose.material3.CardDefaults.outlinedCardColors(
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerLow
-                            ),
-                            border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-                            shape = MaterialTheme.shapes.extraLarge
-                        ) {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 16.dp)
-                            ) {
-                                Row(
-                                     modifier = Modifier
-                                         .fillMaxWidth()
-                                         .expressiveClickable { 
-                                             viewModel.onPodcastLinkClicked()
-                                             onPodcastClick(state.podcastId) 
-                                         }
-                                         .padding(horizontal = 20.dp)
-                                         .padding(bottom = 12.dp),
-                                     verticalAlignment = Alignment.CenterVertically
-                                 ) {
-                                     Icon(
-                                         imageVector = Icons.Rounded.Subscriptions,
-                                         contentDescription = null,
-                                         tint = MaterialTheme.colorScheme.primary,
-                                         modifier = Modifier.size(20.dp)
-                                     )
-                                     Spacer(modifier = Modifier.width(10.dp))
-                                     Text(
-                                         text = "More from ${state.podcastTitle}",
-                                         style = MaterialTheme.typography.titleMedium.copy(
-                                             fontWeight = FontWeight.Bold,
-                                             letterSpacing = (-0.1).sp
-                                         ),
-                                         color = MaterialTheme.colorScheme.onSurface,
-                                         modifier = Modifier.weight(1f),
-                                         maxLines = 1,
-                                         overflow = TextOverflow.Ellipsis
-                                     )
-                                     Icon(
-                                         imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                                         contentDescription = "Go to podcast",
-                                         tint = MaterialTheme.colorScheme.onSurfaceVariant
-                                     )
-                                 }
-                                
-                                // Horizontal episodes row
-                                val relatedListState = rememberLazyListState()
-                                LaunchedEffect(relatedListState.isScrollInProgress) {
-                                    if (relatedListState.isScrollInProgress) {
-                                        viewModel.onRelatedEpisodesScrolled()
-                                    }
-                                }
-                                LazyRow(
-                                    state = relatedListState,
-                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                    contentPadding = PaddingValues(horizontal = 16.dp)
-                                ) {
-                                    if (state.relatedEpisodesLoading) {
-                                        // Skeleton loaders
-                                        items(4) {
-                                            val baseColor = MaterialTheme.colorScheme.surfaceContainerHigh
-                                            val highlightColor = MaterialTheme.colorScheme.surfaceContainerHighest
-                                            
-                                            Column(
-                                                modifier = Modifier.width(120.dp),
-                                                horizontalAlignment = Alignment.CenterHorizontally
-                                            ) {
-                                                // Skeleton artwork with shimmer
-                                                Box(
-                                                    modifier = Modifier
-                                                        .size(120.dp)
-                                                        .clip(MaterialTheme.shapes.medium)
-                                                        .background(baseColor)
-                                                        .m3Shimmer(baseColor, highlightColor)
-                                                )
-                                                
-                                                Spacer(modifier = Modifier.height(8.dp))
-                                                
-                                                // Skeleton text with shimmer
-                                                Box(
-                                                    modifier = Modifier
-                                                        .fillMaxWidth()
-                                                        .height(14.dp)
-                                                        .clip(MaterialTheme.shapes.small)
-                                                        .background(baseColor)
-                                                        .m3Shimmer(baseColor, highlightColor)
-                                                )
-                                                Spacer(modifier = Modifier.height(4.dp))
-                                                Box(
-                                                    modifier = Modifier
-                                                        .fillMaxWidth(0.7f)
-                                                        .height(14.dp)
-                                                        .clip(MaterialTheme.shapes.small)
-                                                        .background(baseColor)
-                                                        .m3Shimmer(baseColor, highlightColor)
-                                                )
-                                            }
-                                        }
-                                    } else if (state.relatedEpisodes.isNotEmpty()) {
-                                         items(state.relatedEpisodes) { episode ->
-                                             androidx.compose.material3.OutlinedCard(
-                                                 shape = RoundedCornerShape(16.dp),
-                                                 colors = androidx.compose.material3.CardDefaults.outlinedCardColors(
-                                                     containerColor = MaterialTheme.colorScheme.surfaceContainerLowest
-                                                 ),
-                                                 border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-                                                 modifier = Modifier
-                                                     .width(140.dp)
-                                                     .expressiveClickable { 
-                                                         viewModel.onRelatedEpisodeClicked()
-                                                         onEpisodeClick(episode) 
-                                                     }
-                                             ) {
-                                                 Column {
-                                                     // Episode Artwork
-                                                     OptimizedImage(
-                                                         url = episode.imageUrl?.ifEmpty { state.episode.podcastImageUrl },
-                                                         proxyWidth = 300, // 140dp thumbnails
-                                                         contentDescription = episode.title,
-                                                         modifier = Modifier
-                                                             .size(140.dp)
-                                                             .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
-                                                         contentScale = ContentScale.Crop
-                                                     )
-                                                     
-                                                     // Title in card footer - minLines for even sizing
-                                                     Text(
-                                                         text = episode.title,
-                                                         style = MaterialTheme.typography.labelMedium.copy(
-                                                             fontWeight = FontWeight.SemiBold,
-                                                             lineHeight = 14.sp
-                                                         ),
-                                                         color = MaterialTheme.colorScheme.onSurface,
-                                                         minLines = 3,
-                                                         maxLines = 3,
-                                                         overflow = TextOverflow.Ellipsis,
-                                                         modifier = Modifier.padding(12.dp)
-                                                     )
-                                                 }
-                                             }
-                                         }
-                                    } else {
-                                        // No episodes message
-                                        item {
-                                            Text(
-                                                text = "No other episodes available",
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                                modifier = Modifier.padding(vertical = 16.dp)
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    }
+            }
+            if (state.episode.description.isNotBlank()) {
+                item(key = "description") {
+                    EpisodeDescriptionCard(
+                        description = state.episode.description,
+                        accentColor = accentColor,
+                        location = state.location,
+                        license = state.license,
+                        persons = state.episode.persons,
+                        onSeekTo = viewModel::seekToPosition,
+                    )
                 }
-
-                // HEADER OVERLAY (Back button + animated background)
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(collapsedHeaderHeight)
-                        .background(headerColor)
-                        .statusBarsPadding()
-                ) {
-                    // Back Button
-                    IconButton(
-                        onClick = onBack,
-                        modifier = Modifier.align(Alignment.CenterStart).padding(start = 4.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Rounded.ArrowBack,
-                            contentDescription = "Back",
-                            tint = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-
-                    // Share Button
-                    var showShareSheet by remember { mutableStateOf(false) }
-                    IconButton(
-                        onClick = { showShareSheet = true },
-                        modifier = Modifier.align(Alignment.CenterEnd).padding(end = 4.dp)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Share,
-                            contentDescription = "Share",
-                            tint = MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-
-                    if (showShareSheet) {
-                        val currentSuccessState = uiState as? cx.aswin.boxcast.feature.info.EpisodeInfoUiState.Success
-                        val shareEpisode = currentSuccessState?.episode ?: cx.aswin.boxcast.core.model.Episode(
-                            id = episodeId,
-                            title = episodeTitle,
-                            description = episodeDescription,
-                            audioUrl = episodeAudioUrl,
-                            imageUrl = episodeImageUrl,
-                            duration = episodeDuration
-                        )
-                        cx.aswin.boxcast.core.designsystem.components.ShareBottomSheet(
-                            id = shareEpisode.id,
-                            type = "episode",
-                            title = shareEpisode.title,
-                            subtitle = podcastTitle,
-                            imageUrl = shareEpisode.imageUrl ?: shareEpisode.podcastImageUrl,
-                            onDismissRequest = { showShareSheet = false },
-                            durationMs = shareEpisode.duration * 1000L,
-                            currentPositionMs = currentSuccessState?.resumePositionMs ?: 0L,
-                            showTimestampOption = false,
-                            onShare = { _, _, timestamp, target ->
-                                cx.aswin.boxcast.core.data.ShareManager.shareEpisode(
-                                    context = context,
-                                    episode = shareEpisode,
-                                    podcastTitle = podcastTitle,
-                                    timestampMs = timestamp,
-                                    target = target
-                                )
-                            }
-                        )
-                    }
+            }
+            if (state.similarEpisodesLoading || state.similarEpisodes.isNotEmpty()) {
+                item(key = "similar_episodes") {
+                    EpisodeRecommendationSection(
+                        title = "More Like This",
+                        icon = Icons.Rounded.AutoAwesome,
+                        episodes = state.similarEpisodes,
+                        loading = state.similarEpisodesLoading,
+                        accentColor = accentColor,
+                        fallbackImageUrl = state.episode.podcastImageUrl,
+                        onEpisodeClick = onEpisodeClick,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    )
                 }
-                
-                // FLOATING TITLE - physically moves from body to header
-                Text(
-                    text = episodeTitle,
-                    fontSize = titleFontSize,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface,
-                    maxLines = titleMaxLines,
-                    overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = titleHorizontalPadding)
-                        .graphicsLayer { 
-                            translationY = titleTranslationY
-                            alpha = titleAlpha 
-                        }
+            }
+            item(key = "related_episodes") {
+                EpisodeRecommendationSection(
+                    title = "More from ${state.podcastTitle}",
+                    icon = Icons.Rounded.Subscriptions,
+                    episodes = state.relatedEpisodes,
+                    loading = state.relatedEpisodesLoading,
+                    accentColor = accentColor,
+                    fallbackImageUrl = state.episode.podcastImageUrl,
+                    emptyMessage = "No other episodes available",
+                    onHeaderClick = {
+                        viewModel.onPodcastLinkClicked()
+                        onPodcastClick(state.podcastId)
+                    },
+                    onEpisodeClick = { episode ->
+                        viewModel.onRelatedEpisodeClicked()
+                        onEpisodeClick(episode)
+                    },
+                    onScrollStarted = viewModel::onRelatedEpisodesScrolled,
+                    modifier = Modifier.padding(horizontal = 16.dp),
                 )
             }
         }
+
+        ExpressiveEpisodeTopBar(
+            title = state.episode.title,
+            collapseFraction = collapseFraction,
+            onShare = { showShareSheet = true },
+            modifier = Modifier.align(Alignment.TopCenter),
+        )
+
+        CompactEpisodeActionRail(
+            state = actionState,
+            callbacks = callbacks,
+            accentColor = accentColor,
+            visible = stickyRailVisible,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = appBarHeight + 8.dp, start = 12.dp, end = 12.dp),
+        )
     }
+
+    if (showShareSheet) {
+        ShareBottomSheet(
+            id = state.episode.id,
+            type = "episode",
+            title = state.episode.title,
+            subtitle = state.podcastTitle,
+            imageUrl = artworkUrl,
+            onDismissRequest = { showShareSheet = false },
+            durationMs = state.episode.duration * 1_000L,
+            currentPositionMs = state.resumePositionMs,
+            showTimestampOption = false,
+            onShare = { _, _, timestamp, target ->
+                ShareManager.shareEpisode(
+                    context = context,
+                    episode = state.episode,
+                    podcastTitle = state.podcastTitle,
+                    timestampMs = timestamp,
+                    target = target,
+                )
+            },
+        )
+    }
+}
+
+@Composable
+private fun ExpressiveEpisodeTopBar(
+    title: String,
+    collapseFraction: Float,
+    onShare: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val containerColor by animateColorAsState(
+        targetValue = MaterialTheme.colorScheme.surfaceContainer.copy(
+            alpha = (collapseFraction * 0.98f).coerceIn(0f, 0.98f),
+        ),
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "episode_top_bar_color",
+    )
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(containerColor)
+            .statusBarsPadding()
+            .height(64.dp)
+            .padding(horizontal = 8.dp),
+    ) {
+        AnimatedVisibility(
+            visible = collapseFraction > 0.68f,
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 64.dp),
+            enter = fadeIn(ExpressiveMotion.SleekFadeSpec) + slideInVertically { it / 3 },
+            exit = fadeOut(ExpressiveMotion.SleekFadeSpec) + slideOutVertically { it / 3 },
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Black,
+                textAlign = TextAlign.Start,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        TopBarAction(
+            onClick = onShare,
+            modifier = Modifier.align(Alignment.CenterEnd),
+        ) {
+            Icon(Icons.Outlined.Share, contentDescription = "Share")
+        }
+    }
+}
+
+@Composable
+private fun TopBarAction(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        modifier = modifier
+            .size(48.dp)
+            .expressiveClickable(shape = CircleShape, onClick = onClick),
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.9f),
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shadowElevation = 2.dp,
+    ) {
+        Box(contentAlignment = Alignment.Center) { content() }
+    }
+}
+
+@Composable
+private fun EpisodeInfoLoading(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(18.dp),
+        ) {
+            BoxLoreLoader.Expressive(size = 84.dp)
+            Text(
+                text = "Tuning this episode…",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpisodeInfoError(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ) {
+            Text(
+                text = "This episode could not be loaded",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(36.dp),
+            )
+        }
+    }
+}
+
+private fun extractArtworkColor(bitmap: Bitmap): Color {
+    val palette = Palette.from(bitmap).generate()
+    return Color(
+        palette.vibrantSwatch?.rgb
+            ?: palette.mutedSwatch?.rgb
+            ?: palette.dominantSwatch?.rgb
+            ?: 0xFF6750A4.toInt(),
+    )
+}
+
+private fun formatRemainingTime(remainingMs: Long): String? {
+    val totalSeconds = remainingMs.coerceAtLeast(0L) / 1_000L
+    if (totalSeconds <= 0L) return null
+    val hours = totalSeconds / 3_600L
+    val minutes = (totalSeconds % 3_600L) / 60L
+    return if (hours > 0L) "${hours}h ${minutes}m left" else "${minutes}m left"
+}

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoScreen.kt
@@ -77,9 +77,25 @@ import cx.aswin.boxcast.feature.info.components.EpisodeActionRailState
 import cx.aswin.boxcast.feature.info.components.EpisodeArtworkBackdrop
 import cx.aswin.boxcast.feature.info.components.EpisodeInfoHero
 import cx.aswin.boxcast.feature.info.components.EpisodeRecommendationSection
+import cx.aswin.boxcast.feature.info.components.EpisodeRecommendationState
 
 private const val HERO_ITEM_KEY = "episode_hero"
 private const val ACTION_RAIL_ITEM_KEY = "episode_action_rail"
+
+private data class EpisodeInfoSuccessFlags(
+    val liked: Boolean,
+    val completed: Boolean,
+    val queued: Boolean,
+    val downloaded: Boolean,
+    val downloading: Boolean,
+    val showMarkPlayedTip: Boolean,
+)
+
+private data class EpisodeInfoSuccessActions(
+    val onPodcastClick: (String) -> Unit,
+    val onEpisodeClick: (Episode) -> Unit,
+    val onMarkPlayedTipDismissed: () -> Unit,
+)
 
 @Composable
 fun EpisodeInfoScreen(
@@ -144,17 +160,21 @@ fun EpisodeInfoScreen(
         EpisodeInfoUiState.Error -> EpisodeInfoError(modifier)
         is EpisodeInfoUiState.Success -> EpisodeInfoSuccess(
             state = state,
-            liked = state.episode.id in likedEpisodeIds,
-            completed = state.episode.id in completedEpisodeIds,
-            queued = state.episode.id in queuedEpisodeIds,
-            downloaded = isDownloaded,
-            downloading = isDownloading,
+            flags = EpisodeInfoSuccessFlags(
+                liked = state.episode.id in likedEpisodeIds,
+                completed = state.episode.id in completedEpisodeIds,
+                queued = state.episode.id in queuedEpisodeIds,
+                downloaded = isDownloaded,
+                downloading = isDownloading,
+                showMarkPlayedTip = showMarkPlayedTip,
+            ),
             viewModel = viewModel,
             entryPointContext = entryPointContext,
-            onPodcastClick = onPodcastClick,
-            onEpisodeClick = onEpisodeClick,
-            showMarkPlayedTip = showMarkPlayedTip,
-            onMarkPlayedTipDismissed = onMarkPlayedTipDismissed,
+            actions = EpisodeInfoSuccessActions(
+                onPodcastClick = onPodcastClick,
+                onEpisodeClick = onEpisodeClick,
+                onMarkPlayedTipDismissed = onMarkPlayedTipDismissed,
+            ),
             bottomContentPadding = bottomContentPadding,
             modifier = modifier,
         )
@@ -164,51 +184,21 @@ fun EpisodeInfoScreen(
 @Composable
 private fun EpisodeInfoSuccess(
     state: EpisodeInfoUiState.Success,
-    liked: Boolean,
-    completed: Boolean,
-    queued: Boolean,
-    downloaded: Boolean,
-    downloading: Boolean,
+    flags: EpisodeInfoSuccessFlags,
     viewModel: EpisodeInfoViewModel,
     entryPointContext: Bundle?,
-    onPodcastClick: (String) -> Unit,
-    onEpisodeClick: (Episode) -> Unit,
-    showMarkPlayedTip: Boolean,
-    onMarkPlayedTipDismissed: () -> Unit,
+    actions: EpisodeInfoSuccessActions,
     bottomContentPadding: Dp,
     modifier: Modifier,
 ) {
-    val context = LocalContext.current
     val density = LocalDensity.current
     val listState = rememberLazyListState()
     var showShareSheet by remember { mutableStateOf(false) }
-    var extractedColor by remember(state.episode.id) { mutableStateOf(Color.Unspecified) }
     val artworkUrl = state.episode.imageUrl?.ifBlank { state.episode.podcastImageUrl }
     val podcastArtworkUrl = state.episode.podcastImageUrl?.ifBlank { state.episode.imageUrl }
-    val palettePainter = rememberAsyncImagePainter(
-        model = ImageRequest.Builder(context)
-            .data(podcastArtworkUrl)
-            .allowHardware(false)
-            .build(),
-    )
-
-    LaunchedEffect(palettePainter.state) {
-        val painterState = palettePainter.state
-        if (painterState is AsyncImagePainter.State.Success) {
-            val bitmap = (painterState.result.drawable as? BitmapDrawable)?.bitmap
-            if (bitmap != null) extractedColor = extractArtworkColor(bitmap)
-        }
-    }
-
-    val paletteColor = if (extractedColor == Color.Unspecified) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        extractedColor
-    }
-    val accentColor by animateColorAsState(
-        targetValue = lerp(paletteColor, MaterialTheme.colorScheme.primary, 0.14f),
-        animationSpec = spring(stiffness = Spring.StiffnessLow),
-        label = "episode_accent",
+    val accentColor = rememberEpisodeAccentColor(
+        episodeId = state.episode.id,
+        artworkUrl = podcastArtworkUrl,
     )
     val collapseThresholdPx = with(density) { 320.dp.toPx() }
     val scrollOffset by remember {
@@ -240,11 +230,11 @@ private fun EpisodeInfoSuccess(
         isPlaying = state.isPlaying,
         isPlaybackLoading = state.isPlaybackLoading,
         isResume = state.resumePositionMs > 0L,
-        isLiked = liked,
-        isDownloaded = downloaded,
-        isDownloading = downloading,
-        isQueued = queued,
-        isCompleted = completed,
+        isLiked = flags.liked,
+        isDownloaded = flags.downloaded,
+        isDownloading = flags.downloading,
+        isQueued = flags.queued,
+        isCompleted = flags.completed,
         progress = progress,
         remainingTimeText = formatRemainingTime(state.durationMs - state.resumePositionMs),
     )
@@ -291,7 +281,7 @@ private fun EpisodeInfoSuccess(
                     collapseFraction = collapseFraction,
                     onPodcastClick = {
                         viewModel.onPodcastLinkClicked()
-                        onPodcastClick(state.podcastId)
+                        actions.onPodcastClick(state.podcastId)
                     },
                 )
             }
@@ -300,8 +290,8 @@ private fun EpisodeInfoSuccess(
                     state = actionState,
                     callbacks = callbacks,
                     accentColor = accentColor,
-                    showMarkPlayedTip = showMarkPlayedTip,
-                    onMarkPlayedTipDismissed = onMarkPlayedTipDismissed,
+                    showMarkPlayedTip = flags.showMarkPlayedTip,
+                    onMarkPlayedTipDismissed = actions.onMarkPlayedTipDismissed,
                     modifier = Modifier.padding(horizontal = 16.dp),
                 )
             }
@@ -309,7 +299,7 @@ private fun EpisodeInfoSuccess(
                 item(key = "cross_promotion") {
                     CrossPromotionCard(
                         crossPromotion = crossPromotion,
-                        onPodcastClick = onPodcastClick,
+                        onPodcastClick = actions.onPodcastClick,
                         modifier = Modifier.padding(horizontal = 16.dp),
                     )
                 }
@@ -329,33 +319,37 @@ private fun EpisodeInfoSuccess(
             if (state.similarEpisodesLoading || state.similarEpisodes.isNotEmpty()) {
                 item(key = "similar_episodes") {
                     EpisodeRecommendationSection(
-                        title = "More Like This",
-                        icon = Icons.Rounded.AutoAwesome,
-                        episodes = state.similarEpisodes,
-                        loading = state.similarEpisodesLoading,
-                        accentColor = accentColor,
-                        fallbackImageUrl = state.episode.podcastImageUrl,
-                        onEpisodeClick = onEpisodeClick,
+                        state = EpisodeRecommendationState(
+                            title = "More Like This",
+                            icon = Icons.Rounded.AutoAwesome,
+                            episodes = state.similarEpisodes,
+                            loading = state.similarEpisodesLoading,
+                            accentColor = accentColor,
+                            fallbackImageUrl = state.episode.podcastImageUrl,
+                        ),
+                        onEpisodeClick = actions.onEpisodeClick,
                         modifier = Modifier.padding(horizontal = 16.dp),
                     )
                 }
             }
             item(key = "related_episodes") {
                 EpisodeRecommendationSection(
-                    title = "More from ${state.podcastTitle}",
-                    icon = Icons.Rounded.Subscriptions,
-                    episodes = state.relatedEpisodes,
-                    loading = state.relatedEpisodesLoading,
-                    accentColor = accentColor,
-                    fallbackImageUrl = state.episode.podcastImageUrl,
-                    emptyMessage = "No other episodes available",
+                    state = EpisodeRecommendationState(
+                        title = "More from ${state.podcastTitle}",
+                        icon = Icons.Rounded.Subscriptions,
+                        episodes = state.relatedEpisodes,
+                        loading = state.relatedEpisodesLoading,
+                        accentColor = accentColor,
+                        fallbackImageUrl = state.episode.podcastImageUrl,
+                        emptyMessage = "No other episodes available",
+                    ),
                     onHeaderClick = {
                         viewModel.onPodcastLinkClicked()
-                        onPodcastClick(state.podcastId)
+                        actions.onPodcastClick(state.podcastId)
                     },
                     onEpisodeClick = { episode ->
                         viewModel.onRelatedEpisodeClicked()
-                        onEpisodeClick(episode)
+                        actions.onEpisodeClick(episode)
                     },
                     onScrollStarted = viewModel::onRelatedEpisodesScrolled,
                     modifier = Modifier.padding(horizontal = 16.dp),
@@ -381,28 +375,79 @@ private fun EpisodeInfoSuccess(
         )
     }
 
-    if (showShareSheet) {
-        ShareBottomSheet(
-            id = state.episode.id,
-            type = "episode",
-            title = state.episode.title,
-            subtitle = state.podcastTitle,
-            imageUrl = artworkUrl,
-            onDismissRequest = { showShareSheet = false },
-            durationMs = state.episode.duration * 1_000L,
-            currentPositionMs = state.resumePositionMs,
-            showTimestampOption = false,
-            onShare = { _, _, timestamp, target ->
-                ShareManager.shareEpisode(
-                    context = context,
-                    episode = state.episode,
-                    podcastTitle = state.podcastTitle,
-                    timestampMs = timestamp,
-                    target = target,
-                )
-            },
-        )
+    EpisodeShareSheet(
+        visible = showShareSheet,
+        state = state,
+        artworkUrl = artworkUrl,
+        onDismiss = { showShareSheet = false },
+    )
+}
+
+@Composable
+private fun rememberEpisodeAccentColor(
+    episodeId: String,
+    artworkUrl: String?,
+): Color {
+    val context = LocalContext.current
+    var extractedColor by remember(episodeId) { mutableStateOf(Color.Unspecified) }
+    val palettePainter = rememberAsyncImagePainter(
+        model = ImageRequest.Builder(context)
+            .data(artworkUrl)
+            .allowHardware(false)
+            .build(),
+    )
+
+    LaunchedEffect(palettePainter.state) {
+        val painterState = palettePainter.state
+        if (painterState is AsyncImagePainter.State.Success) {
+            val bitmap = (painterState.result.drawable as? BitmapDrawable)?.bitmap
+            if (bitmap != null) extractedColor = extractArtworkColor(bitmap)
+        }
     }
+
+    val paletteColor = if (extractedColor == Color.Unspecified) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        extractedColor
+    }
+    val accentColor by animateColorAsState(
+        targetValue = lerp(paletteColor, MaterialTheme.colorScheme.primary, 0.14f),
+        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        label = "episode_accent",
+    )
+    return accentColor
+}
+
+@Composable
+private fun EpisodeShareSheet(
+    visible: Boolean,
+    state: EpisodeInfoUiState.Success,
+    artworkUrl: String?,
+    onDismiss: () -> Unit,
+) {
+    if (!visible) return
+
+    val context = LocalContext.current
+    ShareBottomSheet(
+        id = state.episode.id,
+        type = "episode",
+        title = state.episode.title,
+        subtitle = state.podcastTitle,
+        imageUrl = artworkUrl,
+        onDismissRequest = onDismiss,
+        durationMs = state.episode.duration * 1_000L,
+        currentPositionMs = state.resumePositionMs,
+        showTimestampOption = false,
+        onShare = { _, _, timestamp, target ->
+            ShareManager.shareEpisode(
+                context = context,
+                episode = state.episode,
+                podcastTitle = state.podcastTitle,
+                timestampMs = timestamp,
+                target = target,
+            )
+        },
+    )
 }
 
 @Composable

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.Subscriptions
@@ -78,6 +79,8 @@ import cx.aswin.boxcast.feature.info.components.EpisodeArtworkBackdrop
 import cx.aswin.boxcast.feature.info.components.EpisodeInfoHero
 import cx.aswin.boxcast.feature.info.components.EpisodeRecommendationSection
 import cx.aswin.boxcast.feature.info.components.EpisodeRecommendationState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 private const val HERO_ITEM_KEY = "episode_hero"
 private const val ACTION_RAIL_ITEM_KEY = "episode_action_rail"
@@ -92,6 +95,7 @@ private data class EpisodeInfoSuccessFlags(
 )
 
 private data class EpisodeInfoSuccessActions(
+    val onBack: () -> Unit,
     val onPodcastClick: (String) -> Unit,
     val onEpisodeClick: (Episode) -> Unit,
     val onMarkPlayedTipDismissed: () -> Unit,
@@ -108,7 +112,7 @@ fun EpisodeInfoScreen(
     podcastId: String,
     podcastTitle: String,
     viewModel: EpisodeInfoViewModel,
-    @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
+    onBack: () -> Unit,
     onPodcastClick: (String) -> Unit,
     onEpisodeClick: (Episode) -> Unit,
     @Suppress("UNUSED_PARAMETER") onPlay: () -> Unit,
@@ -171,6 +175,7 @@ fun EpisodeInfoScreen(
             viewModel = viewModel,
             entryPointContext = entryPointContext,
             actions = EpisodeInfoSuccessActions(
+                onBack = onBack,
                 onPodcastClick = onPodcastClick,
                 onEpisodeClick = onEpisodeClick,
                 onMarkPlayedTipDismissed = onMarkPlayedTipDismissed,
@@ -360,6 +365,7 @@ private fun EpisodeInfoSuccess(
         ExpressiveEpisodeTopBar(
             title = state.episode.title,
             collapseFraction = collapseFraction,
+            onBack = actions.onBack,
             onShare = { showShareSheet = true },
             modifier = Modifier.align(Alignment.TopCenter),
         )
@@ -401,7 +407,11 @@ private fun rememberEpisodeAccentColor(
         val painterState = palettePainter.state
         if (painterState is AsyncImagePainter.State.Success) {
             val bitmap = (painterState.result.drawable as? BitmapDrawable)?.bitmap
-            if (bitmap != null) extractedColor = extractArtworkColor(bitmap)
+            if (bitmap != null) {
+                extractedColor = withContext(Dispatchers.Default) {
+                    extractArtworkColorFromBoundedBitmap(bitmap)
+                }
+            }
         }
     }
 
@@ -454,6 +464,7 @@ private fun EpisodeShareSheet(
 private fun ExpressiveEpisodeTopBar(
     title: String,
     collapseFraction: Float,
+    onBack: () -> Unit,
     onShare: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -472,12 +483,18 @@ private fun ExpressiveEpisodeTopBar(
             .height(64.dp)
             .padding(horizontal = 8.dp),
     ) {
+        TopBarAction(
+            onClick = onBack,
+            modifier = Modifier.align(Alignment.CenterStart),
+        ) {
+            Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back")
+        }
         AnimatedVisibility(
             visible = collapseFraction > 0.68f,
             modifier = Modifier
                 .align(Alignment.CenterStart)
                 .fillMaxWidth()
-                .padding(start = 16.dp, end = 64.dp),
+                .padding(start = 64.dp, end = 64.dp),
             enter = fadeIn(ExpressiveMotion.SleekFadeSpec) + slideInVertically { it / 3 },
             exit = fadeOut(ExpressiveMotion.SleekFadeSpec) + slideOutVertically { it / 3 },
         ) {
@@ -574,6 +591,24 @@ private fun extractArtworkColor(bitmap: Bitmap): Color {
             ?: palette.dominantSwatch?.rgb
             ?: 0xFF6750A4.toInt(),
     )
+}
+
+private fun extractArtworkColorFromBoundedBitmap(bitmap: Bitmap): Color {
+    val maximumDimension = maxOf(bitmap.width, bitmap.height)
+    if (maximumDimension <= 256) return extractArtworkColor(bitmap)
+
+    val scale = 256f / maximumDimension
+    val scaledBitmap = Bitmap.createScaledBitmap(
+        bitmap,
+        (bitmap.width * scale).toInt().coerceAtLeast(1),
+        (bitmap.height * scale).toInt().coerceAtLeast(1),
+        true,
+    )
+    return try {
+        extractArtworkColor(scaledBitmap)
+    } finally {
+        scaledBitmap.recycle()
+    }
 }
 
 private fun formatRemainingTime(remainingMs: Long): String? {

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoViewModel.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoViewModel.kt
@@ -289,20 +289,18 @@ class EpisodeInfoViewModel(
                         )
                         
                         val existingState = _uiState.value as? EpisodeInfoUiState.Success
-                        _uiState.value = EpisodeInfoUiState.Success(
+                        _uiState.value = existingState?.copy(
+                            episode = currentEpisode,
+                            podcastId = finalPodcastId,
+                            podcastTitle = finalPodcastTitle,
+                        ) ?: EpisodeInfoUiState.Success(
                             episode = currentEpisode,
                             podcastId = finalPodcastId,
                             podcastTitle = finalPodcastTitle,
                             resumePositionMs = resumeMs,
                             durationMs = durationMs,
-                            relatedEpisodes = existingState?.relatedEpisodes ?: emptyList(),
-                            relatedEpisodesLoading = existingState?.relatedEpisodesLoading ?: true,
-                            similarEpisodes = existingState?.similarEpisodes ?: emptyList(),
-                            similarEpisodesLoading = existingState?.similarEpisodesLoading ?: true,
-                            location = existingState?.location ?: initialLocation,
-                            license = existingState?.license ?: initialLicense,
-                            crossPromotion = existingState?.crossPromotion,
-                            crossPromoLoading = existingState?.crossPromoLoading ?: false
+                            location = initialLocation,
+                            license = initialLicense,
                         )
 
                         detectCrossPromotion(currentEpisode, finalPodcastTitle)

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoViewModel.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/EpisodeInfoViewModel.kt
@@ -31,6 +31,7 @@ sealed interface EpisodeInfoUiState {
         val similarEpisodes: List<Episode> = emptyList(),
         val similarEpisodesLoading: Boolean = true,
         val isPlaying: Boolean = false, // Sync with global player
+        val isPlaybackLoading: Boolean = false,
         val location: String? = null,
         val license: String? = null,
         val crossPromotion: cx.aswin.boxcast.core.model.ResolvedCrossPromotion? = null,
@@ -107,13 +108,19 @@ class EpisodeInfoViewModel(
                 if (currentState is EpisodeInfoUiState.Success) {
                     val isSameEpisode = playerState.currentEpisode?.id == currentState.episode.id
                     val isPlaying = isSameEpisode && playerState.isPlaying
+                    val isPlaybackLoading = isSameEpisode && playerState.isLoading
                     
                     // If playing this episode, we can also sync the progress in real-time
                     val resumePos = if (isSameEpisode) playerState.position else currentState.resumePositionMs
                     
-                    if (currentState.isPlaying != isPlaying || (isSameEpisode && currentState.resumePositionMs != resumePos)) {
+                    if (
+                        currentState.isPlaying != isPlaying ||
+                        currentState.isPlaybackLoading != isPlaybackLoading ||
+                        (isSameEpisode && currentState.resumePositionMs != resumePos)
+                    ) {
                         _uiState.value = currentState.copy(
                             isPlaying = isPlaying,
+                            isPlaybackLoading = isPlaybackLoading,
                             resumePositionMs = resumePos
                         )
                     }

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/PodcastInfoScreen.kt
@@ -2471,11 +2471,13 @@ fun EpisodeListItem(
                 // Play Button
                 cx.aswin.boxcast.core.designsystem.components.ExpressivePlayButton(
                     onClick = onPlayClick,
-                    isPlaying = isPlaying, 
-                    isResume = isResume,
+                    state = cx.aswin.boxcast.core.designsystem.components.ExpressivePlayButtonState(
+                        isPlaying = isPlaying,
+                        isResume = isResume,
+                        progress = progress,
+                        timeText = timeLeft,
+                    ),
                     accentColor = accentColor,
-                    progress = progress,
-                    timeText = timeLeft,
                     modifier = Modifier
                         .height(44.dp)
                         .padding(start = 16.dp)

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeActionRail.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeActionRail.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
 import cx.aswin.boxcast.core.designsystem.components.ExpressivePlayButton
+import cx.aswin.boxcast.core.designsystem.components.ExpressivePlayButtonState
 import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
 import cx.aswin.boxcast.core.designsystem.theme.ExpressiveMotion
 import cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes
@@ -101,12 +102,14 @@ internal fun EpisodeActionRail(
     ) {
         ExpressivePlayButton(
             onClick = callbacks.onMainActionClick,
-            isPlaying = state.isPlaying,
-            isLoading = state.isPlaybackLoading,
-            isResume = state.isResume,
+            state = ExpressivePlayButtonState(
+                isPlaying = state.isPlaying,
+                isLoading = state.isPlaybackLoading,
+                isResume = state.isResume,
+                progress = state.progress,
+                timeText = state.remainingTimeText,
+            ),
             accentColor = accentColor,
-            progress = state.progress,
-            timeText = state.remainingTimeText,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(60.dp),

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeActionRail.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeActionRail.kt
@@ -1,0 +1,368 @@
+package cx.aswin.boxcast.feature.info.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAddCheck
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.DownloadDone
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import cx.aswin.boxcast.core.designsystem.components.BoxLoreLoader
+import cx.aswin.boxcast.core.designsystem.components.ExpressivePlayButton
+import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import cx.aswin.boxcast.core.designsystem.theme.ExpressiveMotion
+import cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes
+import cx.aswin.boxcast.core.designsystem.theme.contrastColor
+import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
+import kotlinx.coroutines.delay
+
+internal data class EpisodeActionRailState(
+    val title: String,
+    val imageUrl: String?,
+    val isPlaying: Boolean,
+    val isPlaybackLoading: Boolean,
+    val isResume: Boolean,
+    val isLiked: Boolean,
+    val isDownloaded: Boolean,
+    val isDownloading: Boolean,
+    val isQueued: Boolean,
+    val isCompleted: Boolean,
+    val progress: Float,
+    val remainingTimeText: String?,
+)
+
+internal data class EpisodeActionRailCallbacks(
+    val onMainActionClick: () -> Unit,
+    val onLikeClick: () -> Unit,
+    val onDownloadClick: () -> Unit,
+    val onQueueClick: () -> Unit,
+    val onMarkPlayedClick: () -> Unit,
+)
+
+@Composable
+internal fun EpisodeActionRail(
+    state: EpisodeActionRailState,
+    callbacks: EpisodeActionRailCallbacks,
+    accentColor: Color,
+    showMarkPlayedTip: Boolean,
+    onMarkPlayedTipDismissed: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        ExpressivePlayButton(
+            onClick = callbacks.onMainActionClick,
+            isPlaying = state.isPlaying,
+            isLoading = state.isPlaybackLoading,
+            isResume = state.isResume,
+            accentColor = accentColor,
+            progress = state.progress,
+            timeText = state.remainingTimeText,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(60.dp),
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(
+                space = 8.dp,
+                alignment = Alignment.CenterHorizontally,
+            ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            EpisodeToolbarActionButton(
+                isActive = state.isCompleted,
+                activeIcon = Icons.Rounded.CheckCircle,
+                inactiveIcon = Icons.Outlined.CheckCircle,
+                contentDescription = if (state.isCompleted) "Mark unplayed" else "Mark played",
+                onClick = callbacks.onMarkPlayedClick,
+            )
+            EpisodeToolbarActionButton(
+                isActive = state.isLiked,
+                activeIcon = Icons.Filled.Favorite,
+                inactiveIcon = Icons.Outlined.FavoriteBorder,
+                contentDescription = if (state.isLiked) "Unlike" else "Like",
+                onClick = callbacks.onLikeClick,
+            )
+            EpisodeToolbarActionButton(
+                isActive = state.isDownloaded,
+                isLoading = state.isDownloading,
+                activeIcon = Icons.Outlined.DownloadDone,
+                inactiveIcon = Icons.Outlined.Download,
+                contentDescription = if (state.isDownloaded) "Remove download" else "Download",
+                onClick = callbacks.onDownloadClick,
+            )
+            EpisodeToolbarActionButton(
+                isActive = state.isQueued,
+                activeIcon = Icons.AutoMirrored.Rounded.PlaylistAddCheck,
+                inactiveIcon = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                contentDescription = if (state.isQueued) "Remove from queue" else "Add to queue",
+                onClick = callbacks.onQueueClick,
+            )
+        }
+        MarkPlayedCoachmark(
+            visible = showMarkPlayedTip,
+            onDismissed = onMarkPlayedTipDismissed,
+        )
+    }
+}
+
+@Composable
+private fun EpisodeToolbarActionButton(
+    isActive: Boolean,
+    activeIcon: ImageVector,
+    inactiveIcon: ImageVector,
+    contentDescription: String,
+    onClick: () -> Unit,
+    isLoading: Boolean = false,
+) {
+    val containerColor by animateColorAsState(
+        targetValue = if (isActive) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            MaterialTheme.colorScheme.surfaceContainerLow
+        },
+        label = "episode_toolbar_container",
+    )
+    val contentColor by animateColorAsState(
+        targetValue = if (isActive) {
+            MaterialTheme.colorScheme.onPrimaryContainer
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        label = "episode_toolbar_content",
+    )
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(48.dp)
+            .expressiveClickable(
+                enabled = !isLoading,
+                shape = ExpressiveShapes.Pill,
+                onClick = onClick,
+            )
+            .background(containerColor, ExpressiveShapes.Pill),
+    ) {
+        if (isLoading) {
+            BoxLoreLoader.CircularWavy(
+                size = 22.dp,
+                color = contentColor,
+            )
+        } else {
+            Icon(
+                imageVector = if (isActive) activeIcon else inactiveIcon,
+                contentDescription = contentDescription,
+                tint = contentColor,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MarkPlayedCoachmark(
+    visible: Boolean,
+    onDismissed: () -> Unit,
+) {
+    var isVisible by remember(visible) { mutableStateOf(visible) }
+    LaunchedEffect(isVisible) {
+        if (isVisible) {
+            delay(4_000)
+            isVisible = false
+            onDismissed()
+        }
+    }
+    AnimatedVisibility(
+        visible = isVisible,
+        enter = fadeIn() + slideInVertically(initialOffsetY = { -it / 2 }),
+        exit = fadeOut() + scaleOut(targetScale = 0.92f),
+    ) {
+        Surface(
+            shape = ExpressiveShapes.Pill,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        ) {
+            Text(
+                text = "Tip: tap the check to mark this episode complete",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 9.dp),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun CompactEpisodeActionRail(
+    state: EpisodeActionRailState,
+    callbacks: EpisodeActionRailCallbacks,
+    accentColor: Color,
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        visible = visible,
+        modifier = modifier,
+        enter = fadeIn(ExpressiveMotion.SleekFadeSpec) +
+            slideInVertically(
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = 200f,
+                ),
+            ) { -it / 3 } +
+            scaleIn(animationSpec = ExpressiveMotion.SpatialLargeSpring, initialScale = 0.96f),
+        exit = fadeOut(ExpressiveMotion.SleekFadeSpec) +
+            slideOutVertically(
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioNoBouncy,
+                    stiffness = 200f,
+                ),
+            ) { -it / 3 } +
+            scaleOut(animationSpec = ExpressiveMotion.SpatialLargeSpring, targetScale = 0.96f),
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = MaterialTheme.shapes.extraLarge,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shadowElevation = 10.dp,
+            tonalElevation = 6.dp,
+        ) {
+            Row(
+                modifier = Modifier.padding(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OptimizedImage(
+                    url = state.imageUrl,
+                    proxyWidth = 144,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(MaterialTheme.shapes.large),
+                    contentScale = ContentScale.Crop,
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = state.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                CompactPlayButton(
+                    isPlaying = state.isPlaying,
+                    isLoading = state.isPlaybackLoading,
+                    progress = state.progress,
+                    accentColor = accentColor,
+                    onClick = callbacks.onMainActionClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CompactPlayButton(
+    isPlaying: Boolean,
+    isLoading: Boolean,
+    progress: Float,
+    accentColor: Color,
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier
+            .padding(start = 4.dp)
+            .size(52.dp)
+            .expressiveClickable(
+                enabled = !isLoading,
+                shape = CircleShape,
+                isolate = true,
+                onClick = onClick,
+            ),
+        shape = CircleShape,
+        color = accentColor,
+        contentColor = accentColor.contrastColor(),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            if (isLoading) {
+                BoxLoreLoader.CircularWavy(
+                    size = 27.dp,
+                    color = accentColor.contrastColor(),
+                )
+            } else {
+                Icon(
+                    imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                    contentDescription = if (isPlaying) "Pause" else "Play",
+                    modifier = Modifier.size(27.dp),
+                )
+            }
+            if (progress > 0f) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.BottomCenter,
+                ) {
+                    LinearProgressIndicator(
+                        progress = { progress },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(3.dp),
+                        color = accentColor.contrastColor(alpha = 0.62f),
+                        trackColor = Color.Transparent,
+                        drawStopIndicator = {},
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeActionRail.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeActionRail.kt
@@ -51,6 +51,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -189,6 +192,10 @@ private fun EpisodeToolbarActionButton(
         contentAlignment = Alignment.Center,
         modifier = Modifier
             .size(48.dp)
+            .semantics {
+                this.contentDescription = contentDescription
+                if (isLoading) stateDescription = "Loading"
+            }
             .expressiveClickable(
                 enabled = !isLoading,
                 shape = ExpressiveShapes.Pill,
@@ -204,7 +211,7 @@ private fun EpisodeToolbarActionButton(
         } else {
             Icon(
                 imageVector = if (isActive) activeIcon else inactiveIcon,
-                contentDescription = contentDescription,
+                contentDescription = null,
                 tint = contentColor,
                 modifier = Modifier.size(22.dp),
             )
@@ -323,10 +330,15 @@ private fun CompactPlayButton(
     accentColor: Color,
     onClick: () -> Unit,
 ) {
+    val contentDescription = if (isPlaying) "Pause" else "Play"
     Surface(
         modifier = Modifier
             .padding(start = 4.dp)
             .size(52.dp)
+            .semantics {
+                this.contentDescription = contentDescription
+                if (isLoading) stateDescription = "Loading"
+            }
             .expressiveClickable(
                 enabled = !isLoading,
                 shape = CircleShape,
@@ -346,7 +358,7 @@ private fun CompactPlayButton(
             } else {
                 Icon(
                     imageVector = if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                    contentDescription = if (isPlaying) "Pause" else "Play",
+                    contentDescription = null,
                     modifier = Modifier.size(27.dp),
                 )
             }

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeDurationFormatter.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeDurationFormatter.kt
@@ -1,7 +1,7 @@
 package cx.aswin.boxcast.feature.info.components
 
 internal fun formatEpisodeDuration(seconds: Int): String {
-    if (seconds <= 0) return ""
+    if (seconds < 60) return ""
     val hours = seconds / 3_600
     val minutes = (seconds % 3_600) / 60
     return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeDurationFormatter.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeDurationFormatter.kt
@@ -1,0 +1,8 @@
+package cx.aswin.boxcast.feature.info.components
+
+internal fun formatEpisodeDuration(seconds: Int): String {
+    if (seconds <= 0) return ""
+    val hours = seconds / 3_600
+    val minutes = (seconds % 3_600) / 60
+    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+}

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeInfoHero.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeInfoHero.kt
@@ -1,0 +1,272 @@
+package cx.aswin.boxcast.feature.info.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.rounded.Label
+import androidx.compose.material.icons.rounded.CalendarToday
+import androidx.compose.material.icons.rounded.Schedule
+import androidx.compose.material.icons.rounded.Tag
+import androidx.compose.material.icons.rounded.Videocam
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes
+import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
+import cx.aswin.boxcast.core.model.Episode
+
+@Composable
+internal fun EpisodeArtworkBackdrop(
+    imageUrl: String?,
+    scrollOffset: Float,
+    collapseFraction: Float,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                translationY = -scrollOffset * 0.5f
+                alpha = 1f - collapseFraction
+            },
+    ) {
+        OptimizedImage(
+            url = imageUrl,
+            proxyWidth = 200,
+            contentDescription = null,
+            modifier = Modifier
+                .fillMaxSize()
+                .alpha(0.5f)
+                .blur(50.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded),
+            contentScale = ContentScale.Crop,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Transparent,
+                            MaterialTheme.colorScheme.background,
+                        ),
+                    ),
+                ),
+        )
+    }
+}
+
+@Composable
+internal fun EpisodeInfoHero(
+    episode: Episode,
+    podcastTitle: String,
+    accentColor: Color,
+    collapseFraction: Float,
+    onPodcastClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    androidx.compose.foundation.layout.Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .graphicsLayer {
+                alpha = 1f - collapseFraction * 0.18f
+                translationY = -collapseFraction * 20.dp.toPx()
+            },
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(204.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                modifier = Modifier
+                    .size(184.dp),
+                shape = MaterialTheme.shapes.extraLarge,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                shadowElevation = 6.dp,
+            ) {
+                OptimizedImage(
+                    url = episode.imageUrl?.ifBlank { episode.podcastImageUrl },
+                    proxyWidth = 640,
+                    contentDescription = episode.title,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            }
+            if (episode.enclosureType?.startsWith("video/") == true) {
+                Surface(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(end = 54.dp, bottom = 2.dp),
+                    shape = ExpressiveShapes.Pill,
+                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    shadowElevation = 6.dp,
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(Icons.Rounded.Videocam, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Text("Video", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
+                    }
+                }
+            }
+        }
+
+        Text(
+            text = episode.title,
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Black,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 24.dp),
+        )
+        Spacer(Modifier.height(10.dp))
+        Row(
+            modifier = Modifier
+                .expressiveClickable(onClick = onPodcastClick)
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = podcastTitle,
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.width(2.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = "Open podcast",
+                tint = accentColor,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+        Spacer(Modifier.height(12.dp))
+        EpisodeMetadataChipsRow(episode)
+    }
+}
+
+private data class EpisodeMetadataChip(
+    val label: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+)
+
+@Composable
+private fun EpisodeMetadataChipsRow(episode: Episode) {
+    val metadata = buildList {
+        if (episode.enclosureType?.startsWith("video/") == true) {
+            add(EpisodeMetadataChip("Video", Icons.Rounded.Videocam))
+        }
+        add(EpisodeMetadataChip(formatDuration(episode.duration), Icons.Rounded.Schedule))
+        formatRelativeDate(episode.publishedDate)?.let {
+            add(EpisodeMetadataChip(it, Icons.Rounded.CalendarToday))
+        }
+        formatSeasonAndEpisode(episode)?.let {
+            add(EpisodeMetadataChip(it, Icons.Rounded.Tag))
+        }
+        episode.episodeType
+            ?.takeUnless { it.equals("full", ignoreCase = true) }
+            ?.let {
+                add(
+                    EpisodeMetadataChip(
+                        it.replaceFirstChar(Char::uppercase),
+                        Icons.AutoMirrored.Rounded.Label,
+                    ),
+                )
+            }
+    }
+
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+        contentPadding = PaddingValues(horizontal = 0.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        items(metadata) { item ->
+            Surface(
+                shape = ExpressiveShapes.Pill,
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = item.icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = item.label,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatDuration(seconds: Int): String {
+    val safeSeconds = seconds.coerceAtLeast(0)
+    val hours = safeSeconds / 3600
+    val minutes = (safeSeconds % 3600) / 60
+    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
+}
+
+private fun formatRelativeDate(timestampSeconds: Long): String? {
+    if (timestampSeconds <= 0L) return null
+    val difference = ((System.currentTimeMillis() / 1000L) - timestampSeconds).coerceAtLeast(0L)
+    return when {
+        difference < 3_600L -> "${difference / 60L}m ago"
+        difference < 86_400L -> "${difference / 3_600L}h ago"
+        difference < 604_800L -> "${difference / 86_400L}d ago"
+        difference < 2_592_000L -> "${difference / 604_800L}w ago"
+        difference < 31_536_000L -> "${difference / 2_592_000L}mo ago"
+        else -> "${difference / 31_536_000L}y ago"
+    }
+}
+
+private fun formatSeasonAndEpisode(episode: Episode): String? = buildString {
+    episode.seasonNumber?.takeIf { it > 0 }?.let { append("S$it") }
+    episode.episodeNumber?.takeIf { it > 0 }?.let {
+        if (isNotEmpty()) append(" ")
+        append("E$it")
+    }
+}.ifBlank { null }

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeInfoHero.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeInfoHero.kt
@@ -107,38 +107,41 @@ internal fun EpisodeInfoHero(
                 .height(204.dp),
             contentAlignment = Alignment.Center,
         ) {
-            Surface(
-                modifier = Modifier
-                    .size(184.dp),
-                shape = MaterialTheme.shapes.extraLarge,
-                color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                shadowElevation = 6.dp,
+            Box(
+                modifier = Modifier.size(184.dp),
             ) {
-                OptimizedImage(
-                    url = episode.imageUrl?.ifBlank { episode.podcastImageUrl },
-                    proxyWidth = 640,
-                    contentDescription = episode.title,
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Crop,
-                )
-            }
-            if (episode.enclosureType?.startsWith("video/") == true) {
                 Surface(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(end = 54.dp, bottom = 2.dp),
-                    shape = ExpressiveShapes.Pill,
-                    color = MaterialTheme.colorScheme.tertiaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.fillMaxSize(),
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
                     shadowElevation = 6.dp,
                 ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                    OptimizedImage(
+                        url = episode.imageUrl?.ifBlank { episode.podcastImageUrl },
+                        proxyWidth = 640,
+                        contentDescription = episode.title,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop,
+                    )
+                }
+                if (episode.enclosureType?.startsWith("video/") == true) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(bottom = 2.dp),
+                        shape = ExpressiveShapes.Pill,
+                        color = MaterialTheme.colorScheme.tertiaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+                        shadowElevation = 6.dp,
                     ) {
-                        Icon(Icons.Rounded.Videocam, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Text("Video", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
+                        Row(
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(Icons.Rounded.Videocam, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Text("Video", style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Bold)
+                        }
                     }
                 }
             }

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeInfoHero.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeInfoHero.kt
@@ -117,7 +117,8 @@ internal fun EpisodeInfoHero(
                     shadowElevation = 6.dp,
                 ) {
                     OptimizedImage(
-                        url = episode.imageUrl?.ifBlank { episode.podcastImageUrl },
+                        url = episode.imageUrl?.takeIf(String::isNotBlank)
+                            ?: episode.podcastImageUrl,
                         proxyWidth = 640,
                         contentDescription = episode.title,
                         modifier = Modifier.fillMaxSize(),
@@ -194,7 +195,9 @@ private fun EpisodeMetadataChipsRow(episode: Episode) {
         if (episode.enclosureType?.startsWith("video/") == true) {
             add(EpisodeMetadataChip("Video", Icons.Rounded.Videocam))
         }
-        add(EpisodeMetadataChip(formatDuration(episode.duration), Icons.Rounded.Schedule))
+        formatEpisodeDuration(episode.duration)
+            .takeIf(String::isNotBlank)
+            ?.let { add(EpisodeMetadataChip(it, Icons.Rounded.Schedule)) }
         formatRelativeDate(episode.publishedDate)?.let {
             add(EpisodeMetadataChip(it, Icons.Rounded.CalendarToday))
         }
@@ -244,13 +247,6 @@ private fun EpisodeMetadataChipsRow(episode: Episode) {
             }
         }
     }
-}
-
-private fun formatDuration(seconds: Int): String {
-    val safeSeconds = seconds.coerceAtLeast(0)
-    val hours = safeSeconds / 3600
-    val minutes = (safeSeconds % 3600) / 60
-    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
 }
 
 private fun formatRelativeDate(timestampSeconds: Long): String? {

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
@@ -45,17 +45,21 @@ import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxcast.core.designsystem.theme.m3Shimmer
 import cx.aswin.boxcast.core.model.Episode
 
+internal data class EpisodeRecommendationState(
+    val title: String,
+    val icon: ImageVector,
+    val episodes: List<Episode>,
+    val loading: Boolean,
+    val accentColor: Color,
+    val fallbackImageUrl: String?,
+    val emptyMessage: String? = null,
+)
+
 @Composable
 internal fun EpisodeRecommendationSection(
-    title: String,
-    icon: ImageVector,
-    episodes: List<Episode>,
-    loading: Boolean,
-    accentColor: Color,
-    fallbackImageUrl: String?,
+    state: EpisodeRecommendationState,
     onEpisodeClick: (Episode) -> Unit,
     modifier: Modifier = Modifier,
-    emptyMessage: String? = null,
     onHeaderClick: (() -> Unit)? = null,
     onScrollStarted: (() -> Unit)? = null,
 ) {
@@ -90,14 +94,14 @@ internal fun EpisodeRecommendationSection(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Icon(
-                    imageVector = icon,
+                    imageVector = state.icon,
                     contentDescription = null,
-                    tint = accentColor,
+                    tint = state.accentColor,
                     modifier = Modifier.size(22.dp),
                 )
                 Spacer(Modifier.width(10.dp))
                 Text(
-                    text = title,
+                    text = state.title,
                     style = MaterialTheme.typography.titleLarge,
                     color = MaterialTheme.colorScheme.onSurface,
                     fontWeight = FontWeight.Black,
@@ -108,7 +112,7 @@ internal fun EpisodeRecommendationSection(
                 if (onHeaderClick != null) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                        contentDescription = "Open $title",
+                        contentDescription = "Open ${state.title}",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
@@ -120,19 +124,18 @@ internal fun EpisodeRecommendationSection(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 when {
-                    loading -> items(4) { RecommendationSkeleton() }
-                    episodes.isNotEmpty() -> items(episodes, key = { it.id }) { episode ->
+                    state.loading -> items(4) { RecommendationSkeleton() }
+                    state.episodes.isNotEmpty() -> items(state.episodes, key = { it.id }) { episode ->
                         ExpressiveEpisodeCard(
                             episode = episode,
                             imageUrl = episode.imageUrl?.ifBlank { episode.podcastImageUrl }
-                                ?: fallbackImageUrl,
-                            accentColor = accentColor,
+                                ?: state.fallbackImageUrl,
                             onClick = { onEpisodeClick(episode) },
                         )
                     }
-                    emptyMessage != null -> item {
+                    state.emptyMessage != null -> item {
                         Text(
-                            text = emptyMessage,
+                            text = state.emptyMessage,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.padding(vertical = 24.dp, horizontal = 4.dp),
@@ -148,7 +151,6 @@ internal fun EpisodeRecommendationSection(
 private fun ExpressiveEpisodeCard(
     episode: Episode,
     imageUrl: String?,
-    accentColor: Color,
     onClick: () -> Unit,
 ) {
     OutlinedCard(

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
@@ -153,6 +153,7 @@ private fun ExpressiveEpisodeCard(
     imageUrl: String?,
     onClick: () -> Unit,
 ) {
+    val durationText = formatEpisodeDuration(episode.duration)
     OutlinedCard(
         modifier = Modifier
             .width(160.dp)
@@ -181,7 +182,7 @@ private fun ExpressiveEpisodeCard(
                         .clip(RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp)),
                     contentScale = ContentScale.Crop,
                 )
-                if (episode.duration > 0) {
+                if (durationText.isNotEmpty()) {
                     Surface(
                         modifier = Modifier
                             .align(Alignment.BottomEnd)
@@ -191,7 +192,7 @@ private fun ExpressiveEpisodeCard(
                         contentColor = Color.White,
                     ) {
                         Text(
-                            text = formatEpisodeDuration(episode.duration),
+                            text = durationText,
                             style = MaterialTheme.typography.labelSmall,
                             fontWeight = FontWeight.Medium,
                             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
@@ -191,7 +191,7 @@ private fun ExpressiveEpisodeCard(
                         contentColor = Color.White,
                     ) {
                         Text(
-                            text = formatCardDuration(episode.duration),
+                            text = formatEpisodeDuration(episode.duration),
                             style = MaterialTheme.typography.labelSmall,
                             fontWeight = FontWeight.Medium,
                             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
@@ -227,13 +227,6 @@ private fun ExpressiveEpisodeCard(
             }
         }
     }
-}
-
-private fun formatCardDuration(seconds: Int): String {
-    if (seconds <= 0) return ""
-    val hours = seconds / 3_600
-    val minutes = (seconds % 3_600) / 60
-    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
 }
 
 @Composable

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
@@ -231,7 +231,9 @@ private fun ExpressiveEpisodeCard(
 
 private fun formatCardDuration(seconds: Int): String {
     if (seconds <= 0) return ""
-    return "${seconds / 60}m"
+    val hours = seconds / 3_600
+    val minutes = (seconds % 3_600) / 60
+    return if (hours > 0) "${hours}h ${minutes}m" else "${minutes}m"
 }
 
 @Composable

--- a/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
+++ b/feature/info/src/main/java/cx/aswin/boxcast/feature/info/components/EpisodeRecommendationSection.kt
@@ -1,0 +1,261 @@
+package cx.aswin.boxcast.feature.info.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cx.aswin.boxcast.core.designsystem.components.OptimizedImage
+import cx.aswin.boxcast.core.designsystem.theme.ExpressiveShapes
+import cx.aswin.boxcast.core.designsystem.theme.expressiveClickable
+import cx.aswin.boxcast.core.designsystem.theme.m3Shimmer
+import cx.aswin.boxcast.core.model.Episode
+
+@Composable
+internal fun EpisodeRecommendationSection(
+    title: String,
+    icon: ImageVector,
+    episodes: List<Episode>,
+    loading: Boolean,
+    accentColor: Color,
+    fallbackImageUrl: String?,
+    onEpisodeClick: (Episode) -> Unit,
+    modifier: Modifier = Modifier,
+    emptyMessage: String? = null,
+    onHeaderClick: (() -> Unit)? = null,
+    onScrollStarted: (() -> Unit)? = null,
+) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(listState.isScrollInProgress) {
+        if (listState.isScrollInProgress) onScrollStarted?.invoke()
+    }
+
+    OutlinedCard(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Column(modifier = Modifier.padding(vertical = 16.dp)) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(
+                        if (onHeaderClick != null) {
+                            Modifier.expressiveClickable(
+                                shape = MaterialTheme.shapes.large,
+                                onClick = onHeaderClick,
+                            )
+                        } else {
+                            Modifier
+                        },
+                    )
+                    .padding(horizontal = 20.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = accentColor,
+                    modifier = Modifier.size(22.dp),
+                )
+                Spacer(Modifier.width(10.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.Black,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                if (onHeaderClick != null) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                        contentDescription = "Open $title",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Spacer(Modifier.height(14.dp))
+            LazyRow(
+                state = listState,
+                contentPadding = PaddingValues(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                when {
+                    loading -> items(4) { RecommendationSkeleton() }
+                    episodes.isNotEmpty() -> items(episodes, key = { it.id }) { episode ->
+                        ExpressiveEpisodeCard(
+                            episode = episode,
+                            imageUrl = episode.imageUrl?.ifBlank { episode.podcastImageUrl }
+                                ?: fallbackImageUrl,
+                            accentColor = accentColor,
+                            onClick = { onEpisodeClick(episode) },
+                        )
+                    }
+                    emptyMessage != null -> item {
+                        Text(
+                            text = emptyMessage,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(vertical = 24.dp, horizontal = 4.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExpressiveEpisodeCard(
+    episode: Episode,
+    imageUrl: String?,
+    accentColor: Color,
+    onClick: () -> Unit,
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .width(160.dp)
+            .expressiveClickable(
+                shape = MaterialTheme.shapes.large,
+                onClick = onClick,
+            ),
+        shape = MaterialTheme.shapes.large,
+        colors = CardDefaults.outlinedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Column {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(1f),
+            ) {
+                OptimizedImage(
+                    url = imageUrl,
+                    proxyWidth = 400,
+                    contentDescription = episode.title,
+                    modifier = Modifier
+                        .matchParentSize()
+                        .clip(RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp)),
+                    contentScale = ContentScale.Crop,
+                )
+                if (episode.duration > 0) {
+                    Surface(
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(6.dp),
+                        shape = MaterialTheme.shapes.small,
+                        color = Color.Black.copy(alpha = 0.6f),
+                        contentColor = Color.White,
+                    ) {
+                        Text(
+                            text = formatCardDuration(episode.duration),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                        )
+                    }
+                }
+            }
+            Column(
+                modifier = Modifier
+                    .padding(10.dp)
+                    .heightIn(min = 58.dp),
+            ) {
+                Text(
+                    text = episode.title,
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontSize = 13.sp,
+                        lineHeight = 17.sp,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(6.dp))
+                episode.podcastTitle?.takeIf(String::isNotBlank)?.let { podcastTitle ->
+                    Text(
+                        text = podcastTitle,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatCardDuration(seconds: Int): String {
+    if (seconds <= 0) return ""
+    return "${seconds / 60}m"
+}
+
+@Composable
+private fun RecommendationSkeleton() {
+    val baseColor = MaterialTheme.colorScheme.surfaceContainerHigh
+    val highlightColor = MaterialTheme.colorScheme.surfaceContainerHighest
+    Column(modifier = Modifier.width(160.dp)) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(MaterialTheme.shapes.large)
+                .background(baseColor)
+                .m3Shimmer(baseColor, highlightColor),
+        )
+        Spacer(Modifier.height(10.dp))
+        repeat(2) { index ->
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(if (index == 0) 1f else 0.72f)
+                    .height(13.dp)
+                    .clip(ExpressiveShapes.Pill)
+                    .background(baseColor)
+                    .m3Shimmer(baseColor, highlightColor),
+            )
+            Spacer(Modifier.height(5.dp))
+        }
+    }
+}

--- a/feature/info/src/test/java/cx/aswin/boxcast/feature/info/components/EpisodeDurationFormatterTest.kt
+++ b/feature/info/src/test/java/cx/aswin/boxcast/feature/info/components/EpisodeDurationFormatterTest.kt
@@ -1,0 +1,26 @@
+package cx.aswin.boxcast.feature.info.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EpisodeDurationFormatterTest {
+    @Test
+    fun `zero duration is hidden`() {
+        assertEquals("", formatEpisodeDuration(0))
+    }
+
+    @Test
+    fun `positive sub-minute duration is hidden`() {
+        assertEquals("", formatEpisodeDuration(59))
+    }
+
+    @Test
+    fun `one minute duration is displayed`() {
+        assertEquals("1m", formatEpisodeDuration(60))
+    }
+
+    @Test
+    fun `hour duration includes remaining minutes`() {
+        assertEquals("1h 1m", formatEpisodeDuration(3_660))
+    }
+}


### PR DESCRIPTION
## Summary
- redesign episode details around an artwork-led Material 3 Expressive layout
- add cohesive episode action controls, a sticky playback rail, and visible playback buffering state
- restyle notes, promotions, and recommendation sections while preserving episode actions
- integrate adaptive recommendations into the time-based home feed hierarchy

## Listener impact → What changes in the user’s life
Episode pages are calmer, easier to scan, and keep the most important playback actions immediately available. Listeners now see when an episode is buffering instead of wondering whether a tap worked, and home recommendations are presented in a more coherent personalized flow.

## Verification
- `./gradlew installDebug`
- installed successfully on the connected device