### PR TITLE
docs: add Cursor Cloud environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+boxlore is a single-product **Android app** (Kotlin, multi-module Gradle: `:app`, `:core:*`, `:feature:*`). There is no server to run — "running" the product means building the debug APK and launching it on an Android emulator. The "smart" backend (search/recommendations/briefing) is a private external service and is not in this repo; without it the app still works as a standard podcast client (offline library, RSS, OPML).
+
+### Environment (already provisioned in the snapshot)
+- JDK 17 at `/usr/lib/jvm/java-17-openjdk-amd64` (the repo requires 17; the base image also ships JDK 21 — do not let Gradle pick 21).
+- Android SDK at `~/Android/Sdk` with `platform-tools`, `build-tools;36.0.0`, `platforms;android-36`, `emulator`, and system images `android-34;google_apis;x86_64` and `android-34;default;x86_64`.
+- `~/.bashrc` exports `JAVA_HOME`, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `PATH`. New non-login shells may not source it — if `java -version` shows 21 or `sdkmanager` is missing, `source ~/.bashrc` first.
+- The update script runs `scripts/ci/write-cloud-agent-local-config.sh`, which writes `local.properties` (`sdk.dir`) and a non-secret stub `app/google-services.json`. Both are gitignored and are NOT secrets.
+
+### Build / test / lint (no device needed)
+Standard commands, all via the Gradle wrapper (see also `.github/workflows/unit-tests.yml`):
+- Build debug APK: `./gradlew assembleDebug` (first run downloads Gradle 9.6.1 + deps, ~4–5 min).
+- Unit tests: `./gradlew testDebugUnitTest --continue`
+- Lint: `./gradlew detekt ktlintCheck lintDebug`
+- Coverage floor / screenshots / dep guard: `./gradlew :koverVerifyMerged :feature:home:verifyRoborazziDebug :app:dependencyGuard`
+- Roborazzi renders real Compose screens on the JVM (no emulator): `./gradlew :feature:home:recordRoborazziDebug` → PNGs in `feature/home/build/intermediates/roborazzi/`.
+
+### Running the app on the emulator (non-obvious gotchas)
+- There is **no `/dev/kvm`** here, so the emulator runs with software CPU emulation (`-no-accel -gpu swiftshader_indirect -no-window`). It is usable but very slow: boot takes several minutes and the starved CPU triggers frequent system-wide "System UI / Process system isn't responding" ANR dialogs. These are environment slowness, not app bugs — dismiss with "Wait" and give screens 60–90s to settle.
+- Prefer the lighter **AOSP image** (`system-images;android-34;default;x86_64`, AVD `boxlore_aosp`) over `google_apis`: Play Services background work on the google_apis image makes ANRs much worse.
+- After install, run `adb shell cmd package compile -m speed -f cx.aswin.boxlore` to AOT-compile — this removes the runtime class-verification overhead that otherwise causes a playback-service ANR on the slow CPU.
+- The launcher activity is `cx.aswin.boxlore/.MainActivity`.
+- **The app requires a syntactically valid `BOXLORE_API_BASE_URL` to launch.** `PodcastRepository` eagerly builds a Retrofit client from it, so an empty value (the default in the stub config) crashes at startup with `IllegalArgumentException: Expected URL scheme 'http' or 'https'`. To launch the UI offline, add to `local.properties`: `BOXLORE_API_BASE_URL=https://api.boxlore.example` (and optionally `BOXLORE_PUBLIC_KEY=demo-placeholder-key`), then rebuild. With a placeholder URL, backend-dependent screens (Explore search, Lore/curiosity, briefing) show graceful "failed to load" states; offline features (onboarding, Library/Downloads, RSS/OPML) work normally. For real backend functionality, set the private `BOXLORE_API_BASE_URL`/`BOXLORE_PUBLIC_KEY` as secrets.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the Cloud Agent development environment for boxlore (Android/Kotlin/Gradle). Adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing non-obvious setup/run caveats so future agents can build, test, and run the app.

- Documents the provisioned toolchain (JDK 17, Android SDK w/ build-tools 36 + platform 36 + emulator) and standard build/test/lint commands (referencing `.github/workflows/unit-tests.yml`).
- Captures the non-obvious runtime gotchas: no `/dev/kvm` (software emulator, slow + system ANRs), preferring the AOSP system image, AOT-compiling to avoid a playback-service ANR, and the empty-`BOXLORE_API_BASE_URL` startup crash + placeholder workaround.

## Motivation

A fresh clone lacks the JDK/SDK, and the app has a couple of non-obvious runtime requirements (valid `BOXLORE_API_BASE_URL`, no KVM). Recording these lets future agents get productive without rediscovering them.

## What changed

- Added `AGENTS.md` (docs only). No application code changed. `local.properties` and `app/google-services.json` are gitignored and generated by `scripts/ci/write-cloud-agent-local-config.sh`.

## Verified in this environment

- `./gradlew assembleDebug` — debug APK built (113 MB).
- `./gradlew testDebugUnitTest --continue` — unit tests pass.
- `./gradlew detekt ktlintCheck lintDebug` — lint passes.
- `./gradlew :feature:home:recordRoborazziDebug` — Compose screenshot renders produced.
- Installed and launched the APK on a software-rendered emulator: completed onboarding and navigated the app (Lore, Library/Downloads).

## Behavior & compatibility

No behavior change; documentation only.

## Impact (required)

- [x] `no-user-impact`

## Test plan

- [x] Built / installed locally (`./gradlew assembleDebug` + `adb install`)
- [x] Manual check: app launches and core navigation works on emulator
- [ ] Add `merge-ci` when ready

## Notes

Onboarding screen:

[boxlore onboarding](https://cursor.com/agents/bc-83f2fbb9-be7b-4faa-90e5-f14a307ec7a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fboxlore_onboarding_screen.png)

Library → Downloads (offline feature, no backend):

[boxlore Library Downloads](https://cursor.com/agents/bc-83f2fbb9-be7b-4faa-90e5-f14a307ec7a1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fboxlore_library_downloads.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83f2fbb9-be7b-4faa-90e5-f14a307ec7a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83f2fbb9-be7b-4faa-90e5-f14a307ec7a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

