### PR TITLE
docs: finish TESTING.md informative closing [skip changelog]

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -174,8 +174,8 @@ Protected inputs:
 
 ## Module README checklist
 
-Every `app/`, `core/*/`, and `feature/*/` module must keep a folder README aligned with [`MODULE_README_TEMPLATE.md`](MODULE_README_TEMPLATE.md), including Testing notes and the primary Gradle test command. Konsist fails if an included module lacks `README.md`.
+Every `app/`, `core/*/`, and `feature/*/` module keeps a folder README. Shape and required sections follow [`MODULE_README_TEMPLATE.md`](MODULE_README_TEMPLATE.md), including Testing notes and the primary Gradle test command. Konsist fails if an included module lacks `README.md`.
 
-## Next phase
+## Open gaps
 
-A later testing phase owns implementation of every **Yet to start** row above (Application-backed Home/Info suites or hermetic equivalents, broader androidTest, additional strict Maestro flows, screenshot goldens, Kover ratchet). This document is the aspirational map; do not claim those rows Done until verified.
+Rows marked **Yet to start** above are still empty: Application-backed Home/Info suites (or hermetic equivalents), broader `androidTest`, additional strict Maestro flows, screenshot goldens, and a higher Kover floor. Treat those statuses as inventory, not a claim that the work is finished.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Finishes the `docs/TESTING.md` rewrite: replace the plan-like “Next phase” closer with an inventory-style “Open gaps” section.

## Test plan
Docs-only; merge without CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-204fe7ab-bbfb-4479-9d41-0f7fc3bc1a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-204fe7ab-bbfb-4479-9d41-0f7fc3bc1a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

