### PR TITLE
ci(test): run suites on merge queue and manual dispatch

### DIFF
--- a/.github/workflows/android-instrumented-tests.yml
+++ b/.github/workflows/android-instrumented-tests.yml
@@ -1,10 +1,10 @@
 name: Instrumented Tests
 
+# Runs when a PR enters the merge queue (merge click), or via manual dispatch.
+# Not on every PR push — emulator jobs are expensive for intermediate commits.
 on:
-  push:
-    branches: [ master, main, "cursor/**" ]
-  pull_request:
-    branches: [ master, main ]
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   compose-android-test:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,10 +1,10 @@
 name: Unit Tests
 
+# Runs when a PR enters the merge queue (merge click), or via manual dispatch.
+# Not on every PR push — avoid burning CI on intermediate commits.
 on:
-  push:
-    branches: [ master, main, "cursor/**" ]
-  pull_request:
-    branches: [ master, main ]
+  merge_group:
+  workflow_dispatch:
 
 jobs:
   unit-tests:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -86,7 +86,15 @@ No Roborazzi/Papyrus plugin is required for the current scaffolding.
 | `unit-tests.yml` | `./gradlew testDebugUnitTest` + `:koverVerifyMerged` (JVM) | Merge queue (`merge_group`) or **Actions → Run workflow** |
 | `android-instrumented-tests.yml` | `:feature:home:connectedDebugAndroidTest` on an API 34 emulator | Same |
 
-These do **not** run on every PR push. Enable a **merge queue** on `master` and mark both workflows as required checks so merge is blocked if they fail. Use manual dispatch anytime you want a one-off run.
+These do **not** run on every PR push. Use manual dispatch anytime you want a one-off run.
+
+**Repo rules (owner only):** apply the merge queue + required checks with:
+
+```bash
+./scripts/ci/configure-master-merge-queue.sh
+```
+
+That script (needs `gh` admin on the repo) creates/updates a `master` ruleset: merge queue + required Unit/Instrumented checks, with bypass for GitHub Actions (data bots) and the repo owner so direct `[skip ci]` pushes still work. The Cursor agent token cannot apply this — run it locally as `ashwkun`.
 
 Maestro / screenshots stay **local** (need a full app install / manual capture).
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -81,16 +81,18 @@ No Roborazzi/Papyrus plugin is required for the current scaffolding.
 
 ## CI
 
-| Workflow | What it runs |
-| :--- | :--- |
-| `unit-tests.yml` | `./gradlew testDebugUnitTest` (JVM) |
-| `android-instrumented-tests.yml` | `:feature:home:connectedDebugAndroidTest` on an API 34 emulator |
+| Workflow | What it runs | When |
+| :--- | :--- | :--- |
+| `unit-tests.yml` | `./gradlew testDebugUnitTest` + `:koverVerifyMerged` (JVM) | Merge queue (`merge_group`) or **Actions → Run workflow** |
+| `android-instrumented-tests.yml` | `:feature:home:connectedDebugAndroidTest` on an API 34 emulator | Same |
+
+These do **not** run on every PR push. Enable a **merge queue** on `master` and mark both workflows as required checks so merge is blocked if they fail. Use manual dispatch anytime you want a one-off run.
 
 Maestro / screenshots stay **local** (need a full app install / manual capture).
 
 Protected inputs:
 - `app/google-services.json` is **gitignored** and must never be committed.
-- The real file is a **release-environment** secret (`GOOGLE_SERVICES_JSON_BASE64` on GitHub Environment `release`). Ordinary PR/push jobs cannot read it.
+- The real file is a **release-environment** secret (`GOOGLE_SERVICES_JSON_BASE64` on GitHub Environment `release`). Ordinary CI jobs cannot read it.
 - The unit-test workflow writes a non-secret CI stub only so the Google Services plugin can configure `:app`, then deletes it. Release workflows keep using the real secret.
 - Locally, keep using your usual `.env` / local `app/google-services.json` — unchanged.
 

--- a/scripts/ci/configure-master-merge-queue.sh
+++ b/scripts/ci/configure-master-merge-queue.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Configure master merge queue + required test checks for ashwkun/boxlore.
+#
+# Requires a token with admin:repo (or repo admin) — the Cursor cloud agent
+# token cannot do this. Run locally as the repo owner:
+#
+#   gh auth login   # if needed, as ashwkun
+#   ./scripts/ci/configure-master-merge-queue.sh
+#
+# Design:
+# - PR merges into master must go through the merge queue
+# - Unit Tests + Instrumented Tests are required for the queue
+# - GitHub Actions (data sync bots) and the repo owner can bypass so
+#   direct [skip ci] data pushes to master keep working
+set -euo pipefail
+
+OWNER="${OWNER:-ashwkun}"
+REPO="${REPO:-boxlore}"
+RULESET_NAME="${RULESET_NAME:-master-merge-queue}"
+
+# https://api.github.com/apps/github-actions
+GITHUB_ACTIONS_APP_ID=15368
+# Repo owner (ashwkun) — keeps emergency direct pushes possible
+OWNER_USER_ID=167635885
+
+# Job `name:` values from the workflows (GitHub check contexts)
+UNIT_CHECK="testDebugUnitTest"
+INSTRUMENTED_CHECK="feature:home connectedDebugAndroidTest"
+
+echo "Checking auth can administer ${OWNER}/${REPO}..."
+if ! gh api "repos/${OWNER}/${REPO}" --jq '.permissions.admin' | grep -qx true; then
+  echo "error: current gh token lacks admin on ${OWNER}/${REPO}" >&2
+  echo "       Sign in as the owner: gh auth login" >&2
+  exit 1
+fi
+
+existing_id="$(
+  gh api "repos/${OWNER}/${REPO}/rulesets" \
+    | jq -r --arg name "$RULESET_NAME" '.[] | select(.name == $name) | .id' \
+    | head -n1
+)"
+if [[ "${existing_id}" == "null" ]]; then
+  existing_id=""
+fi
+
+payload="$(cat <<EOF
+{
+  "name": "${RULESET_NAME}",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/master"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": ${GITHUB_ACTIONS_APP_ID},
+      "actor_type": "Integration",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": ${OWNER_USER_ID},
+      "actor_type": "User",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "merge_queue",
+      "parameters": {
+        "merge_method": "SQUASH",
+        "max_entries_to_build": 5,
+        "min_entries_to_merge": 1,
+        "max_entries_to_merge": 5,
+        "min_entries_to_merge_wait_minutes": 0,
+        "check_response_timeout_minutes": 90,
+        "grouping_strategy": "ALLGREEN"
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          { "context": "${UNIT_CHECK}" },
+          { "context": "${INSTRUMENTED_CHECK}" }
+        ]
+      }
+    }
+  ]
+}
+EOF
+)"
+
+if [[ -n "${existing_id}" ]]; then
+  echo "Updating existing ruleset id=${existing_id}..."
+  echo "${payload}" | gh api --method PUT "repos/${OWNER}/${REPO}/rulesets/${existing_id}" --input -
+else
+  echo "Creating ruleset ${RULESET_NAME}..."
+  echo "${payload}" | gh api --method POST "repos/${OWNER}/${REPO}/rulesets" --input -
+fi
+
+echo
+echo "Configured. Verify:"
+echo "  https://github.com/${OWNER}/${REPO}/settings/rules"
+echo "  gh api repos/${OWNER}/${REPO}/rulesets --jq '.[].name'"
+echo
+echo "PR merges → merge queue → ${UNIT_CHECK} + ${INSTRUMENTED_CHECK}."
+echo "GitHub Actions + owner bypass keep direct master data pushes working."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Unit and instrumented test workflows now trigger only on **`merge_group`** (merge queue) and **`workflow_dispatch`** (manual)
- Removed `push` / `pull_request` triggers so intermediate PR commits no longer burn CI
- Added `scripts/ci/configure-master-merge-queue.sh` for the repo owner to apply merge-queue + required checks (with bot bypass)

## Motivation

Per-push PR CI (especially the emulator job) is expensive and doesn’t match the desired gate: run once when merging, block if red, plus a manual re-run option — without blocking GitHub Actions data pushes to `master`.

## What changed

- `.github/workflows/unit-tests.yml` — `on: merge_group` + `workflow_dispatch`
- `.github/workflows/android-instrumented-tests.yml` — same
- `scripts/ci/configure-master-merge-queue.sh` — creates/updates the `master` ruleset
- `docs/TESTING.md` — CI trigger + ruleset setup notes

## Behavior & compatibility

- **No run** on every PR push
- **Runs** when a PR enters the merge queue
- **Runs** from Actions → Run workflow anytime
- Data bots that push directly to `master` stay unblocked via ruleset bypass (GitHub Actions app + owner)

## Impact (required)

### User impact

- [x] `no-user-impact`

## Test plan

- [ ] As repo owner, run `./scripts/ci/configure-master-merge-queue.sh`
- [ ] Confirm ruleset at https://github.com/ashwkun/boxlore/settings/rules
- [ ] Enqueue a PR and confirm both test workflows start once
- [ ] Confirm a sync/data bot push to `master` still succeeds
- [ ] From Actions, manually run **Unit Tests** / **Instrumented Tests**

## Notes

**Repo settings:** the Cursor agent token cannot create rulesets (`403 Resource not accessible by integration`). After merging this branch stack, run locally as `ashwkun`:

```bash
./scripts/ci/configure-master-merge-queue.sh
```

Base: `cursor/full-refactor-tests-3b38` (lands with the test workflows from that branch).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a4cc20d-7e0d-4eb5-8807-60244e094018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a4cc20d-7e0d-4eb5-8807-60244e094018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

