### PR TITLE
chore(ci): run unit tests on merge queue only

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,9 +1,9 @@
 name: Unit Tests
 
-# Runs on every PR (and merge queue / manual dispatch) so architecture/regression
-# suites gate before merge — not only when a PR enters the merge queue.
+# Runs when a PR enters the merge queue (merge click), or via manual dispatch.
+# Not on every PR push — intermediate commits should not burn CI minutes.
+# Direct bot/owner pushes to master do not use the merge queue and are unaffected.
 on:
-  pull_request:
   merge_group:
   workflow_dispatch:
 

--- a/docs/PLAN_MODULAR_ANDROID_HARDENING.md
+++ b/docs/PLAN_MODULAR_ANDROID_HARDENING.md
@@ -516,7 +516,7 @@ Rename slim leftover `:core:data` → `:core:catalog` (or document `:core:data` 
 
 #### B0 — CI floors (quick wins)
 
-**Status:** done for current floors — `:koverVerifyMerged` in `unit-tests.yml`; google-services stub action; unit tests on **every PR** + architecture boundary script (`scripts/ci/check-feature-no-boxlore-database.sh`); detekt + ktlint baseline checks run in CI; non-blocking `./gradlew lintDebug` (`continue-on-error: true`).
+**Status:** done for current floors — `:koverVerifyMerged` in `unit-tests.yml`; google-services stub action; unit + instrumented tests on **merge queue** (`merge_group`) + architecture boundary script (`scripts/ci/check-feature-no-boxlore-database.sh`); detekt + ktlint baseline checks run in that same CI job; non-blocking `./gradlew lintDebug` (`continue-on-error: true`).
 
 - ~~Optional non-blocking `./gradlew lintDebug` job → then fail-on-error.~~ non-blocking step landed; fail-on-error later.
 - ~~Add detekt/ktlint with baseline when ready.~~ done (see B9).
@@ -577,7 +577,7 @@ Rename slim leftover `:core:data` → `:core:catalog` (or document `:core:data` 
 
 #### B9 — Static analysis
 
-**Status:** done for detekt + ktlint — detekt uses `config/detekt/{detekt.yml,baseline.xml}`; ktlint uses `org.jlleitschuh.gradle.ktlint` plus per-project baselines under `config/ktlint/`. CI runs `./gradlew detekt` and `./gradlew ktlintCheck` on every PR, failing only on new quality/style issues beyond the committed baselines. ktlint format tasks are not wired into build or CI.
+**Status:** done for detekt + ktlint — detekt uses `config/detekt/{detekt.yml,baseline.xml}`; ktlint uses `org.jlleitschuh.gradle.ktlint` plus per-project baselines under `config/ktlint/`. CI runs `./gradlew detekt` and `./gradlew ktlintCheck` on merge queue (with unit tests), failing only on new quality/style issues beyond the committed baselines. ktlint format tasks are not wired into build or CI.
 
 - Keep aligned with existing `.coderabbit.yaml` / Sonar — don’t fight duplicate rule noise.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -116,8 +116,8 @@ No Roborazzi/Papyrus plugin is required for the current scaffolding.
 
 | Workflow | What it runs | When |
 | :--- | :--- | :--- |
-| `unit-tests.yml` | Architecture boundary script + detekt + ktlint + `testDebugUnitTest` (includes Konsist) + `:koverVerifyMerged` + non-blocking `lintDebug` | **Every PR** (`pull_request`), merge queue (`merge_group`), or **Actions → Run workflow** |
-| `android-instrumented-tests.yml` | `:feature:home:connectedDebugAndroidTest` on an API 34 emulator | Merge queue / manual |
+| `unit-tests.yml` | Architecture boundary script + detekt + ktlint + `testDebugUnitTest` (includes Konsist) + `:koverVerifyMerged` + non-blocking `lintDebug` | **Merge queue only** (`merge_group`), or **Actions → Run workflow** |
+| `android-instrumented-tests.yml` | `:feature:home:connectedDebugAndroidTest` on an API 34 emulator | **Merge queue only** / manual |
 | `maestro-nightly.yml` | Validate `maestro/*.yaml`; optional Maestro Cloud when secrets present | Nightly cron (UTC) / manual |
 
 Architecture boundary: `scripts/ci/check-feature-no-boxlore-database.sh` fails if Home/Info ViewModels or assemblers re-introduce `BoxLoreDatabase`. Konsist/filesystem guards in `:core:testing` additionally enforce feature isolation, `getInstance` allowlist, `:core:data` ↛ designsystem, and module README presence.


### PR DESCRIPTION
## Summary
- Remove `pull_request` from `unit-tests.yml` so unit/detekt/ktlint/Kover only run on **merge queue** (`merge_group`) or manual dispatch — same pattern as instrumented tests.
- Direct bot/owner pushes to `master` never enter the merge queue, so they stay unaffected.
- After merge, apply `./scripts/ci/configure-master-merge-queue.sh` so master requires those checks at merge time (Actions + owner bypass for data bots).

## Test plan
- [ ] Pushing a commit to an open PR does **not** start Unit Tests
- [ ] Adding the PR to the merge queue runs Unit + Instrumented checks
- [ ] Bot direct pushes to master still succeed without those checks