### PR TITLE
fix(playback): keep player UI in sync when reopening while audio plays

### DIFF
--- a/core/playback/src/main/java/cx/aswin/boxlore/core/data/PlaybackRepository.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/data/PlaybackRepository.kt
@@ -2203,17 +2203,31 @@ class PlaybackRepository(
         // If saved queue is empty but we have an episode, make a single-item queue
         val restoredQueue = if (savedQueue.isEmpty()) listOf(episode) else savedQueue
 
-        // Update state but don't play
+        // Prefer live MediaController truth when the playback service is still running
+        // (e.g. user swiped the app from recents while audio continued). Forcing
+        // isPlaying=false here races with syncStateFromMediaController() and leaves
+        // the UI paused while ExoPlayer keeps playing.
+        val controller = mediaController
+        val controllerPlaying = controller?.isPlaying == true
+        val controllerPosition = controller?.currentPosition?.takeIf { it > 0 }
+        val controllerDuration = controller?.duration?.takeIf { it > 0 }
+
         _playerState.value =
             _playerState.value.copy(
                 currentEpisode = episode,
                 currentPodcast = podcast,
-                isPlaying = false,
-                position = lastSession.progressMs,
-                duration = lastSession.durationMs,
+                isPlaying = controllerPlaying,
+                position = controllerPosition ?: lastSession.progressMs,
+                duration = controllerDuration ?: lastSession.durationMs,
                 isLiked = lastSession.isLiked,
                 queue = restoredQueue,
             )
+
+        // Re-sync after metadata restore in case the controller connected first and
+        // onIsPlayingChanged won't fire again (already playing when the listener attached).
+        if (controller != null) {
+            syncStateFromMediaController()
+        }
 
         return true
     }


### PR DESCRIPTION
## Summary
- `restoreLastSession()` no longer forces `isPlaying = false` when the MediaController is still connected and playing (e.g. after swiping the app from recents).
- Prefers live controller position/duration and re-syncs player state so the mini/full player matches audio after reopen.

## Listener impact → What changes in the user’s life
If you swipe Boxlore away while a podcast is still playing, then open the app again, the player now shows **playing** instead of incorrectly looking paused while audio continues.

## Test plan
- [ ] Start playback, swipe app from recents (audio should continue)
- [ ] Reopen Boxlore — mini player / player UI should show playing, not paused
- [ ] Pause and resume still work after reconnect
- [ ] Cold start with no background playback still restores last episode as paused