### PR TITLE
fix(prefs): keep learner signal log off in release unless opted in

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -7,6 +7,7 @@ The application module owns the Android app shell: `BoxLoreApplication`, `MainAc
 ## Public API
 
 - `BoxLoreApplication.container` exposes the process-scoped `AppContainer`.
+- On startup, `BoxLoreApplication` configures `LearningEventLog` via `BoxcastPrefs.resolveLearnerLogEnabled`: on by default in debug when unset; **always off in release** unless the user has explicitly persisted an opt-in from the debug screen.
 - `AppContainer` constructs the shared graph: database, network, RSS, ranking, catalog, playback, queue, downloads, prefs, and analytics dependencies.
 - `SharedAppDependenciesHolder` and `DownloadsDependenciesHolder` are installed from the application so workers and Media3 services reuse the same graph.
 - `DownloadServiceLauncherHolder` is installed with `MediaDownloadService::class.java` so `:core:downloads` can launch the foreground download service without depending on `:core:playback`.

--- a/app/src/main/java/cx/aswin/boxlore/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxlore/BoxLoreApplication.kt
@@ -63,11 +63,11 @@ class BoxLoreApplication : Application(), Configuration.Provider {
         // a second RankingFeedbackRepository client diverging from the container.
         container.rankingFeedbackRepository
 
-        // Live learner signal log: on by default in debug builds, off for release users
-        // unless they explicitly opt in via the debug screen toggle. A persisted choice wins.
+        // Live learner signal log: on by default in debug; release stays off unless the
+        // user explicitly opts in via the debug-screen toggle (persisted true).
         LearningEventLog.configure(
             cx.aswin.boxlore.core.prefs.BoxcastPrefs(this)
-                .isLearnerLogEnabled(default = BuildConfig.DEBUG),
+                .resolveLearnerLogEnabled(isDebugBuild = BuildConfig.DEBUG),
         )
 
         val config = PostHogAndroidConfig(

--- a/core/prefs/README.md
+++ b/core/prefs/README.md
@@ -9,6 +9,7 @@ Owns user preference persistence and migration helpers: DataStore-backed user pr
 - `UserPreferencesRepository` exposes DataStore-backed settings such as theme, region, skip durations, smart downloads, and playback preferences.
 - `Context.userPreferencesDataStore` defines the `user_preferences` DataStore delegate.
 - `BoxcastPrefs` is the typed facade for `boxlore_prefs` values such as onboarding, genres, recommendation caches, Learn history, and learner-log gates.
+- `resolveLearnerLogEnabled(isDebugBuild)`: debug defaults on when unset; **release is always off** unless the user explicitly persisted `true` via the debug-screen toggle.
 - `UserPreferenceKeys` centralizes DataStore preference keys.
 - `PrefsFileMigrator` opens canonical SharedPreferences files and migrates from legacy file names.
 - `PlaybackSkipBounds` and `EngagementPromptConstants` provide shared preference-related bounds and thresholds.

--- a/core/prefs/src/main/java/cx/aswin/boxlore/core/prefs/BoxcastPrefs.kt
+++ b/core/prefs/src/main/java/cx/aswin/boxlore/core/prefs/BoxcastPrefs.kt
@@ -115,6 +115,21 @@ class BoxcastPrefs(context: Context) {
         prefs.edit().putBoolean(KEY_LEARNER_LOG_ENABLED, enabled).apply()
     }
 
+    /**
+     * Startup gate for [cx.aswin.boxlore.core.ranking.LearningEventLog].
+     *
+     * - Debug: on when the pref is unset; a persisted toggle always wins.
+     * - Release: **always off** unless the user has explicitly persisted `true`
+     *   (debug-screen toggle via [setLearnerLogEnabled]). Never defaults on.
+     */
+    fun resolveLearnerLogEnabled(isDebugBuild: Boolean): Boolean {
+        if (!isDebugBuild) {
+            return prefs.contains(KEY_LEARNER_LOG_ENABLED) &&
+                prefs.getBoolean(KEY_LEARNER_LOG_ENABLED, false)
+        }
+        return isLearnerLogEnabled(default = true)
+    }
+
     companion object {
         /** Canonical SharedPreferences file name (migrated from `boxcast_prefs`). */
         const val PREFS_NAME = PrefsFileMigrator.Files.PREFS

--- a/core/prefs/src/test/java/cx/aswin/boxlore/core/prefs/BoxcastPrefsTest.kt
+++ b/core/prefs/src/test/java/cx/aswin/boxlore/core/prefs/BoxcastPrefsTest.kt
@@ -76,4 +76,20 @@ class BoxcastPrefsTest {
         prefs.setLearnerLogEnabled(true)
         assertTrue(prefs.isLearnerLogEnabled(default = false))
     }
+
+    @Test
+    fun resolveLearnerLogEnabled_releaseOffUnlessExplicitOptIn() {
+        assertFalse(prefs.resolveLearnerLogEnabled(isDebugBuild = false))
+        prefs.setLearnerLogEnabled(true)
+        assertTrue(prefs.resolveLearnerLogEnabled(isDebugBuild = false))
+        prefs.setLearnerLogEnabled(false)
+        assertFalse(prefs.resolveLearnerLogEnabled(isDebugBuild = false))
+    }
+
+    @Test
+    fun resolveLearnerLogEnabled_debugDefaultsOnWhenUnset() {
+        assertTrue(prefs.resolveLearnerLogEnabled(isDebugBuild = true))
+        prefs.setLearnerLogEnabled(false)
+        assertFalse(prefs.resolveLearnerLogEnabled(isDebugBuild = true))
+    }
 }

--- a/core/ranking/README.md
+++ b/core/ranking/README.md
@@ -47,7 +47,7 @@ src/main/java/cx/aswin/boxlore/core/ranking/
 - Production ranking instances are application-scoped and installed from `AppContainer`.
 - Room and model updates use background dispatchers through suspend APIs.
 - Scorers may be called from UI, service, or worker paths; keep scoring APIs suspend where they touch persisted state.
-- `LearningEventLog` is process/session state and is not a durable event log.
+- `LearningEventLog` is process/session state and is not a durable event log. Capture is gated at app start via `BoxcastPrefs.resolveLearnerLogEnabled`: on by default in debug; **always off in release** unless the user explicitly opts in on the debug screen.
 
 ## Persistence & identity
 


### PR DESCRIPTION
## Summary
- Make `LearningEventLog` startup gating explicit via `BoxcastPrefs.resolveLearnerLogEnabled`: debug defaults on when unset; **release stays off** unless the user has persisted an explicit opt-in from the debug screen.
- Add unit coverage for release/debug resolution paths and document the gate in prefs/ranking READMEs.

## Test plan
- [x] `:core:prefs:testDebugUnitTest` — `BoxcastPrefsTest` release/debug resolve cases
- [x] `./gradlew installDebug` on connected device
- [ ] Confirm release build starts with log off when pref key is unset
- [ ] Confirm debug-screen toggle persists and enables capture in release