### PR TITLE
chore(ci): gate expensive tests behind merge-ci label

### DIFF
--- a/.github/workflows/android-instrumented-tests.yml
+++ b/.github/workflows/android-instrumented-tests.yml
@@ -1,14 +1,22 @@
 name: Instrumented Tests
 
-# Runs when a PR enters the merge queue (merge click), or via manual dispatch.
-# Not on every PR push — emulator jobs are expensive for intermediate commits.
+# Same merge-gate as unit tests: only when `merge-ci` is on the PR (or merge
+# queue / manual). Emulator jobs are too expensive for every intermediate push.
+# Direct bot/owner pushes to master do not use PRs and are unaffected.
 on:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:
 
 jobs:
   compose-android-test:
     name: feature:home connectedDebugAndroidTest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'merge-ci'))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/android-instrumented-tests.yml
+++ b/.github/workflows/android-instrumented-tests.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
       - name: Install Android build-tools 36
         run: |
           set -euo pipefail

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,15 +1,25 @@
 name: Unit Tests
 
-# Runs when a PR enters the merge queue (merge click), or via manual dispatch.
-# Not on every PR push — intermediate commits should not burn CI minutes.
-# Direct bot/owner pushes to master do not use the merge queue and are unaffected.
+# Merge-gate only (not every PR push):
+# - Add the `merge-ci` label when ready to merge → runs on that commit and on
+#   later pushes while the label stays.
+# - `merge_group` kept for orgs that enable a merge queue later.
+# - Manual: Actions → Run workflow.
+# Direct bot/owner pushes to master never open a PR, so they are unaffected.
 on:
+  pull_request:
+    types: [labeled, synchronize, opened, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:
 
 jobs:
   unit-tests:
     name: testDebugUnitTest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'merge-ci'))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/docs/PLAN_MODULAR_ANDROID_HARDENING.md
+++ b/docs/PLAN_MODULAR_ANDROID_HARDENING.md
@@ -516,7 +516,7 @@ Rename slim leftover `:core:data` → `:core:catalog` (or document `:core:data` 
 
 #### B0 — CI floors (quick wins)
 
-**Status:** done for current floors — `:koverVerifyMerged` in `unit-tests.yml`; google-services stub action; unit + instrumented tests on **merge queue** (`merge_group`) + architecture boundary script (`scripts/ci/check-feature-no-boxlore-database.sh`); detekt + ktlint baseline checks run in that same CI job; non-blocking `./gradlew lintDebug` (`continue-on-error: true`).
+**Status:** done for current floors — `:koverVerifyMerged` in `unit-tests.yml`; google-services stub action; unit + instrumented tests on the **`merge-ci` label** merge-gate (+ `merge_group` if a queue is ever enabled) + architecture boundary script (`scripts/ci/check-feature-no-boxlore-database.sh`); detekt + ktlint baseline checks run in that same CI job; non-blocking `./gradlew lintDebug` (`continue-on-error: true`).
 
 - ~~Optional non-blocking `./gradlew lintDebug` job → then fail-on-error.~~ non-blocking step landed; fail-on-error later.
 - ~~Add detekt/ktlint with baseline when ready.~~ done (see B9).
@@ -577,7 +577,7 @@ Rename slim leftover `:core:data` → `:core:catalog` (or document `:core:data` 
 
 #### B9 — Static analysis
 
-**Status:** done for detekt + ktlint — detekt uses `config/detekt/{detekt.yml,baseline.xml}`; ktlint uses `org.jlleitschuh.gradle.ktlint` plus per-project baselines under `config/ktlint/`. CI runs `./gradlew detekt` and `./gradlew ktlintCheck` on merge queue (with unit tests), failing only on new quality/style issues beyond the committed baselines. ktlint format tasks are not wired into build or CI.
+**Status:** done for detekt + ktlint — detekt uses `config/detekt/{detekt.yml,baseline.xml}`; ktlint uses `org.jlleitschuh.gradle.ktlint` plus per-project baselines under `config/ktlint/`. CI runs `./gradlew detekt` and `./gradlew ktlintCheck` on the merge-gate (`merge-ci` label), failing only on new quality/style issues beyond the committed baselines. ktlint format tasks are not wired into build or CI.
 
 - Keep aligned with existing `.coderabbit.yaml` / Sonar — don’t fight duplicate rule noise.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -116,19 +116,21 @@ No Roborazzi/Papyrus plugin is required for the current scaffolding.
 
 | Workflow | What it runs | When |
 | :--- | :--- | :--- |
-| `unit-tests.yml` | Architecture boundary script + detekt + ktlint + `testDebugUnitTest` (includes Konsist) + `:koverVerifyMerged` + non-blocking `lintDebug` | **Merge queue only** (`merge_group`), or **Actions → Run workflow** |
-| `android-instrumented-tests.yml` | `:feature:home:connectedDebugAndroidTest` on an API 34 emulator | **Merge queue only** / manual |
+| `unit-tests.yml` | Architecture boundary script + detekt + ktlint + `testDebugUnitTest` (includes Konsist) + `:koverVerifyMerged` + non-blocking `lintDebug` | **`merge-ci` label** on the PR (and later pushes while labeled), merge queue if enabled, or **Actions → Run workflow** |
+| `android-instrumented-tests.yml` | `:feature:home:connectedDebugAndroidTest` on an API 34 emulator | Same merge-gate as unit tests |
 | `maestro-nightly.yml` | Validate `maestro/*.yaml`; optional Maestro Cloud when secrets present | Nightly cron (UTC) / manual |
 
 Architecture boundary: `scripts/ci/check-feature-no-boxlore-database.sh` fails if Home/Info ViewModels or assemblers re-introduce `BoxLoreDatabase`. Konsist/filesystem guards in `:core:testing` additionally enforce feature isolation, `getInstance` allowlist, `:core:data` ↛ designsystem, and module README presence.
 
-**Repo rules (owner only):** apply the merge queue + required checks with:
+**Repo rules (owner only):** apply required merge-gate checks with:
 
 ```bash
 ./scripts/ci/configure-master-merge-queue.sh
 ```
 
-That script (needs `gh` admin on the repo) creates/updates a `master` ruleset: merge queue + required Unit/Instrumented checks, with bypass for GitHub Actions (data bots) and the repo owner so direct `[skip ci]` pushes still work. The Cursor agent token cannot apply this — run it locally as `ashwkun`.
+That script (needs `gh` admin on the repo) creates/updates the `master-required-checks` ruleset (Unit + Instrumented required to merge a PR) and ensures the `merge-ci` label exists. **How to use:** open/iterate the PR without CI → add `merge-ci` when ready → wait for green checks → merge. Direct bot/chore pushes to `master` are not gated (no “require pull request” rule). Owner bypass remains for emergencies.
+
+> Note: GitHub **merge queue** is not available on this user-owned repo (API rejects `merge_queue`). The `merge-ci` label is the substitute for “run expensive scans only when merging.”
 
 Maestro device-farm stays **optional** (needs `MAESTRO_CLOUD_API_KEY` + `MAESTRO_PROJECT_ID`). Screenshots stay local (manual capture).
 

--- a/scripts/ci/configure-master-merge-queue.sh
+++ b/scripts/ci/configure-master-merge-queue.sh
@@ -1,26 +1,25 @@
 #!/usr/bin/env bash
-# Configure master merge queue + required test checks for ashwkun/boxlore.
+# Configure master required merge-gate checks for ashwkun/boxlore.
 #
-# Requires a token with admin:repo (or repo admin) — the Cursor cloud agent
-# token cannot do this. Run locally as the repo owner:
+# Requires a token with admin:repo (or repo admin). Run locally as the owner:
 #
 #   gh auth login   # if needed, as ashwkun
 #   ./scripts/ci/configure-master-merge-queue.sh
 #
 # Design:
-# - PR merges into master must go through the merge queue
-# - Unit Tests + Instrumented Tests are required for the queue
-# - GitHub Actions (data sync bots) and the repo owner can bypass so
-#   direct [skip ci] data pushes to master keep working
+# - PR merges into master require Unit + Instrumented status checks
+# - CI only runs when the PR has the `merge-ci` label (see workflows) — not on
+#   every intermediate push
+# - No "require pull request" / merge_queue rule: this is a user-owned repo and
+#   merge_queue is rejected by the API; data bots must keep pushing to master
+# - Repo owner can bypass the ruleset for emergencies
 set -euo pipefail
 
 OWNER="${OWNER:-ashwkun}"
 REPO="${REPO:-boxlore}"
-RULESET_NAME="${RULESET_NAME:-master-merge-queue}"
+RULESET_NAME="${RULESET_NAME:-master-required-checks}"
 
-# https://api.github.com/apps/github-actions
-GITHUB_ACTIONS_APP_ID=15368
-# Repo owner (ashwkun) — keeps emergency direct pushes possible
+# Repo owner (ashwkun) — emergency ruleset bypass
 OWNER_USER_ID=167635885
 
 # Job `name:` values from the workflows (GitHub check contexts)
@@ -32,6 +31,33 @@ if ! gh api "repos/${OWNER}/${REPO}" --jq '.permissions.admin' | grep -qx true; 
   echo "error: current gh token lacks admin on ${OWNER}/${REPO}" >&2
   echo "       Sign in as the owner: gh auth login" >&2
   exit 1
+fi
+
+# Ensure the merge-gate label exists (workflows key off this name).
+if ! gh label list --repo "${OWNER}/${REPO}" --search merge-ci --json name --jq '.[].name' | grep -qx merge-ci; then
+  echo "Creating label merge-ci..."
+  gh label create merge-ci \
+    --repo "${OWNER}/${REPO}" \
+    --description "Run merge-gate CI (unit + instrumented). Add when ready to merge." \
+    --color "0E8A16"
+fi
+
+# Drop classic branch protection if present — it blocks non-admin direct pushes
+# (breaks data bots). Rulesets below do not require a PR for direct pushes.
+if gh api "repos/${OWNER}/${REPO}/branches/master/protection" >/dev/null 2>&1; then
+  echo "Removing classic branch protection on master (bots need direct push)..."
+  gh api --method DELETE "repos/${OWNER}/${REPO}/branches/master/protection"
+fi
+
+# Remove obsolete merge-queue ruleset name if left from earlier attempts.
+old_mq_id="$(
+  gh api "repos/${OWNER}/${REPO}/rulesets" \
+    | jq -r '.[] | select(.name == "master-merge-queue") | .id' \
+    | head -n1
+)"
+if [[ -n "${old_mq_id}" && "${old_mq_id}" != "null" ]]; then
+  echo "Deleting obsolete ruleset master-merge-queue id=${old_mq_id}..."
+  gh api --method DELETE "repos/${OWNER}/${REPO}/rulesets/${old_mq_id}"
 fi
 
 existing_id="$(
@@ -56,29 +82,12 @@ payload="$(cat <<EOF
   },
   "bypass_actors": [
     {
-      "actor_id": ${GITHUB_ACTIONS_APP_ID},
-      "actor_type": "Integration",
-      "bypass_mode": "always"
-    },
-    {
       "actor_id": ${OWNER_USER_ID},
       "actor_type": "User",
       "bypass_mode": "always"
     }
   ],
   "rules": [
-    {
-      "type": "merge_queue",
-      "parameters": {
-        "merge_method": "SQUASH",
-        "max_entries_to_build": 5,
-        "min_entries_to_merge": 1,
-        "max_entries_to_merge": 5,
-        "min_entries_to_merge_wait_minutes": 0,
-        "check_response_timeout_minutes": 90,
-        "grouping_strategy": "ALLGREEN"
-      }
-    },
     {
       "type": "required_status_checks",
       "parameters": {
@@ -108,5 +117,9 @@ echo "Configured. Verify:"
 echo "  https://github.com/${OWNER}/${REPO}/settings/rules"
 echo "  gh api repos/${OWNER}/${REPO}/rulesets --jq '.[].name'"
 echo
-echo "PR merges → merge queue → ${UNIT_CHECK} + ${INSTRUMENTED_CHECK}."
-echo "GitHub Actions + owner bypass keep direct master data pushes working."
+echo "Workflow:"
+echo "  1. Open / update PR as usual (no Unit/Instrumented CI yet)"
+echo "  2. Add label \`merge-ci\` when ready → Unit + Instrumented run"
+echo "  3. Merge only after both checks are green"
+echo "Direct master pushes (bots / chores) stay outside these gates."
+echo "Owner bypass remains for emergency ruleset overrides."

--- a/scripts/ci/configure-master-merge-queue.sh
+++ b/scripts/ci/configure-master-merge-queue.sh
@@ -34,13 +34,12 @@ if ! gh api "repos/${OWNER}/${REPO}" --jq '.permissions.admin' | grep -qx true; 
 fi
 
 # Ensure the merge-gate label exists (workflows key off this name).
-if ! gh label list --repo "${OWNER}/${REPO}" --search merge-ci --json name --jq '.[].name' | grep -qx merge-ci; then
-  echo "Creating label merge-ci..."
-  gh label create merge-ci \
-    --repo "${OWNER}/${REPO}" \
-    --description "Run merge-gate CI (unit + instrumented). Add when ready to merge." \
-    --color "0E8A16"
-fi
+echo "Ensuring label merge-ci..."
+gh label create merge-ci \
+  --repo "${OWNER}/${REPO}" \
+  --description "Run merge-gate CI (unit + instrumented). Add when ready to merge." \
+  --color "0E8A16" \
+  --force
 
 # Drop classic branch protection if present — it blocks non-admin direct pushes
 # (breaks data bots). Rulesets below do not require a PR for direct pushes.


### PR DESCRIPTION
## Summary
- Unit + instrumented workflows no longer run on every PR push.
- Add the \`merge-ci\` label when ready → checks run; required by \`master-required-checks\` ruleset before merge.
- Direct bot/owner pushes to \`master\` stay allowed (no require-PR / no classic branch protection).
- GitHub merge queue is unavailable on this user-owned repo; \`merge-ci\` is the substitute. Script updated accordingly.

## Test plan
- [ ] Push to an unlabeled PR → no Unit/Instrumented runs
- [ ] Add \`merge-ci\` → both checks run
- [ ] Merge blocked until both are green
- [ ] Bot direct push to master still works