### PR TITLE
ci: require CodeRabbit review threads resolved before merge [skip unit]

### DIFF
--- a/.cursor/rules/pr-impact-labels.mdc
+++ b/.cursor/rules/pr-impact-labels.mdc
@@ -47,7 +47,7 @@ Agent / maintainer flow:
 
 1. Open and iterate the PR (Sonar + CodeRabbit + unit suite run on each push).
 2. Wait for **`testDebugUnitTest`**, **`SonarCloud Code Analysis`**, **`CodeRabbit`**, and **`coderabbit-threads-resolved`** green.
-3. Address CodeRabbit findings and mark each CodeRabbit thread **Resolved** (required for merge; Cursor agents must not merge while this check is red).
+3. Address CodeRabbit findings and mark each CodeRabbit thread **Resolved** (required for merge; Cursor agents must not merge while this check is red). After resolving without a new push, re-run **CodeRabbit Threads Resolved** (`workflow_dispatch` with `pr_number`) so the check flips green.
 4. Merge via **Merge when ready** (merge queue, squash) — the queue re-runs **`testDebugUnitTest`** and re-checks threads.
 5. Optional: Actions → Run workflow (`Unit Tests`) for a manual full gate.
 

--- a/.cursor/rules/pr-impact-labels.mdc
+++ b/.cursor/rules/pr-impact-labels.mdc
@@ -40,14 +40,16 @@ Master is protected by a **merge queue** ruleset. Required checks:
 |:--|:--|
 | `testDebugUnitTest` | Full unit / static / Kover / Roborazzi gate (PR + merge queue) |
 | `SonarCloud Code Analysis` | SonarCloud quality gate must pass (**0 new-code issues**) |
-| `CodeRabbit` | CodeRabbit review green; resolve all review threads |
+| `CodeRabbit` | CodeRabbit review job finished (not “no open findings”) |
+| `coderabbit-threads-resolved` | **Mandatory:** every non-outdated CodeRabbit review thread is Resolved |
 
 Agent / maintainer flow:
 
 1. Open and iterate the PR (Sonar + CodeRabbit + unit suite run on each push).
-2. Wait for **`testDebugUnitTest`**, **`SonarCloud Code Analysis`**, and **`CodeRabbit`** green; resolve all review threads.
-3. Merge via **Merge when ready** (merge queue, squash) — the queue re-runs **`testDebugUnitTest`**.
-4. Optional: Actions → Run workflow (`Unit Tests`) for a manual full gate.
+2. Wait for **`testDebugUnitTest`**, **`SonarCloud Code Analysis`**, **`CodeRabbit`**, and **`coderabbit-threads-resolved`** green.
+3. Address CodeRabbit findings and mark each CodeRabbit thread **Resolved** (required for merge; Cursor agents must not merge while this check is red).
+4. Merge via **Merge when ready** (merge queue, squash) — the queue re-runs **`testDebugUnitTest`** and re-checks threads.
+5. Optional: Actions → Run workflow (`Unit Tests`) for a manual full gate.
 
 **Title skips (when appropriate only):**
 
@@ -73,4 +75,4 @@ Use Conventional Commits only:
 4. Never apply two user-impact level labels on the same PR.
 5. If the label is `user-impact-high` or `user-impact-medium`, the PR body **must** include **Listener impact → What changes in the user’s life** in plain listener language (not just engineering bullets). Skip that section only for `user-impact-low` or `no-user-impact`.
 6. If a PR title violates Conventional Commits, rename it with `gh pr edit <n> --title "type(scope): …"` before merge.
-7. Before merging: confirm SonarCloud + CodeRabbit + unit tests are green and review threads are resolved, then **Merge when ready** (merge queue re-runs unit tests). Do not force-push into an active queue entry.
+7. Before merging: confirm SonarCloud + CodeRabbit + **`coderabbit-threads-resolved`** + unit tests are green, then **Merge when ready** (merge queue re-runs unit tests). Do not force-push into an active queue entry.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,8 @@ Master uses a **merge queue**. Required checks before merge:
 3. **`CodeRabbit`** — review job finished (does **not** mean findings are cleared)
 4. **`coderabbit-threads-resolved`** — **mandatory:** every non-outdated CodeRabbit review thread is marked Resolved
 
+Flow:
+
 1. Open the PR and iterate as usual (Sonar + CodeRabbit + unit suite run on each push).
 2. Address CodeRabbit findings and mark every CodeRabbit thread **Resolved**; wait for SonarCloud, unit tests, and **`coderabbit-threads-resolved`**.
 3. Use **Merge when ready** — the PR enters the merge queue (squash), which re-runs **`testDebugUnitTest`** and re-checks threads.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,11 +18,12 @@ Master uses a **merge queue**. Required checks before merge:
 
 1. **`testDebugUnitTest`** — runs on PR pushes and again in the merge queue (put `[skip unit]` in the PR title to no-op for safe docs/chore only; check still reports green)
 2. **`SonarCloud Code Analysis`** — quality gate must pass (**0 new-code issues**)
-3. **`CodeRabbit`** — review must be green; resolve all review threads
+3. **`CodeRabbit`** — review job finished (does **not** mean findings are cleared)
+4. **`coderabbit-threads-resolved`** — **mandatory:** every non-outdated CodeRabbit review thread is marked Resolved
 
 1. Open the PR and iterate as usual (Sonar + CodeRabbit + unit suite run on each push).
-2. Resolve CodeRabbit threads; wait for SonarCloud and unit tests.
-3. Use **Merge when ready** — the PR enters the merge queue (squash), which re-runs **`testDebugUnitTest`**.
+2. Address CodeRabbit findings and mark every CodeRabbit thread **Resolved**; wait for SonarCloud, unit tests, and **`coderabbit-threads-resolved`**.
+3. Use **Merge when ready** — the PR enters the merge queue (squash), which re-runs **`testDebugUnitTest`** and re-checks threads.
 4. Optional: Actions → Run workflow (`Unit Tests`) for a manual full gate.
 
 Scheduled bots push to `master` via the **boxlore-master-pusher** GitHub App (ruleset Integration bypass).

--- a/.github/workflows/coderabbit-threads-resolved.yml
+++ b/.github/workflows/coderabbit-threads-resolved.yml
@@ -13,6 +13,10 @@
 # Scope: only threads whose first comment author login contains "coderabbit"
 # (bot or app). Human review threads are still covered by the ruleset flag
 # `required_review_thread_resolution: true`.
+#
+# Note: GitHub Actions does not support `pull_request_review_thread` as a workflow
+# event. After resolving threads without a new push, re-run this workflow
+# (Actions → CodeRabbit Threads Resolved, or workflow_dispatch with pr_number).
 
 name: CodeRabbit Threads Resolved
 
@@ -21,16 +25,14 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
     types: [submitted, dismissed]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
   check_run:
     types: [completed]
   merge_group:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "PR number to evaluate (optional; omit for merge_group / current SHA)"
-        required: false
+        description: "PR number to evaluate (required when dispatching manually)"
+        required: true
         type: string
 
 concurrency:
@@ -58,11 +60,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number || '' }}
-          PR_NUMBER_EVENT: ${{ github.event.pull_request.number || github.event.pull_request_review.pull_request.number || github.event.pull_request_review_thread.pull_request.number || '' }}
+          PR_NUMBER_EVENT: ${{ github.event.pull_request.number || '' }}
+          PR_NUMBER_REVIEW: ${{ github.event.pull_request_review.pull_request.number || '' }}
           HEAD_SHA_PR: ${{ github.event.pull_request.head.sha || '' }}
           HEAD_SHA_MG: ${{ github.event.merge_group.head_sha || '' }}
           HEAD_SHA_REVIEW: ${{ github.event.pull_request_review.pull_request.head.sha || '' }}
-          HEAD_SHA_THREAD: ${{ github.event.pull_request_review_thread.pull_request.head.sha || '' }}
           HEAD_SHA_CHECK: ${{ github.event.check_run.head_sha || '' }}
           REPO: ${{ github.repository }}
         run: |
@@ -78,11 +80,7 @@ jobs:
               ;;
             pull_request_review)
               HEAD_SHA="$HEAD_SHA_REVIEW"
-              PR_NUMBER="${PR_NUMBER_EVENT}"
-              ;;
-            pull_request_review_thread)
-              HEAD_SHA="$HEAD_SHA_THREAD"
-              PR_NUMBER="${PR_NUMBER_EVENT}"
+              PR_NUMBER="${PR_NUMBER_REVIEW}"
               ;;
             merge_group)
               HEAD_SHA="$HEAD_SHA_MG"
@@ -91,11 +89,11 @@ jobs:
               HEAD_SHA="$HEAD_SHA_CHECK"
               ;;
             workflow_dispatch)
-              if [[ -n "${PR_NUMBER}" ]]; then
-                HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
-              else
-                HEAD_SHA="${GITHUB_SHA}"
+              if [[ -z "${PR_NUMBER}" ]]; then
+                echo "::error::workflow_dispatch requires pr_number"
+                exit 1
               fi
+              HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
               ;;
             *)
               HEAD_SHA="${GITHUB_SHA}"
@@ -206,6 +204,7 @@ jobs:
               echo "$OPEN_JSON" | jq -r '.[] | "- **@\(.author)**: \(.preview)\n  \(.url)"'
               echo
               echo "Agents: fix or consciously dismiss each finding, then mark the thread **Resolved**."
+              echo "Then re-run this workflow (or push) so the check turns green."
               echo "Do not merge while this check is red."
             } > /tmp/cr-threads-summary.md
 
@@ -246,7 +245,6 @@ jobs:
             *) CONCLUSION=failure ;;
           esac
 
-          # Compact JSON body for the Checks API.
           jq -n \
             --arg name "coderabbit-threads-resolved" \
             --arg head_sha "$HEAD_SHA" \

--- a/.github/workflows/coderabbit-threads-resolved.yml
+++ b/.github/workflows/coderabbit-threads-resolved.yml
@@ -40,17 +40,16 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  checks: write
+  contents: read       # metadata / no checkout required
+  pull-requests: read  # resolve PR number / head SHA; read review threads
+  checks: write        # publish the coderabbit-threads-resolved check run
 
 jobs:
   coderabbit-threads-resolved:
     name: coderabbit-threads-resolved
     if: >
       github.event_name != 'check_run' ||
-      contains(github.event.check_run.name, 'CodeRabbit') ||
-      contains(github.event.check_run.name, 'CodeRabbit AI')
+      contains(github.event.check_run.name, 'CodeRabbit')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -60,11 +59,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number || '' }}
+          # pull_request and pull_request_review both expose PR under github.event.pull_request
           PR_NUMBER_EVENT: ${{ github.event.pull_request.number || '' }}
-          PR_NUMBER_REVIEW: ${{ github.event.pull_request_review.pull_request.number || '' }}
           HEAD_SHA_PR: ${{ github.event.pull_request.head.sha || '' }}
           HEAD_SHA_MG: ${{ github.event.merge_group.head_sha || '' }}
-          HEAD_SHA_REVIEW: ${{ github.event.pull_request_review.pull_request.head.sha || '' }}
           HEAD_SHA_CHECK: ${{ github.event.check_run.head_sha || '' }}
           REPO: ${{ github.repository }}
         run: |
@@ -74,13 +72,9 @@ jobs:
           PR_NUMBER="${PR_NUMBER_INPUT:-}"
 
           case "$EVENT_NAME" in
-            pull_request)
+            pull_request|pull_request_review)
               HEAD_SHA="$HEAD_SHA_PR"
               PR_NUMBER="${PR_NUMBER_EVENT}"
-              ;;
-            pull_request_review)
-              HEAD_SHA="$HEAD_SHA_REVIEW"
-              PR_NUMBER="${PR_NUMBER_REVIEW}"
               ;;
             merge_group)
               HEAD_SHA="$HEAD_SHA_MG"
@@ -138,11 +132,15 @@ jobs:
 
           echo "Evaluating CodeRabbit threads on PR #${PR_NUMBER} @ ${HEAD_SHA}"
 
-          # GraphQL: unresolved + non-outdated threads whose first comment is from CodeRabbit.
-          QUERY='query($owner:String!, $repo:String!, $number:Int!) {
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+
+          # Paginate reviewThreads — GitHub caps first/last at 100 per page.
+          QUERY='query($owner:String!, $repo:String!, $number:Int!, $cursor:String) {
             repository(owner:$owner, name:$repo) {
               pullRequest(number:$number) {
-                reviewThreads(first:100) {
+                reviewThreads(first:100, after:$cursor) {
+                  pageInfo { hasNextPage endCursor }
                   nodes {
                     isResolved
                     isOutdated
@@ -159,18 +157,36 @@ jobs:
             }
           }'
 
-          OWNER="${REPO%/*}"
-          NAME="${REPO#*/}"
+          ALL_NODES='[]'
+          CURSOR=""
+          while true; do
+            ARGS=(
+              -f query="$QUERY"
+              -F owner="$OWNER"
+              -F repo="$NAME"
+              -F number="$PR_NUMBER"
+            )
+            if [[ -n "$CURSOR" ]]; then
+              ARGS+=(-f cursor="$CURSOR")
+            else
+              # Explicit GraphQL null for the first page
+              ARGS+=(-F cursor=null)
+            fi
+            RESPONSE="$(gh api graphql "${ARGS[@]}")"
 
-          RESPONSE="$(gh api graphql \
-            -f query="$QUERY" \
-            -F owner="$OWNER" \
-            -F repo="$NAME" \
-            -F number="$PR_NUMBER")"
+            PAGE_NODES="$(echo "$RESPONSE" | jq -c '.data.repository.pullRequest.reviewThreads.nodes // []')"
+            ALL_NODES="$(jq -c --argjson a "$ALL_NODES" --argjson b "$PAGE_NODES" '$a + $b')"
+
+            HAS_NEXT="$(echo "$RESPONSE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')"
+            CURSOR="$(echo "$RESPONSE" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')"
+            if [[ "$HAS_NEXT" != "true" || -z "$CURSOR" ]]; then
+              break
+            fi
+          done
 
           OPEN_JSON="$(
-            echo "$RESPONSE" | jq -c '
-              [.data.repository.pullRequest.reviewThreads.nodes[]?
+            echo "$ALL_NODES" | jq -c '
+              [.[]?
                | select(.isResolved == false and .isOutdated == false)
                | select(
                    ((.comments.nodes[0].author.login // "") | ascii_downcase)

--- a/.github/workflows/coderabbit-threads-resolved.yml
+++ b/.github/workflows/coderabbit-threads-resolved.yml
@@ -1,0 +1,266 @@
+# Fail when CodeRabbit left unresolved, non-outdated PR review threads.
+#
+# Required on `master` (merge queue ruleset) as check name:
+#   coderabbit-threads-resolved
+#
+# Why this exists:
+# - The CodeRabbit App check often means "review finished", not "no open findings".
+# - Cursor / merge-when-ready can merge once required checks are green; without this
+#   gate, open CodeRabbit threads do not block merge.
+# - GitHub's `required_review_thread_resolution` helps for human review UX, but we
+#   also publish an explicit named check Cursor agents and the merge queue can require.
+#
+# Scope: only threads whose first comment author login contains "coderabbit"
+# (bot or app). Human review threads are still covered by the ruleset flag
+# `required_review_thread_resolution: true`.
+
+name: CodeRabbit Threads Resolved
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+  check_run:
+    types: [completed]
+  merge_group:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to evaluate (optional; omit for merge_group / current SHA)"
+        required: false
+        type: string
+
+concurrency:
+  group: coderabbit-threads-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
+jobs:
+  coderabbit-threads-resolved:
+    name: coderabbit-threads-resolved
+    if: >
+      github.event_name != 'check_run' ||
+      contains(github.event.check_run.name, 'CodeRabbit') ||
+      contains(github.event.check_run.name, 'CodeRabbit AI')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Resolve head SHA + PR number
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER_INPUT: ${{ github.event.inputs.pr_number || '' }}
+          PR_NUMBER_EVENT: ${{ github.event.pull_request.number || github.event.pull_request_review.pull_request.number || github.event.pull_request_review_thread.pull_request.number || '' }}
+          HEAD_SHA_PR: ${{ github.event.pull_request.head.sha || '' }}
+          HEAD_SHA_MG: ${{ github.event.merge_group.head_sha || '' }}
+          HEAD_SHA_REVIEW: ${{ github.event.pull_request_review.pull_request.head.sha || '' }}
+          HEAD_SHA_THREAD: ${{ github.event.pull_request_review_thread.pull_request.head.sha || '' }}
+          HEAD_SHA_CHECK: ${{ github.event.check_run.head_sha || '' }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          HEAD_SHA=""
+          PR_NUMBER="${PR_NUMBER_INPUT:-}"
+
+          case "$EVENT_NAME" in
+            pull_request)
+              HEAD_SHA="$HEAD_SHA_PR"
+              PR_NUMBER="${PR_NUMBER_EVENT}"
+              ;;
+            pull_request_review)
+              HEAD_SHA="$HEAD_SHA_REVIEW"
+              PR_NUMBER="${PR_NUMBER_EVENT}"
+              ;;
+            pull_request_review_thread)
+              HEAD_SHA="$HEAD_SHA_THREAD"
+              PR_NUMBER="${PR_NUMBER_EVENT}"
+              ;;
+            merge_group)
+              HEAD_SHA="$HEAD_SHA_MG"
+              ;;
+            check_run)
+              HEAD_SHA="$HEAD_SHA_CHECK"
+              ;;
+            workflow_dispatch)
+              if [[ -n "${PR_NUMBER}" ]]; then
+                HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
+              else
+                HEAD_SHA="${GITHUB_SHA}"
+              fi
+              ;;
+            *)
+              HEAD_SHA="${GITHUB_SHA}"
+              ;;
+          esac
+
+          if [[ -z "$HEAD_SHA" ]]; then
+            echo "::error::Could not resolve head SHA for event=${EVENT_NAME}"
+            exit 1
+          fi
+
+          if [[ -z "${PR_NUMBER}" ]]; then
+            PR_NUMBER="$(
+              gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+                --jq '.[0].number // empty' 2>/dev/null || true
+            )"
+          fi
+
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Resolved head_sha=${HEAD_SHA} pr_number=${PR_NUMBER:-none}"
+
+      - name: Require CodeRabbit review threads resolved
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${PR_NUMBER}" ]]; then
+            echo "::notice::No PR associated with ${HEAD_SHA}; treating as pass (docs/branch-only SHA)."
+            {
+              echo "conclusion=success"
+              echo "summary=No pull request for this SHA; nothing to gate."
+              echo "title=No PR — skipped"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Evaluating CodeRabbit threads on PR #${PR_NUMBER} @ ${HEAD_SHA}"
+
+          # GraphQL: unresolved + non-outdated threads whose first comment is from CodeRabbit.
+          QUERY='query($owner:String!, $repo:String!, $number:Int!) {
+            repository(owner:$owner, name:$repo) {
+              pullRequest(number:$number) {
+                reviewThreads(first:100) {
+                  nodes {
+                    isResolved
+                    isOutdated
+                    comments(first:1) {
+                      nodes {
+                        author { login }
+                        url
+                        body
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }'
+
+          OWNER="${REPO%/*}"
+          NAME="${REPO#*/}"
+
+          RESPONSE="$(gh api graphql \
+            -f query="$QUERY" \
+            -F owner="$OWNER" \
+            -F repo="$NAME" \
+            -F number="$PR_NUMBER")"
+
+          OPEN_JSON="$(
+            echo "$RESPONSE" | jq -c '
+              [.data.repository.pullRequest.reviewThreads.nodes[]?
+               | select(.isResolved == false and .isOutdated == false)
+               | select(
+                   ((.comments.nodes[0].author.login // "") | ascii_downcase)
+                   | contains("coderabbit")
+                 )
+               | {
+                   author: (.comments.nodes[0].author.login // "unknown"),
+                   url: (.comments.nodes[0].url // ""),
+                   preview: (
+                     (.comments.nodes[0].body // "")
+                     | gsub("\r"; "")
+                     | split("\n")
+                     | map(select(length > 0))
+                     | .[0] // ""
+                     | .[0:160]
+                   )
+                 }
+              ]
+            '
+          )"
+
+          COUNT="$(echo "$OPEN_JSON" | jq 'length')"
+          echo "open_coderabbit_threads=${COUNT}"
+
+          if [[ "$COUNT" -gt 0 ]]; then
+            {
+              echo "### Unresolved CodeRabbit review threads (${COUNT})"
+              echo
+              echo "Merge is blocked until these threads are addressed **and resolved** on GitHub."
+              echo
+              echo "$OPEN_JSON" | jq -r '.[] | "- **@\(.author)**: \(.preview)\n  \(.url)"'
+              echo
+              echo "Agents: fix or consciously dismiss each finding, then mark the thread **Resolved**."
+              echo "Do not merge while this check is red."
+            } > /tmp/cr-threads-summary.md
+
+            {
+              echo "conclusion=failure"
+              echo "title=${COUNT} unresolved CodeRabbit thread(s)"
+              echo "summary<<EOF"
+              cat /tmp/cr-threads-summary.md
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+
+            cat /tmp/cr-threads-summary.md
+            echo "::error::${COUNT} unresolved CodeRabbit review thread(s) on PR #${PR_NUMBER}"
+            exit 1
+          fi
+
+          {
+            echo "conclusion=success"
+            echo "title=All CodeRabbit threads resolved"
+            echo "summary=No unresolved, non-outdated CodeRabbit review threads on PR #${PR_NUMBER}."
+          } >> "$GITHUB_OUTPUT"
+          echo "All CodeRabbit review threads are resolved (or outdated)."
+
+      - name: Publish check run
+        if: always() && steps.meta.outputs.head_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
+          CONCLUSION: ${{ steps.gate.outputs.conclusion || 'failure' }}
+          TITLE: ${{ steps.gate.outputs.title || 'CodeRabbit threads gate failed' }}
+          SUMMARY: ${{ steps.gate.outputs.summary || 'Gate step did not complete.' }}
+        run: |
+          set -euo pipefail
+          CONCLUSION="${CONCLUSION:-failure}"
+          case "$CONCLUSION" in
+            success|failure|neutral|cancelled|skipped|timed_out|action_required) ;;
+            *) CONCLUSION=failure ;;
+          esac
+
+          # Compact JSON body for the Checks API.
+          jq -n \
+            --arg name "coderabbit-threads-resolved" \
+            --arg head_sha "$HEAD_SHA" \
+            --arg status "completed" \
+            --arg conclusion "$CONCLUSION" \
+            --arg title "$TITLE" \
+            --arg summary "$SUMMARY" \
+            '{
+              name: $name,
+              head_sha: $head_sha,
+              status: $status,
+              conclusion: $conclusion,
+              output: {
+                title: $title,
+                summary: $summary
+              }
+            }' | gh api --method POST "repos/${REPO}/check-runs" --input -

--- a/.github/workflows/merge-queue-external-gates.yml
+++ b/.github/workflows/merge-queue-external-gates.yml
@@ -115,28 +115,41 @@ jobs:
 
             // Live gate: unresolved CodeRabbit threads must be resolved before merge.
             // Publishes the named required check `coderabbit-threads-resolved`.
-            const threads = await github.graphql(`
-              query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $number) {
-                    reviewThreads(first: 100) {
-                      nodes {
-                        isResolved
-                        isOutdated
-                        comments(first: 1) {
-                          nodes { author { login } url body }
+            // Paginate — GitHub caps reviewThreads at 100 per page.
+            const threadNodes = [];
+            let cursor = null;
+            let hasNextPage = true;
+            while (hasNextPage) {
+              const threadsPage = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100, after: $cursor) {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          isResolved
+                          isOutdated
+                          comments(first: 1) {
+                            nodes { author { login } url body }
+                          }
                         }
                       }
                     }
                   }
                 }
-              }
-            `, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              number: prNumber,
-            });
-            const openCodeRabbit = (threads.repository.pullRequest.reviewThreads.nodes || [])
+              `, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: prNumber,
+                cursor,
+              });
+              const conn = threadsPage.repository.pullRequest.reviewThreads;
+              threadNodes.push(...(conn.nodes || []));
+              hasNextPage = Boolean(conn.pageInfo?.hasNextPage);
+              cursor = conn.pageInfo?.endCursor || null;
+              if (!cursor) hasNextPage = false;
+            }
+            const openCodeRabbit = threadNodes
               .filter((t) => !t.isResolved && !t.isOutdated)
               .filter((t) => {
                 const login = (t.comments?.nodes?.[0]?.author?.login || '').toLowerCase();

--- a/.github/workflows/merge-queue-external-gates.yml
+++ b/.github/workflows/merge-queue-external-gates.yml
@@ -1,10 +1,11 @@
 name: Merge queue external gates
 
-# Merge queue required checks include SonarCloud + CodeRabbit, which normally
-# report on pull_request SHAs only. On merge_group, re-assert those conclusions
-# as check runs on the queue SHA so the queue does not time out waiting.
+# Merge queue required checks include SonarCloud + CodeRabbit + coderabbit-threads-resolved,
+# which normally report on pull_request SHAs only. On merge_group, re-assert those
+# conclusions as check runs on the queue SHA so the queue does not time out waiting.
 #
 # Does not invent a pass: fails if the contributing PR head never went green.
+# For coderabbit-threads-resolved, re-evaluates live CodeRabbit threads (not a stale bridge).
 on:
   merge_group:
 
@@ -112,13 +113,20 @@ jobs:
               });
             }
 
-            // Also require review threads resolved (CodeRabbit included).
+            // Live gate: unresolved CodeRabbit threads must be resolved before merge.
+            // Publishes the named required check `coderabbit-threads-resolved`.
             const threads = await github.graphql(`
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
                     reviewThreads(first: 100) {
-                      nodes { isResolved isOutdated }
+                      nodes {
+                        isResolved
+                        isOutdated
+                        comments(first: 1) {
+                          nodes { author { login } url body }
+                        }
+                      }
                     }
                   }
                 }
@@ -128,11 +136,46 @@ jobs:
               repo: context.repo.repo,
               number: prNumber,
             });
-            const openThreads = (threads.repository.pullRequest.reviewThreads.nodes || [])
-              .filter((t) => !t.isResolved && !t.isOutdated);
-            if (openThreads.length > 0) {
+            const openCodeRabbit = (threads.repository.pullRequest.reviewThreads.nodes || [])
+              .filter((t) => !t.isResolved && !t.isOutdated)
+              .filter((t) => {
+                const login = (t.comments?.nodes?.[0]?.author?.login || '').toLowerCase();
+                return login.includes('coderabbit');
+              });
+
+            const threadsOk = openCodeRabbit.length === 0;
+            const threadSummary = threadsOk
+              ? `No unresolved, non-outdated CodeRabbit review threads on PR #${prNumber}.`
+              : [
+                  `### Unresolved CodeRabbit review threads (${openCodeRabbit.length})`,
+                  '',
+                  ...openCodeRabbit.map((t) => {
+                    const c = t.comments?.nodes?.[0] || {};
+                    const preview = (c.body || '').split('\n').find((l) => l.trim()) || '';
+                    return `- **@${c.author?.login || 'coderabbit'}**: ${preview.slice(0, 160)}\n  ${c.url || ''}`;
+                  }),
+                  '',
+                  'Merge is blocked until these threads are addressed and marked Resolved.',
+                ].join('\n');
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'coderabbit-threads-resolved',
+              head_sha: headSha,
+              status: 'completed',
+              conclusion: threadsOk ? 'success' : 'failure',
+              output: {
+                title: threadsOk
+                  ? 'All CodeRabbit threads resolved'
+                  : `${openCodeRabbit.length} unresolved CodeRabbit thread(s)`,
+                summary: threadSummary,
+              },
+            });
+
+            if (!threadsOk) {
               failures.push(
-                `PR #${prNumber} has ${openThreads.length} unresolved review thread(s)`
+                `PR #${prNumber} has ${openCodeRabbit.length} unresolved CodeRabbit review thread(s)`
               );
             }
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Short entrypoint for Cursor / Codex / cloud agents. Prefer this over long essays
 - Commit / push / open a PR **only when the user asks**. Conventional Commits titles.
 - Every PR needs **exactly one** user-impact label (`user-impact-high|medium|low` or `no-user-impact`); optional `backend-change`. Changelog / README upcoming workflows depend on these — see [`.cursor/rules/pr-impact-labels.mdc`](.cursor/rules/pr-impact-labels.mdc).
 - Merge via **Merge when ready** (merge queue). Unit suite runs on every PR push (cancels prior in-progress runs) and again in the queue; use `[skip unit]` / `[skip changelog]` only when appropriate. No `merge-ci`.
-- SonarCloud: **0 new-code issues** (quality gate must fail if any new issue). Resolve all CodeRabbit review threads before merge.
+- SonarCloud: **0 new-code issues** (quality gate must fail if any new issue). Required check **`coderabbit-threads-resolved`** must be green — address CodeRabbit findings and mark every CodeRabbit review thread **Resolved** before merge (the bare `CodeRabbit` check only means the review job finished).
 - Never commit secrets (`local.properties`, `.env`, keystores, `google-services.json`).
 - Do **not** hand-edit `CHANGELOG.md` or README Upcoming — `changelog-on-merge` owns that.
 - **boxlore-only:** do not change other `boxcreate` repos or org-wide bot settings unless asked. Keep proxy/backend internals out of public Android PR text.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -168,10 +168,11 @@ See [`docs/screenshots/README.md`](screenshots/README.md).
 | Workflow | Runs | When | Status |
 | :--- | :--- | :--- | :--- |
 | `unit-tests.yml` | Architecture + detekt + ktlint + unit + Roborazzi + Kover + lint + Dependency Guard | PR / merge queue / dispatch | Done |
-| `merge-queue-external-gates.yml` | Re-assert SonarCloud + CodeRabbit on merge group SHA | merge queue | Done |
+| `merge-queue-external-gates.yml` | Re-assert SonarCloud + CodeRabbit + live `coderabbit-threads-resolved` on merge group SHA | merge queue | Done |
+| `coderabbit-threads-resolved.yml` | Fail unless all non-outdated CodeRabbit review threads are Resolved | PR / thread events / merge queue | Done |
 | `maestro-nightly.yml` | Validate Maestro YAML | Nightly / manual | Done |
 
-**Merge gate:** master uses a merge queue. Required checks: **`testDebugUnitTest`**, **`SonarCloud Code Analysis`**, **`CodeRabbit`** (resolve all review threads). The unit suite runs on every PR push (new commits cancel prior in-progress runs) and again in the merge queue (or via Actions → Run workflow). Put `[skip unit]` in the PR title to no-op that job for docs/chore-only changes (still reports green; `workflow_dispatch` always runs full). Bots push to master via **boxlore-master-pusher** (ruleset Integration bypass).
+**Merge gate:** master uses a merge queue. Required checks: **`testDebugUnitTest`**, **`SonarCloud Code Analysis`**, **`CodeRabbit`**, and **`coderabbit-threads-resolved`** (CodeRabbit findings addressed and every non-outdated CodeRabbit thread marked Resolved — the bare `CodeRabbit` check only means the review job finished). The unit suite runs on every PR push (new commits cancel prior in-progress runs) and again in the merge queue (or via Actions → Run workflow). Put `[skip unit]` in the PR title to no-op that job for docs/chore-only changes (still reports green; `workflow_dispatch` always runs full). Bots push to master via **boxlore-master-pusher** (ruleset Integration bypass).
 
 Protected inputs: `app/google-services.json` is gitignored; CI writes a non-secret stub.
 

--- a/scripts/ci/configure-master-merge-queue.sh
+++ b/scripts/ci/configure-master-merge-queue.sh
@@ -2,9 +2,10 @@
 # Enable master merge queue + required checks, with bot-safe bypass.
 #
 # Required checks (must be green before merge / in the queue):
-#   1. testDebugUnitTest          — unit job (merge_group or workflow_dispatch)
-#   2. SonarCloud Code Analysis  — SonarCloud GitHub App (bridged on merge_group)
-#   3. CodeRabbit                — CodeRabbit status (bridged on merge_group)
+#   1. testDebugUnitTest               — unit job (merge_group or workflow_dispatch)
+#   2. SonarCloud Code Analysis       — SonarCloud GitHub App (bridged on merge_group)
+#   3. CodeRabbit                     — CodeRabbit status (bridged on merge_group)
+#   4. coderabbit-threads-resolved    — unresolved CodeRabbit threads must be Resolved
 #
 # Bypass (always): boxlore-master-pusher Integration (app 4340323) + Organization admins.
 # Scheduled bots (episode tracker, sync-pi-data, changelog-on-merge, …) mint an
@@ -119,7 +120,8 @@ build_ruleset_body() {
             required_status_checks: [
               { context: "testDebugUnitTest" },
               { context: "SonarCloud Code Analysis" },
-              { context: "CodeRabbit" }
+              { context: "CodeRabbit" },
+              { context: "coderabbit-threads-resolved" }
             ]
           }
         },
@@ -204,7 +206,7 @@ FINAL_ID="$(
 echo
 echo "Master merge queue is active (ruleset id=${FINAL_ID})."
 echo "  Rules: https://github.com/${OWNER}/${REPO}/settings/rules"
-echo "  Required checks: testDebugUnitTest | SonarCloud Code Analysis | CodeRabbit"
+echo "  Required checks: testDebugUnitTest | SonarCloud Code Analysis | CodeRabbit | coderabbit-threads-resolved"
 if [[ "${PUSHER_BYPASS_OK}" == "true" ]]; then
   echo "  Bypass: boxlore-master-pusher (app ${PUSHER_APP_ID}) + Organization admins"
 else
@@ -215,10 +217,10 @@ else
   echo "  and BOXLORE_PUSHER_APP_ID / BOXLORE_PUSHER_PRIVATE_KEY are set as repo secrets." >&2
 fi
 echo
-echo "Human PR flow:"
-echo "  1. Open / iterate PR (Sonar + CodeRabbit run; unit suite waits for merge queue)"
-echo "  2. Resolve all review threads (CodeRabbit included)"
-echo "  3. Merge when ready → enters merge queue (runs unit + bridges Sonar/CodeRabbit)"
+echo "Human / Cursor PR flow:"
+echo "  1. Open / iterate PR (Sonar + CodeRabbit + coderabbit-threads-resolved; unit suite on PR + queue)"
+echo "  2. Address CodeRabbit findings and mark every CodeRabbit thread Resolved"
+echo "  3. Merge when ready → enters merge queue (runs unit + bridges Sonar/CodeRabbit/threads)"
 echo "  4. Optional: Actions → Run workflow (unit-tests) for a manual gate"
 echo
 if [[ "${PUSHER_BYPASS_OK}" == "true" ]]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes unresolved CodeRabbit review threads a **hard merge blocker** via a named required check (`coderabbit-threads-resolved`), so Cursor / merge-when-ready cannot merge while relevant CodeRabbit comments are still open.

The bare `CodeRabbit` check only means the review job finished — it does not mean findings are cleared. This PR closes that gap.

## What changed

- New workflow `.github/workflows/coderabbit-threads-resolved.yml` — fails (and publishes check run `coderabbit-threads-resolved`) when any **unresolved, non-outdated** review thread’s first comment author is CodeRabbit
- Triggers on PR open/sync, reviews, CodeRabbit `check_run` completion, merge queue, and manual `workflow_dispatch` (re-run after resolving threads without a push)
- Merge-queue bridge re-evaluates live CodeRabbit threads and publishes the same named check on the queue SHA
- `scripts/ci/configure-master-merge-queue.sh` adds `coderabbit-threads-resolved` to the master ruleset required checks
- Agent / PR / testing docs updated so Cursor agents treat thread resolution as mandatory

## Admin follow-up (required for enforcement)

This cloud agent token lacks repo **admin**, so the live ruleset was **not** updated yet. After this PR’s workflow has run at least once (so GitHub knows the check name), an org admin should run:

```bash
./scripts/ci/configure-master-merge-queue.sh
```

That adds `coderabbit-threads-resolved` alongside `testDebugUnitTest`, `SonarCloud Code Analysis`, and `CodeRabbit` on ruleset `master-merge-queue` (id `19175179`).

Until then: the check still runs and fails visibly on PRs with open CodeRabbit threads; GitHub’s existing `required_review_thread_resolution: true` continues to apply.

## Behavior & compatibility

- No app / listener behavior change
- Outdated threads are ignored; only CodeRabbit-authored threads are gated by the named check (human threads remain covered by the ruleset flag)

## Test plan

- [ ] Open this PR → `coderabbit-threads-resolved` appears and is green (no open CR threads)
- [ ] On a PR with an open CodeRabbit thread → check goes red and lists the threads
- [ ] Resolve the thread → re-run **CodeRabbit Threads Resolved** (or push) → check turns green
- [ ] After admin runs configure script → merge queue requires the new check

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1e55e04-4317-4a62-9050-07b5d403d56a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1e55e04-4317-4a62-9050-07b5d403d56a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

