### PR TITLE
ci(gradle): enable Develocity Build Scans with TOS agree

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,7 +17,56 @@ pluginManagement {
 }
 
 plugins {
+    id("com.gradle.develocity") version "4.5.0"
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
+
+val isCi =
+    !System.getenv("CI").isNullOrEmpty() ||
+        !System.getenv("GITHUB_ACTIONS").isNullOrEmpty()
+
+develocity {
+    buildScan {
+        // Required to publish to the public Develocity host without an interactive prompt.
+        // Local builds stay on-demand (`./gradlew <task> --scan`); CI publishes every run.
+        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+        termsOfUseAgree.set("yes")
+
+        // CI agents exit as soon as Gradle returns; finish the upload before that.
+        uploadInBackground.set(!isCi)
+
+        if (isCi) {
+            publishing.onlyIf { true }
+            tag("CI")
+            System.getenv("GITHUB_WORKFLOW")
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { value("GitHub workflow", it) }
+            System.getenv("GITHUB_RUN_ID")
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { value("GitHub run id", it) }
+            System.getenv("GITHUB_REF_NAME")
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { value("GitHub ref", it) }
+            System.getenv("GITHUB_SHA")
+                ?.takeIf { it.isNotEmpty() }
+                ?.let { value("GitHub SHA", it.take(12)) }
+            val repository = System.getenv("GITHUB_REPOSITORY")
+            if (!repository.isNullOrEmpty()) {
+                link("GitHub repository", "https://github.com/$repository")
+                val runId = System.getenv("GITHUB_RUN_ID")
+                if (!runId.isNullOrEmpty()) {
+                    link(
+                        "GitHub Actions run",
+                        "https://github.com/$repository/actions/runs/$runId",
+                    )
+                }
+            }
+        } else {
+            // Keep everyday local builds private unless --scan is passed explicitly.
+            publishing.onlyIf { false }
+            tag("Local")
+        }
+    }
 }
 
 /**

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,14 +36,13 @@ develocity {
         uploadInBackground.set(!isCi)
 
         if (isCi) {
-            publishing.onlyIf { true }
+            // Default publish-on policy already publishes; no onlyIf needed in CI.
             tag("CI")
             System.getenv("GITHUB_WORKFLOW")
                 ?.takeIf { it.isNotEmpty() }
                 ?.let { value("GitHub workflow", it) }
-            System.getenv("GITHUB_RUN_ID")
-                ?.takeIf { it.isNotEmpty() }
-                ?.let { value("GitHub run id", it) }
+            val runId = System.getenv("GITHUB_RUN_ID")?.takeIf { it.isNotEmpty() }
+            runId?.let { value("GitHub run id", it) }
             System.getenv("GITHUB_REF_NAME")
                 ?.takeIf { it.isNotEmpty() }
                 ?.let { value("GitHub ref", it) }
@@ -53,8 +52,7 @@ develocity {
             val repository = System.getenv("GITHUB_REPOSITORY")
             if (!repository.isNullOrEmpty()) {
                 link("GitHub repository", "https://github.com/$repository")
-                val runId = System.getenv("GITHUB_RUN_ID")
-                if (!runId.isNullOrEmpty()) {
+                if (runId != null) {
                     link(
                         "GitHub Actions run",
                         "https://github.com/$repository/actions/runs/$runId",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Apply the Develocity Gradle plugin (`4.5.0`) so Build Scans can publish instead of staying "unpublished"
- Agree to Develocity terms of use in `settings.gradle.kts` (required for non-interactive publish)
- Local builds stay private unless you pass `--scan`; CI publishes every Gradle run with GitHub metadata

## Motivation

Gradle was offering Build Scans that stayed unpublished because TOS were never accepted and the project had no Develocity config. That made troubleshooting slow (no shareable scan URL).

## What changed

- Added `com.gradle.develocity` in `settings.gradle.kts`
- Configured publish policy:
  - **Local:** on-demand via `./gradlew <task> --scan`
  - **CI (`CI` / `GITHUB_ACTIONS`):** always publish, upload in foreground, tag `CI`, attach GitHub run/ref/SHA links

## Behavior & compatibility

- Everyday local Gradle builds do **not** publish a scan
- `./gradlew help --scan` (and any other task with `--scan`) publishes a public URL on `gradle.com`
- No app runtime or secret handling changes; `local.properties` / `google-services.json` remain gitignored and untouched

## Impact (required)

### User impact — pick **exactly one**

- [x] `no-user-impact`

### Backend — optional

- [ ] `backend-change`

## Test plan

- [x] `./gradlew help --scan` published successfully (example: https://gradle.com/s/2s566jm6sq63k)
- [x] `./gradlew help` completed with no scan publish
- [ ] After merge, spot-check a CI Gradle job log for a published Build Scan URL

## Notes

Public scans go to Gradle’s hosted Develocity (`gradle.com`). They capture build metadata / console output, not source or APKs. Don’t pass secrets on the Gradle command line if you publish a scan.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a4cc20d-7e0d-4eb5-8807-60244e094018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a4cc20d-7e0d-4eb5-8807-60244e094018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

