### PR TITLE
fix(playback): revamp Android Auto artwork loading and collage freshness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -217,6 +217,7 @@ Historical FQCNs and preference file names remain reachable so upgrades from old
 | `boxcast_theme_fast_cache` | `boxlore_theme_fast_cache` | `UserPreferencesRepository` |
 | `boxcast_analytics_prefs` | `boxlore_analytics_prefs` | `AnalyticsHelper` |
 | `boxcast_player` | `boxlore_player` | `PlaybackRepository` / `PodcastRepository` |
+| — | `android_auto_artwork_sources` | `AutoArtworkSourceStore` / `AutoCollageProvider` (Android Auto art URI map; do not rename) |
 | `boxcast_api_config` | `boxlore_api_config` | `BoxLoreAppRoot` |
 | `boxcast_referrer_prefs` | `boxlore_referrer_prefs` | `InstallReferrerManager` |
 

--- a/core/playback/README.md
+++ b/core/playback/README.md
@@ -16,11 +16,12 @@ Owns playback session control, queue orchestration, smart queue logic, Media3 pl
 - `PlaybackControlSync` keeps UI playback speed / seek sizes aligned with Media3 when a session is cleared or a new queue starts, and sanitizes user-requested speeds before apply/persist.
 - `HistoryRecommendationLogic`, `AutoVoiceSearchLogic`, `SmartQueueRefillPolicy`, `MixtapeResumePolicy`, `NightWindowLogic`, and `ListeningHistoryUpsertLogic` are JVM-testable playback helpers.
 - `AutoArtworkFetchLogic` and `AutoCollageFreshnessLogic` encode Android Auto artwork fetch / collage cache policy for hermetic tests.
+- `AutoCollagePrewarmPolicy` and `AutoCollageFolderLogic` encode prewarm throttle and aligned image/key folder inputs for hermetic tests.
 - `PlaybackIntroOutroController` manages intro-skip and outro-trim playback lifecycle.
 - `service.BoxLorePlaybackService`, `service.MediaDownloadService`, and `service.AutoCollageProvider` are manifest-facing services.
 - `service.SmartQueueRefillCoordinator`, `service.CoilBitmapLoader`, and `service.auto.*` support service internals and Android Auto.
 - Android Auto browse artwork:
-  - `AutoArtworkRepository` + `AutoArtworkSourceStore` register remote/local sources into an in-memory map and durable `android_auto_artwork_sources` prefs (`commit`, not async `apply`) before returning `content://…/art|local|collage/…` URIs.
+  - `AutoArtworkRepository` + `AutoArtworkSourceStore` register remote/local sources into an in-memory map immediately and `commit` prefs on a background thread before/while returning `content://…/art|local|collage/…` URIs.
   - `AutoCollageProvider` lazily fetches remote covers with validated HTTPS redirects, lenient image content-types, magic-byte checks, and one retry; folder collage URIs include a `v=` cache-buster so Auto hosts reload when resume/history content changes.
   - `AutoCollagePrewarmer` / `AutoCollageGenerator` / `AutoCollageLayouts` rebuild section collages from content keys (resume episode IDs, queue IDs, subscriptions, …), use a shorter TTL for partial/fallback tiles, and refresh on mark-complete / queue changes via `AutoBrowseLibraryHost.requestAutoCollageRefresh`.
   - `AutoArtworkDownloader` is the shared HTTPS fetch path (validated redirects + public-host checks) used by both collage generation and the ContentProvider.

--- a/core/playback/README.md
+++ b/core/playback/README.md
@@ -22,7 +22,8 @@ Owns playback session control, queue orchestration, smart queue logic, Media3 pl
 - Android Auto browse artwork:
   - `AutoArtworkRepository` + `AutoArtworkSourceStore` register remote/local sources into an in-memory map and durable `android_auto_artwork_sources` prefs (`commit`, not async `apply`) before returning `content://…/art|local|collage/…` URIs.
   - `AutoCollageProvider` lazily fetches remote covers with validated HTTPS redirects, lenient image content-types, magic-byte checks, and one retry; folder collage URIs include a `v=` cache-buster so Auto hosts reload when resume/history content changes.
-  - `AutoCollagePrewarmer` / `AutoCollageGenerator` rebuild section collages from content keys (resume episode IDs, queue IDs, subscriptions, …), use a shorter TTL for partial/fallback tiles, and refresh on mark-complete / queue changes via `AutoBrowseLibraryHost.requestAutoCollageRefresh`.
+  - `AutoCollagePrewarmer` / `AutoCollageGenerator` / `AutoCollageLayouts` rebuild section collages from content keys (resume episode IDs, queue IDs, subscriptions, …), use a shorter TTL for partial/fallback tiles, and refresh on mark-complete / queue changes via `AutoBrowseLibraryHost.requestAutoCollageRefresh`.
+  - `AutoArtworkDownloader` is the shared HTTPS fetch path (validated redirects + public-host checks) used by both collage generation and the ContentProvider.
 
 ## Internal structure
 

--- a/core/playback/README.md
+++ b/core/playback/README.md
@@ -15,9 +15,14 @@ Owns playback session control, queue orchestration, smart queue logic, Media3 pl
 - `PlaybackMediaIdPolicy`, `PlaybackArtworkResolver`, and `PlaybackSkipPolicy` define session IDs, artwork, and skip behavior.
 - `PlaybackControlSync` keeps UI playback speed / seek sizes aligned with Media3 when a session is cleared or a new queue starts, and sanitizes user-requested speeds before apply/persist.
 - `HistoryRecommendationLogic`, `AutoVoiceSearchLogic`, `SmartQueueRefillPolicy`, `MixtapeResumePolicy`, `NightWindowLogic`, and `ListeningHistoryUpsertLogic` are JVM-testable playback helpers.
+- `AutoArtworkFetchLogic` and `AutoCollageFreshnessLogic` encode Android Auto artwork fetch / collage cache policy for hermetic tests.
 - `PlaybackIntroOutroController` manages intro-skip and outro-trim playback lifecycle.
 - `service.BoxLorePlaybackService`, `service.MediaDownloadService`, and `service.AutoCollageProvider` are manifest-facing services.
 - `service.SmartQueueRefillCoordinator`, `service.CoilBitmapLoader`, and `service.auto.*` support service internals and Android Auto.
+- Android Auto browse artwork:
+  - `AutoArtworkRepository` + `AutoArtworkSourceStore` register remote/local sources into an in-memory map and durable `android_auto_artwork_sources` prefs (`commit`, not async `apply`) before returning `content://…/art|local|collage/…` URIs.
+  - `AutoCollageProvider` lazily fetches remote covers with validated HTTPS redirects, lenient image content-types, magic-byte checks, and one retry; folder collage URIs include a `v=` cache-buster so Auto hosts reload when resume/history content changes.
+  - `AutoCollagePrewarmer` / `AutoCollageGenerator` rebuild section collages from content keys (resume episode IDs, queue IDs, subscriptions, …), use a shorter TTL for partial/fallback tiles, and refresh on mark-complete / queue changes via `AutoBrowseLibraryHost.requestAutoCollageRefresh`.
 
 ## Internal structure
 
@@ -73,13 +78,14 @@ Files under `core/data/service` are compatibility stubs for old service class na
 - Manifest-facing service class names are system identities.
 - Media ID prefixes such as `episode:`, `queue:`, and `learn:` are session and Android Auto contracts.
 - SharedPreferences file `boxcast_player` stores playback session flags.
+- SharedPreferences file `android_auto_artwork_sources` maps Android Auto artwork content keys to remote HTTPS URLs or sandboxed local paths (identity for Auto collage ContentProvider; do not rename lightly).
 - Preference key `device_uuid` is a stable install identifier and must not be logged raw.
 - Queue, history, and download rows are persisted by `:core:database` and `:core:downloads`.
 
 ## Testing notes
 
 - Unit tests live under `core/playback/src/test`.
-- Existing coverage includes skip policy, media ID policy, artwork resolution, control sync (speed/seek preserve on clear), history recommendation filtering, voice search, smart-queue refill policy, mixtape resume policy, night-window logic, listening-history upsert logic, queue math, skip memory, smart queue, and playback session mapping.
+- Existing coverage includes skip policy, media ID policy, artwork resolution, control sync (speed/seek preserve on clear), history recommendation filtering, voice search, smart-queue refill policy, mixtape resume policy, night-window logic, listening-history upsert logic, queue math, skip memory, smart queue, playback session mapping, Auto artwork fetch/content-type policy, collage freshness signatures, and Auto artwork source-store durability.
 - Service-level tests must install shared dependency holders before exercising service code.
 
 ```bash

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/AutoArtworkFetchLogic.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/AutoArtworkFetchLogic.kt
@@ -1,0 +1,84 @@
+package cx.aswin.boxlore.core.playback
+
+/**
+ * Pure helpers for Android Auto remote artwork fetch validation.
+ * Keeps ContentProvider networking policy hermetically testable.
+ */
+object AutoArtworkFetchLogic {
+    const val MAX_ARTWORK_BYTES = 8L * 1024L * 1024L
+    const val MAX_REDIRECTS = 5
+    const val CONNECT_TIMEOUT_MS = 8_000
+    const val READ_TIMEOUT_MS = 12_000
+
+    private val JPEG = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
+    private val PNG =
+        byteArrayOf(
+            0x89.toByte(),
+            0x50,
+            0x4E,
+            0x47,
+            0x0D,
+            0x0A,
+            0x1A,
+            0x0A,
+        )
+    private val GIF87A = "GIF87a".toByteArray(Charsets.US_ASCII)
+    private val GIF89A = "GIF89a".toByteArray(Charsets.US_ASCII)
+    private val RIFF = "RIFF".toByteArray(Charsets.US_ASCII)
+    private val WEBP = "WEBP".toByteArray(Charsets.US_ASCII)
+
+    fun isAcceptableImageContentType(contentType: String?): Boolean {
+        val normalized =
+            contentType
+                .orEmpty()
+                .substringBefore(';')
+                .trim()
+                .lowercase()
+        if (normalized.isEmpty()) return true
+        if (normalized.startsWith("image/")) return true
+        // Many podcast CDNs omit a precise image type.
+        return normalized == "application/octet-stream" ||
+            normalized == "binary/octet-stream" ||
+            normalized == "application/binary"
+    }
+
+    fun looksLikeImage(header: ByteArray): Boolean {
+        if (header.size < 3) return false
+        if (startsWith(header, JPEG)) return true
+        if (header.size >= 8 && startsWith(header, PNG)) return true
+        if (header.size >= 6 && (startsWith(header, GIF87A) || startsWith(header, GIF89A))) {
+            return true
+        }
+        return header.size >= 12 &&
+            startsWith(header, RIFF) &&
+            header.copyOfRange(8, 12).contentEquals(WEBP)
+    }
+
+    fun shouldAcceptArtwork(
+        responseCode: Int,
+        contentType: String?,
+        contentLength: Long,
+        headerBytes: ByteArray? = null,
+    ): Boolean {
+        if (responseCode !in 200..299) return false
+        if (contentLength > MAX_ARTWORK_BYTES) return false
+        if (!isAcceptableImageContentType(contentType)) return false
+        if (headerBytes != null && headerBytes.isNotEmpty() && !looksLikeImage(headerBytes)) {
+            return false
+        }
+        return true
+    }
+
+    fun isRedirect(responseCode: Int): Boolean = responseCode in setOf(301, 302, 303, 307, 308)
+
+    private fun startsWith(
+        bytes: ByteArray,
+        prefix: ByteArray,
+    ): Boolean {
+        if (bytes.size < prefix.size) return false
+        for (i in prefix.indices) {
+            if (bytes[i] != prefix[i]) return false
+        }
+        return true
+    }
+}

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/AutoCollageFolderLogic.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/AutoCollageFolderLogic.kt
@@ -1,0 +1,30 @@
+package cx.aswin.boxlore.core.playback
+
+/**
+ * Builds aligned collage image URL + content-key lists for Android Auto folder tiles.
+ * Keys and images always come from the same filtered entries so signatures match pixels.
+ */
+object AutoCollageFolderLogic {
+    data class ArtPair(
+        val contentKey: String,
+        val imageUrl: String,
+    )
+
+    fun takeAligned(
+        pairs: List<ArtPair>,
+        limit: Int = 4,
+    ): List<ArtPair> = pairs.filter { it.contentKey.isNotBlank() && it.imageUrl.isNotBlank() }.take(limit)
+
+    fun imagesOf(pairs: List<ArtPair>): List<String> = pairs.map { it.imageUrl }
+
+    fun keysOf(pairs: List<ArtPair>): List<String> = pairs.map { it.contentKey }
+
+    fun pairOrNull(
+        contentKey: String?,
+        imageUrl: String?,
+    ): ArtPair? {
+        val key = contentKey?.takeIf { it.isNotBlank() } ?: return null
+        val image = imageUrl?.takeIf { it.isNotBlank() } ?: return null
+        return ArtPair(contentKey = key, imageUrl = image)
+    }
+}

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/AutoCollageFreshnessLogic.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/AutoCollageFreshnessLogic.kt
@@ -1,0 +1,55 @@
+package cx.aswin.boxlore.core.playback
+
+/**
+ * Pure collage cache-key / freshness policy for Android Auto folder tiles.
+ */
+object AutoCollageFreshnessLogic {
+    const val SIGNATURE_VERSION = "collage-v4"
+
+    /** Full collages with real tiles stay fresh this long unless content keys change. */
+    const val FULL_TTL_MS = 2L * 60L * 60L * 1_000L
+
+    /** Partial / fallback collages expire sooner so the next prewarm can recover art. */
+    const val PARTIAL_TTL_MS = 20L * 60L * 1_000L
+
+    fun buildSignature(
+        contentKeysOrUrls: List<String>,
+        loadedImageCount: Int,
+        expectedImageCount: Int,
+    ): String {
+        val values =
+            contentKeysOrUrls
+                .take(4)
+                .filter(String::isNotBlank)
+                .joinToString("\n")
+        return buildString {
+            append(SIGNATURE_VERSION)
+            append('\n')
+            append(values)
+            append("\nloaded=")
+            append(loadedImageCount.coerceAtLeast(0))
+            append("\nexpected=")
+            append(expectedImageCount.coerceAtLeast(0))
+        }.hashCode().toString()
+    }
+
+    fun isFresh(
+        ageMs: Long,
+        storedSignature: String?,
+        currentSignature: String,
+        loadedImageCount: Int,
+        expectedImageCount: Int,
+    ): Boolean {
+        if (storedSignature.isNullOrBlank() || storedSignature != currentSignature) return false
+        if (ageMs < 0L) return false
+        val ttl =
+            if (expectedImageCount > 0 && loadedImageCount < expectedImageCount) {
+                PARTIAL_TTL_MS
+            } else if (loadedImageCount <= 0 && expectedImageCount > 0) {
+                PARTIAL_TTL_MS
+            } else {
+                FULL_TTL_MS
+            }
+        return ageMs < ttl
+    }
+}

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/AutoCollagePrewarmPolicy.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/AutoCollagePrewarmPolicy.kt
@@ -1,0 +1,12 @@
+package cx.aswin.boxlore.core.playback
+
+/** Throttle policy for Android Auto collage prewarm / refresh. */
+object AutoCollagePrewarmPolicy {
+    const val MIN_REFRESH_INTERVAL_MS = 30_000L
+
+    fun shouldRun(
+        force: Boolean,
+        lastPrewarmAtMs: Long,
+        nowMs: Long,
+    ): Boolean = force || nowMs - lastPrewarmAtMs >= MIN_REFRESH_INTERVAL_MS
+}

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloader.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloader.kt
@@ -1,0 +1,132 @@
+package cx.aswin.boxlore.core.playback.service
+
+import android.util.Log
+import cx.aswin.boxlore.core.playback.AutoArtworkFetchLogic
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.InetAddress
+import java.net.URI
+import java.net.URL
+
+/**
+ * Shared HTTPS artwork downloader for Android Auto collage generation and
+ * [AutoCollageProvider] lazy cover fetches. Validates public hosts on every hop.
+ */
+internal object AutoArtworkDownloader {
+    private const val TAG = "AutoArtworkDl"
+
+    fun parseHttpsUrl(raw: String): URL? {
+        val normalized = raw.replaceFirst("http://", "https://")
+        return runCatching { URI(normalized).toURL() }.getOrNull()
+    }
+
+    fun downloadHttpsBytes(startUrl: URL): ByteArray? {
+        var current = startUrl
+        var redirects = 0
+        while (redirects <= AutoArtworkFetchLogic.MAX_REDIRECTS) {
+            when (val outcome = fetchOnce(current)) {
+                null -> return null
+                is FetchOutcome.Redirect -> {
+                    current = outcome.url
+                    redirects += 1
+                }
+                is FetchOutcome.Body -> return outcome.bytes
+            }
+        }
+        return null
+    }
+
+    fun isPublicHttpsUrl(url: URL): Boolean {
+        if (url.protocol != "https" || (url.port != -1 && url.port != 443)) return false
+        val addresses =
+            runCatching { InetAddress.getAllByName(url.host) }.getOrNull()
+                ?: return false
+        return addresses.isNotEmpty() &&
+            addresses.all { address ->
+                !address.isAnyLocalAddress &&
+                    !address.isLoopbackAddress &&
+                    !address.isLinkLocalAddress &&
+                    !address.isSiteLocalAddress &&
+                    !address.isMulticastAddress &&
+                    !address.isUniqueLocalIpv6()
+            }
+    }
+
+    private fun fetchOnce(url: URL): FetchOutcome? {
+        if (!isPublicHttpsUrl(url)) return null
+        var connection: HttpURLConnection? = null
+        return try {
+            connection = openGet(url)
+            val code = connection.responseCode
+            if (AutoArtworkFetchLogic.isRedirect(code)) {
+                val location = connection.getHeaderField("Location") ?: return null
+                val next = resolveRedirect(url, location) ?: return null
+                FetchOutcome.Redirect(next)
+            } else if (
+                !AutoArtworkFetchLogic.shouldAcceptArtwork(
+                    code,
+                    connection.contentType,
+                    connection.contentLengthLong,
+                )
+            ) {
+                null
+            } else {
+                connection.inputStream.use { input ->
+                    readBounded(input)?.let(FetchOutcome::Body)
+                }
+            }
+        } catch (error: Exception) {
+            Log.w(TAG, "Artwork download failed for $url", error)
+            null
+        } finally {
+            connection?.disconnect()
+        }
+    }
+
+    private fun openGet(url: URL): HttpURLConnection {
+        val connection = url.openConnection() as HttpURLConnection
+        connection.instanceFollowRedirects = false
+        connection.connectTimeout = AutoArtworkFetchLogic.CONNECT_TIMEOUT_MS
+        connection.readTimeout = AutoArtworkFetchLogic.READ_TIMEOUT_MS
+        connection.doInput = true
+        connection.connect()
+        return connection
+    }
+
+    private fun resolveRedirect(
+        current: URL,
+        location: String,
+    ): URL? =
+        runCatching {
+            URI(current.toURI().resolve(location).toString()).toURL()
+        }.getOrNull()
+
+    private fun readBounded(input: InputStream): ByteArray? {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        val out = java.io.ByteArrayOutputStream()
+        var total = 0L
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            total += read
+            if (total > AutoArtworkFetchLogic.MAX_ARTWORK_BYTES) return null
+            out.write(buffer, 0, read)
+        }
+        return out.toByteArray().takeIf { it.isNotEmpty() }
+    }
+
+    private fun InetAddress.isUniqueLocalIpv6(): Boolean {
+        val bytes = address
+        return bytes.size == 16 && (bytes[0].toInt() and 0xFE) == 0xFC
+    }
+
+    private sealed class FetchOutcome {
+        class Redirect(
+            val url: URL,
+        ) : FetchOutcome()
+
+        class Body(
+            val bytes: ByteArray,
+        ) : FetchOutcome()
+    }
+}

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloader.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloader.kt
@@ -17,7 +17,8 @@ internal object AutoArtworkDownloader {
 
     fun parseHttpsUrl(raw: String): URL? {
         val normalized = raw.replaceFirst("http://", "https://")
-        return runCatching { URI(normalized).toURL() }.getOrNull()
+        val url = runCatching { URI(normalized).toURL() }.getOrNull() ?: return null
+        return url.takeIf { it.protocol == "https" }
     }
 
     fun downloadHttpsBytes(startUrl: URL): ByteArray? {

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloader.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloader.kt
@@ -42,16 +42,16 @@ internal object AutoArtworkDownloader {
         val addresses =
             runCatching { InetAddress.getAllByName(url.host) }.getOrNull()
                 ?: return false
-        return addresses.isNotEmpty() &&
-            addresses.all { address ->
-                !address.isAnyLocalAddress &&
-                    !address.isLoopbackAddress &&
-                    !address.isLinkLocalAddress &&
-                    !address.isSiteLocalAddress &&
-                    !address.isMulticastAddress &&
-                    !address.isUniqueLocalIpv6()
-            }
+        return addresses.isNotEmpty() && addresses.all(::isPublicAddress)
     }
+
+    fun isPublicAddress(address: InetAddress): Boolean =
+        !address.isAnyLocalAddress &&
+            !address.isLoopbackAddress &&
+            !address.isLinkLocalAddress &&
+            !address.isSiteLocalAddress &&
+            !address.isMulticastAddress &&
+            !address.isUniqueLocalIpv6()
 
     private fun fetchOnce(url: URL): FetchOutcome? {
         if (!isPublicHttpsUrl(url)) return null

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageGenerator.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageGenerator.kt
@@ -4,13 +4,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.LinearGradient
-import android.graphics.Paint
-import android.graphics.Rect
-import android.graphics.RectF
-import android.graphics.Shader
-import android.graphics.Typeface
 import android.net.Uri
 import android.util.Log
 import cx.aswin.boxlore.core.playback.AutoArtworkFetchLogic
@@ -22,20 +15,12 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
-import java.net.HttpURLConnection
-import java.net.InetAddress
-import java.net.URL
 
 /**
  * Generates composite collage bitmaps from multiple podcast cover art images
  * for Android Auto grid tiles.
  *
- * Layout adapts to the number of available images:
- * - 4 images → 2×2 grid
- * - 3 images → 1 large left + 2 stacked right
- * - 2 images → side-by-side split
- * - 1 image  → full-bleed single cover
- * - 0 images → branded gradient with category label
+ * Layout adapts to the number of available images via [AutoCollageLayouts].
  */
 object AutoCollageGenerator {
     private const val TAG = "AutoCollage"
@@ -54,13 +39,12 @@ object AutoCollageGenerator {
      */
     suspend fun generateAllCollages(
         context: Context,
-        folderImages: Map<String, List<String>>, // folderId → list of image URLs (max 4)
+        folderImages: Map<String, List<String>>,
         folderContentKeys: Map<String, List<String>> = emptyMap(),
     ): Map<String, Uri> =
         withContext(Dispatchers.IO) {
             val results = mutableMapOf<String, Uri>()
             val cacheDir = File(context.cacheDir, "auto_collages").apply { mkdirs() }
-
             for ((folderId, imageUrls) in folderImages) {
                 try {
                     generateOneCollage(
@@ -69,14 +53,11 @@ object AutoCollageGenerator {
                         folderId = folderId,
                         imageUrls = imageUrls,
                         contentKeys = folderContentKeys[folderId].orEmpty(),
-                    )?.let { result ->
-                        results[folderId] = result.uri
-                    }
+                    )?.let { result -> results[folderId] = result.uri }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to generate collage for $folderId", e)
                 }
             }
-
             results
         }
 
@@ -94,8 +75,6 @@ object AutoCollageGenerator {
         val urls = imageUrls.take(4).filter { it.isNotBlank() }
         val expected = urls.size
         val signatureValues = contentKeys.ifEmpty { urls }
-
-        // Probe cache freshness using the last known loaded count (stored in .meta).
         val cachedMeta = readMeta(metaFile)
         val provisionalSignature =
             AutoCollageFreshnessLogic.buildSignature(
@@ -142,7 +121,6 @@ object AutoCollageGenerator {
         runCatching { signatureFile.writeText(signature) }
         runCatching { metaFile.writeText("$loaded\n$expected") }
         built.bitmap.recycle()
-
         Log.d(TAG, "Generated collage for $folderId (loaded=$loaded/$expected)")
         return CollageResult(
             uri = AutoCollageProvider.getUri(context, "$safeName.png", signature),
@@ -165,10 +143,6 @@ object AutoCollageGenerator {
         val loadedImageCount: Int,
     )
 
-    /**
-     * Create a single collage bitmap from a list of image URLs.
-     * Adapts layout based on how many images are available.
-     */
     private suspend fun createCollageBitmap(
         imageUrls: List<String>,
         folderId: String,
@@ -177,299 +151,40 @@ object AutoCollageGenerator {
             val size = COLLAGE_SIZE
             val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
             val canvas = Canvas(bitmap)
-
             val bitmaps =
                 imageUrls
-                    .map { url ->
-                        async(Dispatchers.IO) { downloadBitmap(url) }
-                    }.awaitAll()
+                    .map { url -> async(Dispatchers.IO) { downloadBitmap(url) } }
+                    .awaitAll()
                     .filterNotNull()
-
-            when (bitmaps.size) {
-                0 -> drawBrandedFallback(canvas, size, folderId)
-                1 -> drawSingleCover(canvas, size, bitmaps[0])
-                2 -> drawTwoSplit(canvas, size, bitmaps)
-                3 -> drawThreeLayout(canvas, size, bitmaps)
-                else -> drawFourGrid(canvas, size, bitmaps)
-            }
-            when {
-                folderId.contains("drive_mix") -> drawLabelBadge(canvas, size, "MIX")
-                folderId.contains("continue") -> drawLabelBadge(canvas, size, "RESUME")
-            }
-
+            AutoCollageLayouts.draw(canvas, size, folderId, bitmaps)
             bitmaps.forEach { it.recycle() }
             BuiltCollage(bitmap = bitmap, loadedImageCount = bitmaps.size)
         }
 
-    private fun drawLabelBadge(
-        canvas: Canvas,
-        size: Int,
-        label: String,
-    ) {
-        val padding = size * 0.04f
-        val badgeWidth = size * if (label.length > 3) 0.42f else 0.28f
-        val badgeHeight = size * 0.14f
-        val badge =
-            RectF(
-                size - badgeWidth - padding,
-                size - badgeHeight - padding,
-                size - padding,
-                size - padding,
-            )
-        canvas.drawRoundRect(
-            badge,
-            size * 0.035f,
-            size * 0.035f,
-            Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                color = Color.parseColor("#D91A1A2E")
-            },
-        )
-        val textPaint =
-            Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                color = Color.WHITE
-                textSize = size * 0.065f
-                typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
-                textAlign = Paint.Align.CENTER
-            }
-        val centerY = badge.centerY() - (textPaint.ascent() + textPaint.descent()) / 2f
-        canvas.drawText(label, badge.centerX(), centerY, textPaint)
-    }
-
-    private fun drawSingleCover(
-        canvas: Canvas,
-        size: Int,
-        bmp: Bitmap,
-    ) {
-        drawCenterCrop(canvas, bmp, Rect(0, 0, size, size))
-    }
-
-    private fun drawTwoSplit(
-        canvas: Canvas,
-        size: Int,
-        bitmaps: List<Bitmap>,
-    ) {
-        val halfW = size / 2
-        val gap = 3
-
-        for (i in 0..1) {
-            val srcBmp = bitmaps[i]
-            val left = if (i == 0) 0 else halfW + gap
-            drawCenterCrop(canvas, srcBmp, Rect(left, 0, size.takeIf { i == 1 } ?: halfW, size))
-        }
-    }
-
-    private fun drawThreeLayout(
-        canvas: Canvas,
-        size: Int,
-        bitmaps: List<Bitmap>,
-    ) {
-        val halfW = size / 2
-        val halfH = size / 2
-        val gap = 3
-
-        drawCenterCrop(canvas, bitmaps[0], Rect(0, 0, halfW, size))
-        drawCenterCrop(canvas, bitmaps[1], Rect(halfW + gap, 0, size, halfH))
-        drawCenterCrop(canvas, bitmaps[2], Rect(halfW + gap, halfH + gap, size, size))
-    }
-
-    private fun drawFourGrid(
-        canvas: Canvas,
-        size: Int,
-        bitmaps: List<Bitmap>,
-    ) {
-        val halfW = size / 2
-        val halfH = size / 2
-        val gap = 3
-
-        val positions =
-            listOf(
-                0f to 0f,
-                (halfW + gap).toFloat() to 0f,
-                0f to (halfH + gap).toFloat(),
-                (halfW + gap).toFloat() to (halfH + gap).toFloat(),
-            )
-
-        for (i in 0 until minOf(4, bitmaps.size)) {
-            val (x, y) = positions[i]
-            drawCenterCrop(
-                canvas,
-                bitmaps[i],
-                Rect(x.toInt(), y.toInt(), (x + halfW).toInt(), (y + halfH).toInt()),
-            )
-        }
-    }
-
-    private fun drawBrandedFallback(
-        canvas: Canvas,
-        size: Int,
-        folderId: String,
-    ) {
-        val gradient =
-            LinearGradient(
-                0f,
-                0f,
-                size.toFloat(),
-                size.toFloat(),
-                Color.parseColor("#1a1a2e"),
-                Color.parseColor("#16213e"),
-                Shader.TileMode.CLAMP,
-            )
-        val bgPaint = Paint().apply { shader = gradient }
-        canvas.drawRect(0f, 0f, size.toFloat(), size.toFloat(), bgPaint)
-
-        val label =
-            when {
-                folderId.contains("continue") -> "PLAY"
-                folderId.contains("download") -> "OFFLINE"
-                folderId.contains("drive_mix") -> "MIX"
-                folderId.contains("time_picks") -> "NOW"
-                folderId.contains("genres") -> "GENRES"
-                folderId.contains("discover") -> "DISCOVER"
-                folderId.contains("library") -> "LIBRARY"
-                else -> "BOXLORE"
-            }
-        val textPaint =
-            Paint().apply {
-                color = Color.WHITE
-                textSize = size * 0.1f
-                textAlign = Paint.Align.CENTER
-                typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
-                isAntiAlias = true
-            }
-        canvas.drawText(label, size / 2f, size / 2f + textSize(textPaint) / 3f, textPaint)
-    }
-
-    private fun textSize(paint: Paint): Float = paint.textSize
-
-    private fun drawCenterCrop(
-        canvas: Canvas,
-        bitmap: Bitmap,
-        destination: Rect,
-    ) {
-        val sourceRatio = bitmap.width.toFloat() / bitmap.height.toFloat()
-        val destinationRatio = destination.width().toFloat() / destination.height().toFloat()
-        val source =
-            if (sourceRatio > destinationRatio) {
-                val width = (bitmap.height * destinationRatio).toInt()
-                val left = (bitmap.width - width) / 2
-                Rect(left, 0, left + width, bitmap.height)
-            } else {
-                val height = (bitmap.width / destinationRatio).toInt()
-                val top = (bitmap.height - height) / 2
-                Rect(0, top, bitmap.width, top + height)
-            }
-        canvas.drawBitmap(bitmap, source, destination, Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG))
-    }
-
-    /**
-     * Download a bitmap from URL with hardened timeouts + redirect validation.
-     * Returns null on failure (never throws).
-     */
     private fun downloadBitmap(urlString: String): Bitmap? {
         return try {
             if (urlString.startsWith("/") || urlString.startsWith("file://")) {
-                val path = urlString.removePrefix("file://")
-                return BitmapFactory.decodeFile(path)
+                return BitmapFactory.decodeFile(urlString.removePrefix("file://"))
             }
-            val bytes =
-                downloadBytes(URL(urlString.replace("http://", "https://")))
-                    ?: return null
+            val url = AutoArtworkDownloader.parseHttpsUrl(urlString) ?: return null
+            val bytes = AutoArtworkDownloader.downloadHttpsBytes(url) ?: return null
             if (!AutoArtworkFetchLogic.looksLikeImage(bytes.copyOf(minOf(12, bytes.size)))) {
                 return null
             }
-            val bounds =
-                BitmapFactory.Options().apply {
-                    inJustDecodeBounds = true
-                }
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
             BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
             val maxDim = maxOf(bounds.outWidth, bounds.outHeight).coerceAtLeast(1)
             var sampleSize = 1
             while (maxDim / sampleSize > 300) sampleSize *= 2
-            val decodeOpts =
-                BitmapFactory.Options().apply {
-                    inSampleSize = sampleSize
-                }
-            BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decodeOpts)
+            BitmapFactory.decodeByteArray(
+                bytes,
+                0,
+                bytes.size,
+                BitmapFactory.Options().apply { inSampleSize = sampleSize },
+            )
         } catch (e: Exception) {
             Log.w(TAG, "Failed to download: $urlString", e)
             null
         }
-    }
-
-    private fun downloadBytes(startUrl: URL): ByteArray? {
-        var current = startUrl
-        var redirects = 0
-        while (redirects <= AutoArtworkFetchLogic.MAX_REDIRECTS) {
-            if (current.protocol != "https" || !isPublicHttpsUrl(current)) return null
-            var connection: HttpURLConnection? = null
-            try {
-                connection = current.openConnection() as HttpURLConnection
-                connection.instanceFollowRedirects = false
-                connection.connectTimeout = AutoArtworkFetchLogic.CONNECT_TIMEOUT_MS
-                connection.readTimeout = AutoArtworkFetchLogic.READ_TIMEOUT_MS
-                connection.doInput = true
-                connection.connect()
-                val code = connection.responseCode
-                if (AutoArtworkFetchLogic.isRedirect(code)) {
-                    val location = connection.getHeaderField("Location") ?: return null
-                    val next =
-                        runCatching {
-                            java.net.URI(current.toURI().resolve(location).toString()).toURL()
-                        }.getOrNull() ?: return null
-                    redirects += 1
-                    current = next
-                    continue
-                }
-                if (
-                    !AutoArtworkFetchLogic.shouldAcceptArtwork(
-                        code,
-                        connection.contentType,
-                        connection.contentLengthLong,
-                    )
-                ) {
-                    return null
-                }
-                return connection.inputStream.use { input ->
-                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                    val out = java.io.ByteArrayOutputStream()
-                    var total = 0L
-                    while (true) {
-                        val read = input.read(buffer)
-                        if (read < 0) break
-                        total += read
-                        if (total > AutoArtworkFetchLogic.MAX_ARTWORK_BYTES) return@use null
-                        out.write(buffer, 0, read)
-                    }
-                    out.toByteArray().takeIf { it.isNotEmpty() }
-                }
-            } catch (e: Exception) {
-                Log.w(TAG, "Download failed for $current", e)
-                return null
-            } finally {
-                connection?.disconnect()
-            }
-        }
-        return null
-    }
-
-    private fun isPublicHttpsUrl(url: URL): Boolean {
-        if (url.protocol != "https" || (url.port != -1 && url.port != 443)) return false
-        val addresses =
-            runCatching { InetAddress.getAllByName(url.host) }.getOrNull()
-                ?: return false
-        return addresses.isNotEmpty() &&
-            addresses.all { address ->
-                !address.isAnyLocalAddress &&
-                    !address.isLoopbackAddress &&
-                    !address.isLinkLocalAddress &&
-                    !address.isSiteLocalAddress &&
-                    !address.isMulticastAddress &&
-                    !address.isUniqueLocalIpv6()
-            }
-    }
-
-    private fun InetAddress.isUniqueLocalIpv6(): Boolean {
-        val bytes = address
-        return bytes.size == 16 && (bytes[0].toInt() and 0xFE) == 0xFC
     }
 }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageGenerator.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageGenerator.kt
@@ -1,9 +1,20 @@
 package cx.aswin.boxlore.core.playback.service
 
 import android.content.Context
-import android.graphics.*
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.RectF
+import android.graphics.Shader
+import android.graphics.Typeface
 import android.net.Uri
 import android.util.Log
+import cx.aswin.boxlore.core.playback.AutoArtworkFetchLogic
+import cx.aswin.boxlore.core.playback.AutoCollageFreshnessLogic
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -12,6 +23,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.net.HttpURLConnection
+import java.net.InetAddress
 import java.net.URL
 
 /**
@@ -29,9 +41,16 @@ object AutoCollageGenerator {
     private const val TAG = "AutoCollage"
     private const val COLLAGE_SIZE = 512 // px, square
 
+    data class CollageResult(
+        val uri: Uri,
+        val signature: String,
+        val loadedImageCount: Int,
+        val expectedImageCount: Int,
+    )
+
     /**
-     * Pre-generate all Home tab collages and return a map of folder ID → content:// URI.
-     * This runs entirely on IO dispatcher and uses only local/cached data.
+     * Pre-generate Home / Library / Discover collages and return folder ID → content URI.
+     * URIs include a `v=` cache-buster so Android Auto reloads when content keys change.
      */
     suspend fun generateAllCollages(
         context: Context,
@@ -44,43 +63,14 @@ object AutoCollageGenerator {
 
             for ((folderId, imageUrls) in folderImages) {
                 try {
-                    val safeName = folderId.replace(Regex("[^a-zA-Z0-9_]"), "_")
-                    val outFile = File(cacheDir, "$safeName.png")
-                    val signatureFile = File(cacheDir, "$safeName.signature")
-                    val uri = AutoCollageProvider.getUri(context, "$safeName.png")
-                    val contentKeys = folderContentKeys[folderId].orEmpty()
-                    val signatureValues = contentKeys.ifEmpty { imageUrls }
-                    val signature =
-                        buildString {
-                            append("collage-v3\n")
-                            append(
-                                signatureValues
-                                    .take(4)
-                                    .filter(String::isNotBlank)
-                                    .joinToString("\n"),
-                            )
-                        }.hashCode().toString()
-                    val isFresh =
-                        outFile.exists() &&
-                            System.currentTimeMillis() - outFile.lastModified() < 6 * 60 * 60 * 1_000L &&
-                            signatureFile.isFile &&
-                            signatureFile.readText() == signature
-                    if (isFresh) {
-                        results[folderId] = uri
-                        continue
-                    }
-
-                    val bitmap = createCollageBitmap(imageUrls, folderId, context)
-                    if (bitmap != null) {
-                        FileOutputStream(outFile).use { out ->
-                            bitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
-                        }
-                        runCatching { signatureFile.writeText(signature) }
-                        bitmap.recycle()
-
-                        // Use our custom exported ContentProvider URI
-                        results[folderId] = uri
-                        Log.d(TAG, "Generated collage for $folderId → $uri")
+                    generateOneCollage(
+                        context = context,
+                        cacheDir = cacheDir,
+                        folderId = folderId,
+                        imageUrls = imageUrls,
+                        contentKeys = folderContentKeys[folderId].orEmpty(),
+                    )?.let { result ->
+                        results[folderId] = result.uri
                     }
                 } catch (e: Exception) {
                     Log.e(TAG, "Failed to generate collage for $folderId", e)
@@ -90,6 +80,91 @@ object AutoCollageGenerator {
             results
         }
 
+    private suspend fun generateOneCollage(
+        context: Context,
+        cacheDir: File,
+        folderId: String,
+        imageUrls: List<String>,
+        contentKeys: List<String>,
+    ): CollageResult? {
+        val safeName = folderId.replace(Regex("[^a-zA-Z0-9_]"), "_")
+        val outFile = File(cacheDir, "$safeName.png")
+        val signatureFile = File(cacheDir, "$safeName.signature")
+        val metaFile = File(cacheDir, "$safeName.meta")
+        val urls = imageUrls.take(4).filter { it.isNotBlank() }
+        val expected = urls.size
+        val signatureValues = contentKeys.ifEmpty { urls }
+
+        // Probe cache freshness using the last known loaded count (stored in .meta).
+        val cachedMeta = readMeta(metaFile)
+        val provisionalSignature =
+            AutoCollageFreshnessLogic.buildSignature(
+                contentKeysOrUrls = signatureValues,
+                loadedImageCount = cachedMeta?.first ?: expected,
+                expectedImageCount = cachedMeta?.second ?: expected,
+            )
+        val ageMs =
+            if (outFile.exists()) {
+                System.currentTimeMillis() - outFile.lastModified()
+            } else {
+                Long.MAX_VALUE
+            }
+        val storedSignature = signatureFile.takeIf { it.isFile }?.readText()
+        if (
+            outFile.exists() &&
+            AutoCollageFreshnessLogic.isFresh(
+                ageMs = ageMs,
+                storedSignature = storedSignature,
+                currentSignature = provisionalSignature,
+                loadedImageCount = cachedMeta?.first ?: expected,
+                expectedImageCount = cachedMeta?.second ?: expected,
+            )
+        ) {
+            return CollageResult(
+                uri = AutoCollageProvider.getUri(context, "$safeName.png", provisionalSignature),
+                signature = provisionalSignature,
+                loadedImageCount = cachedMeta?.first ?: expected,
+                expectedImageCount = cachedMeta?.second ?: expected,
+            )
+        }
+
+        val built = createCollageBitmap(urls, folderId) ?: return null
+        val loaded = built.loadedImageCount
+        val signature =
+            AutoCollageFreshnessLogic.buildSignature(
+                contentKeysOrUrls = signatureValues,
+                loadedImageCount = loaded,
+                expectedImageCount = expected,
+            )
+        FileOutputStream(outFile).use { out ->
+            built.bitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
+        }
+        runCatching { signatureFile.writeText(signature) }
+        runCatching { metaFile.writeText("$loaded\n$expected") }
+        built.bitmap.recycle()
+
+        Log.d(TAG, "Generated collage for $folderId (loaded=$loaded/$expected)")
+        return CollageResult(
+            uri = AutoCollageProvider.getUri(context, "$safeName.png", signature),
+            signature = signature,
+            loadedImageCount = loaded,
+            expectedImageCount = expected,
+        )
+    }
+
+    private fun readMeta(metaFile: File): Pair<Int, Int>? {
+        if (!metaFile.isFile) return null
+        val lines = runCatching { metaFile.readLines() }.getOrNull() ?: return null
+        val loaded = lines.getOrNull(0)?.toIntOrNull() ?: return null
+        val expected = lines.getOrNull(1)?.toIntOrNull() ?: return null
+        return loaded to expected
+    }
+
+    private data class BuiltCollage(
+        val bitmap: Bitmap,
+        val loadedImageCount: Int,
+    )
+
     /**
      * Create a single collage bitmap from a list of image URLs.
      * Adapts layout based on how many images are available.
@@ -97,17 +172,14 @@ object AutoCollageGenerator {
     private suspend fun createCollageBitmap(
         imageUrls: List<String>,
         folderId: String,
-        context: Context,
-    ): Bitmap? =
+    ): BuiltCollage? =
         coroutineScope {
             val size = COLLAGE_SIZE
             val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
             val canvas = Canvas(bitmap)
 
-            // Download images in parallel (with timeout protection)
-            val urls = imageUrls.take(4).filter { it.isNotBlank() }
             val bitmaps =
-                urls
+                imageUrls
                     .map { url ->
                         async(Dispatchers.IO) { downloadBitmap(url) }
                     }.awaitAll()
@@ -125,9 +197,8 @@ object AutoCollageGenerator {
                 folderId.contains("continue") -> drawLabelBadge(canvas, size, "RESUME")
             }
 
-            // Recycle source bitmaps
             bitmaps.forEach { it.recycle() }
-            bitmap
+            BuiltCollage(bitmap = bitmap, loadedImageCount = bitmaps.size)
         }
 
     private fun drawLabelBadge(
@@ -164,9 +235,6 @@ object AutoCollageGenerator {
         canvas.drawText(label, badge.centerX(), centerY, textPaint)
     }
 
-    // ============= Layout Renderers =============
-
-    /** Full-bleed single image */
     private fun drawSingleCover(
         canvas: Canvas,
         size: Int,
@@ -175,14 +243,13 @@ object AutoCollageGenerator {
         drawCenterCrop(canvas, bmp, Rect(0, 0, size, size))
     }
 
-    /** Side-by-side vertical split */
     private fun drawTwoSplit(
         canvas: Canvas,
         size: Int,
         bitmaps: List<Bitmap>,
     ) {
         val halfW = size / 2
-        val gap = 3 // thin gap between images
+        val gap = 3
 
         for (i in 0..1) {
             val srcBmp = bitmaps[i]
@@ -191,7 +258,6 @@ object AutoCollageGenerator {
         }
     }
 
-    /** 1 large left + 2 stacked right */
     private fun drawThreeLayout(
         canvas: Canvas,
         size: Int,
@@ -201,17 +267,11 @@ object AutoCollageGenerator {
         val halfH = size / 2
         val gap = 3
 
-        // Left: large
         drawCenterCrop(canvas, bitmaps[0], Rect(0, 0, halfW, size))
-
-        // Top-right
         drawCenterCrop(canvas, bitmaps[1], Rect(halfW + gap, 0, size, halfH))
-
-        // Bottom-right
         drawCenterCrop(canvas, bitmaps[2], Rect(halfW + gap, halfH + gap, size, size))
     }
 
-    /** Classic 2×2 grid */
     private fun drawFourGrid(
         canvas: Canvas,
         size: Int,
@@ -239,13 +299,11 @@ object AutoCollageGenerator {
         }
     }
 
-    /** Branded gradient fallback when no images available */
     private fun drawBrandedFallback(
         canvas: Canvas,
         size: Int,
         folderId: String,
     ) {
-        // Dark gradient background
         val gradient =
             LinearGradient(
                 0f,
@@ -259,7 +317,6 @@ object AutoCollageGenerator {
         val bgPaint = Paint().apply { shader = gradient }
         canvas.drawRect(0f, 0f, size.toFloat(), size.toFloat(), bgPaint)
 
-        // Stable text glyphs render consistently across head units.
         val label =
             when {
                 folderId.contains("continue") -> "PLAY"
@@ -304,10 +361,8 @@ object AutoCollageGenerator {
         canvas.drawBitmap(bitmap, source, destination, Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG))
     }
 
-    // ============= Image Downloading =============
-
     /**
-     * Download a bitmap from URL with a 3-second timeout.
+     * Download a bitmap from URL with hardened timeouts + redirect validation.
      * Returns null on failure (never throws).
      */
     private fun downloadBitmap(urlString: String): Bitmap? {
@@ -316,52 +371,105 @@ object AutoCollageGenerator {
                 val path = urlString.removePrefix("file://")
                 return BitmapFactory.decodeFile(path)
             }
-            val url = URL(urlString.replace("http://", "https://"))
-            val conn = url.openConnection() as HttpURLConnection
-            conn.connectTimeout = 3000
-            conn.readTimeout = 3000
-            conn.instanceFollowRedirects = true
-            conn.doInput = true
-            conn.connect()
-
-            if (conn.responseCode == HttpURLConnection.HTTP_OK) {
-                val inputStream = conn.inputStream
-                val opts =
-                    BitmapFactory.Options().apply {
-                        // Downsample to save memory (max 256px per source)
-                        inSampleSize = 1
-                        inJustDecodeBounds = true
-                    }
-                // Two-pass decode: measure first, then downsample
-                BitmapFactory.decodeStream(inputStream, null, opts)
-                inputStream.close()
-
-                // Calculate sample size
-                val maxDim = maxOf(opts.outWidth, opts.outHeight)
-                var sampleSize = 1
-                while (maxDim / sampleSize > 300) sampleSize *= 2
-
-                val conn2 = url.openConnection() as HttpURLConnection
-                conn2.connectTimeout = 3000
-                conn2.readTimeout = 3000
-                conn2.instanceFollowRedirects = true
-                conn2.doInput = true
-                conn2.connect()
-
-                val decodeOpts =
-                    BitmapFactory.Options().apply {
-                        inSampleSize = sampleSize
-                    }
-                val bmp = BitmapFactory.decodeStream(conn2.inputStream, null, decodeOpts)
-                conn2.disconnect()
-                bmp
-            } else {
-                conn.disconnect()
-                null
+            val bytes =
+                downloadBytes(URL(urlString.replace("http://", "https://")))
+                    ?: return null
+            if (!AutoArtworkFetchLogic.looksLikeImage(bytes.copyOf(minOf(12, bytes.size)))) {
+                return null
             }
+            val bounds =
+                BitmapFactory.Options().apply {
+                    inJustDecodeBounds = true
+                }
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+            val maxDim = maxOf(bounds.outWidth, bounds.outHeight).coerceAtLeast(1)
+            var sampleSize = 1
+            while (maxDim / sampleSize > 300) sampleSize *= 2
+            val decodeOpts =
+                BitmapFactory.Options().apply {
+                    inSampleSize = sampleSize
+                }
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decodeOpts)
         } catch (e: Exception) {
             Log.w(TAG, "Failed to download: $urlString", e)
             null
         }
+    }
+
+    private fun downloadBytes(startUrl: URL): ByteArray? {
+        var current = startUrl
+        var redirects = 0
+        while (redirects <= AutoArtworkFetchLogic.MAX_REDIRECTS) {
+            if (current.protocol != "https" || !isPublicHttpsUrl(current)) return null
+            var connection: HttpURLConnection? = null
+            try {
+                connection = current.openConnection() as HttpURLConnection
+                connection.instanceFollowRedirects = false
+                connection.connectTimeout = AutoArtworkFetchLogic.CONNECT_TIMEOUT_MS
+                connection.readTimeout = AutoArtworkFetchLogic.READ_TIMEOUT_MS
+                connection.doInput = true
+                connection.connect()
+                val code = connection.responseCode
+                if (AutoArtworkFetchLogic.isRedirect(code)) {
+                    val location = connection.getHeaderField("Location") ?: return null
+                    val next =
+                        runCatching {
+                            java.net.URI(current.toURI().resolve(location).toString()).toURL()
+                        }.getOrNull() ?: return null
+                    redirects += 1
+                    current = next
+                    continue
+                }
+                if (
+                    !AutoArtworkFetchLogic.shouldAcceptArtwork(
+                        code,
+                        connection.contentType,
+                        connection.contentLengthLong,
+                    )
+                ) {
+                    return null
+                }
+                return connection.inputStream.use { input ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    val out = java.io.ByteArrayOutputStream()
+                    var total = 0L
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        total += read
+                        if (total > AutoArtworkFetchLogic.MAX_ARTWORK_BYTES) return@use null
+                        out.write(buffer, 0, read)
+                    }
+                    out.toByteArray().takeIf { it.isNotEmpty() }
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Download failed for $current", e)
+                return null
+            } finally {
+                connection?.disconnect()
+            }
+        }
+        return null
+    }
+
+    private fun isPublicHttpsUrl(url: URL): Boolean {
+        if (url.protocol != "https" || (url.port != -1 && url.port != 443)) return false
+        val addresses =
+            runCatching { InetAddress.getAllByName(url.host) }.getOrNull()
+                ?: return false
+        return addresses.isNotEmpty() &&
+            addresses.all { address ->
+                !address.isAnyLocalAddress &&
+                    !address.isLoopbackAddress &&
+                    !address.isLinkLocalAddress &&
+                    !address.isSiteLocalAddress &&
+                    !address.isMulticastAddress &&
+                    !address.isUniqueLocalIpv6()
+            }
+    }
+
+    private fun InetAddress.isUniqueLocalIpv6(): Boolean {
+        val bytes = address
+        return bytes.size == 16 && (bytes[0].toInt() and 0xFE) == 0xFC
     }
 }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageLayouts.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageLayouts.kt
@@ -1,0 +1,189 @@
+package cx.aswin.boxlore.core.playback.service
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.RectF
+import android.graphics.Shader
+import android.graphics.Typeface
+
+/** Layout helpers for [AutoCollageGenerator] Android Auto folder tiles. */
+internal object AutoCollageLayouts {
+    fun draw(
+        canvas: Canvas,
+        size: Int,
+        folderId: String,
+        bitmaps: List<Bitmap>,
+    ) {
+        when (bitmaps.size) {
+            0 -> drawBrandedFallback(canvas, size, folderId)
+            1 -> drawSingleCover(canvas, size, bitmaps[0])
+            2 -> drawTwoSplit(canvas, size, bitmaps)
+            3 -> drawThreeLayout(canvas, size, bitmaps)
+            else -> drawFourGrid(canvas, size, bitmaps)
+        }
+        when {
+            folderId.contains("drive_mix") -> drawLabelBadge(canvas, size, "MIX")
+            folderId.contains("continue") -> drawLabelBadge(canvas, size, "RESUME")
+        }
+    }
+
+    private fun drawLabelBadge(
+        canvas: Canvas,
+        size: Int,
+        label: String,
+    ) {
+        val padding = size * 0.04f
+        val badgeWidth = size * if (label.length > 3) 0.42f else 0.28f
+        val badgeHeight = size * 0.14f
+        val badge =
+            RectF(
+                size - badgeWidth - padding,
+                size - badgeHeight - padding,
+                size - padding,
+                size - padding,
+            )
+        canvas.drawRoundRect(
+            badge,
+            size * 0.035f,
+            size * 0.035f,
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = Color.parseColor("#D91A1A2E")
+            },
+        )
+        val textPaint =
+            Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = Color.WHITE
+                textSize = size * 0.065f
+                typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+                textAlign = Paint.Align.CENTER
+            }
+        val centerY = badge.centerY() - (textPaint.ascent() + textPaint.descent()) / 2f
+        canvas.drawText(label, badge.centerX(), centerY, textPaint)
+    }
+
+    private fun drawSingleCover(
+        canvas: Canvas,
+        size: Int,
+        bmp: Bitmap,
+    ) {
+        drawCenterCrop(canvas, bmp, Rect(0, 0, size, size))
+    }
+
+    private fun drawTwoSplit(
+        canvas: Canvas,
+        size: Int,
+        bitmaps: List<Bitmap>,
+    ) {
+        val halfW = size / 2
+        val gap = 3
+        for (i in 0..1) {
+            val left = if (i == 0) 0 else halfW + gap
+            drawCenterCrop(canvas, bitmaps[i], Rect(left, 0, size.takeIf { i == 1 } ?: halfW, size))
+        }
+    }
+
+    private fun drawThreeLayout(
+        canvas: Canvas,
+        size: Int,
+        bitmaps: List<Bitmap>,
+    ) {
+        val halfW = size / 2
+        val halfH = size / 2
+        val gap = 3
+        drawCenterCrop(canvas, bitmaps[0], Rect(0, 0, halfW, size))
+        drawCenterCrop(canvas, bitmaps[1], Rect(halfW + gap, 0, size, halfH))
+        drawCenterCrop(canvas, bitmaps[2], Rect(halfW + gap, halfH + gap, size, size))
+    }
+
+    private fun drawFourGrid(
+        canvas: Canvas,
+        size: Int,
+        bitmaps: List<Bitmap>,
+    ) {
+        val halfW = size / 2
+        val halfH = size / 2
+        val gap = 3
+        val positions =
+            listOf(
+                0f to 0f,
+                (halfW + gap).toFloat() to 0f,
+                0f to (halfH + gap).toFloat(),
+                (halfW + gap).toFloat() to (halfH + gap).toFloat(),
+            )
+        for (i in 0 until minOf(4, bitmaps.size)) {
+            val (x, y) = positions[i]
+            drawCenterCrop(
+                canvas,
+                bitmaps[i],
+                Rect(x.toInt(), y.toInt(), (x + halfW).toInt(), (y + halfH).toInt()),
+            )
+        }
+    }
+
+    private fun drawBrandedFallback(
+        canvas: Canvas,
+        size: Int,
+        folderId: String,
+    ) {
+        val gradient =
+            LinearGradient(
+                0f,
+                0f,
+                size.toFloat(),
+                size.toFloat(),
+                Color.parseColor("#1a1a2e"),
+                Color.parseColor("#16213e"),
+                Shader.TileMode.CLAMP,
+            )
+        canvas.drawRect(0f, 0f, size.toFloat(), size.toFloat(), Paint().apply { shader = gradient })
+        val label =
+            when {
+                folderId.contains("continue") -> "PLAY"
+                folderId.contains("download") -> "OFFLINE"
+                folderId.contains("drive_mix") -> "MIX"
+                folderId.contains("time_picks") -> "NOW"
+                folderId.contains("genres") -> "GENRES"
+                folderId.contains("discover") -> "DISCOVER"
+                folderId.contains("library") -> "LIBRARY"
+                else -> "BOXLORE"
+            }
+        val textPaint =
+            Paint().apply {
+                color = Color.WHITE
+                textSize = size * 0.1f
+                textAlign = Paint.Align.CENTER
+                typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+                isAntiAlias = true
+            }
+        canvas.drawText(label, size / 2f, size / 2f + textPaint.textSize / 3f, textPaint)
+    }
+
+    private fun drawCenterCrop(
+        canvas: Canvas,
+        bitmap: Bitmap,
+        destination: Rect,
+    ) {
+        val sourceRatio = bitmap.width.toFloat() / bitmap.height.toFloat()
+        val destinationRatio = destination.width().toFloat() / destination.height().toFloat()
+        val source =
+            if (sourceRatio > destinationRatio) {
+                val width = (bitmap.height * destinationRatio).toInt()
+                val left = (bitmap.width - width) / 2
+                Rect(left, 0, left + width, bitmap.height)
+            } else {
+                val height = (bitmap.width / destinationRatio).toInt()
+                val top = (bitmap.height - height) / 2
+                Rect(0, top, bitmap.width, top + height)
+            }
+        canvas.drawBitmap(
+            bitmap,
+            source,
+            destination,
+            Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG),
+        )
+    }
+}

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollagePrewarmer.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollagePrewarmer.kt
@@ -5,7 +5,10 @@ import android.net.Uri
 import android.util.Log
 import androidx.media3.session.MediaLibraryService.MediaLibrarySession
 import cx.aswin.boxlore.core.database.BoxLoreDatabase
+import cx.aswin.boxlore.core.database.DownloadedEpisodeEntity
+import cx.aswin.boxlore.core.database.ListeningHistoryEntity
 import cx.aswin.boxlore.core.database.PodcastEntity
+import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.core.playback.MixtapeEngine
 import cx.aswin.boxlore.core.playback.QueueRepository
@@ -51,137 +54,154 @@ internal class AutoCollagePrewarmer(
 
     private suspend fun runPrewarm() {
         try {
-            val history = database.listeningHistoryDao().getRecentHistoryList(300)
-            val resumeItems = database.listeningHistoryDao().getResumeItemsList()
-            val subscriptions = database.podcastDao().getSubscribedPodcastsList()
-            val downloads = database.downloadedEpisodeDao().getCompletedDownloads(8)
-            val queue = queueRepository.getQueueSnapshot()
-            val historyImages =
-                history.mapNotNull {
-                    it.episodeImageUrl ?: it.podcastImageUrl
-                }
-            val resumeImages =
-                resumeItems.mapNotNull {
-                    it.episodeImageUrl ?: it.podcastImageUrl
-                }
-            val subscriptionImages = subscriptions.mapNotNull { it.imageUrl }
-            val downloadImages =
-                downloads.mapNotNull {
-                    it.episodeImageUrl ?: it.podcastImageUrl
-                }
-            val queueImages = queue.mapNotNull { it.imageUrl ?: it.podcastImageUrl }
-            val newEpisodeImages =
-                subscriptions.mapNotNull {
-                    it.latestEpisode?.imageUrl ?: it.imageUrl
-                }
-            var mixtape =
-                MixtapeEngine.build(
-                    subscriptions = subscriptions.map(toAutoPodcast),
-                    history = history,
-                    adaptiveRanking =
-                        MixtapeEngine.AdaptiveRanking(
-                            scorer = adaptiveCandidateScorer,
-                            surface = RankingSurface.ANDROID_AUTO,
-                        ),
+            val snapshot = loadSnapshot()
+            val mixtape = resolveMixtape(snapshot)
+            val uris =
+                AutoCollageGenerator.generateAllCollages(
+                    context = context,
+                    folderImages = snapshot.folderImages(mixtape),
+                    folderContentKeys = snapshot.folderContentKeys(mixtape),
                 )
-            if (mixtape.episodes.size < 3) {
-                val recommendations =
-                    runCatching {
-                        withTimeout(6_000L) {
-                            smartQueueSources.getPersonalizedRecommendations(
-                                history = smartQueueSources.getHistoryForRecommendations(25),
-                                interests = smartQueueSources.getInterests(),
-                                country = smartQueueSources.getRegion(),
-                                subscribedPodcastIds = subscriptions.map { it.podcastId },
-                                subscribedGenres = subscriptions.mapNotNull { it.genre }.distinct(),
-                            )
-                        }
-                    }.getOrDefault(emptyList())
-                mixtape =
-                    MixtapeEngine.build(
-                        subscriptions = subscriptions.map(toAutoPodcast),
-                        history = history,
-                        recommendations = recommendations,
-                        adaptiveRanking =
-                            MixtapeEngine.AdaptiveRanking(
-                                scorer = adaptiveCandidateScorer,
-                                surface = RankingSurface.ANDROID_AUTO,
-                            ),
+            onCollagesReady(uris)
+            notifyBrowseTree(snapshot.subscriptions.size, snapshot.resumeItems.size)
+        } catch (error: Exception) {
+            Log.w("AutoBrowse", "Unable to prewarm Android Auto artwork", error)
+        }
+    }
+
+    private suspend fun loadSnapshot(): PrewarmSnapshot {
+        val history = database.listeningHistoryDao().getRecentHistoryList(300)
+        val resumeItems = database.listeningHistoryDao().getResumeItemsList()
+        val subscriptions = database.podcastDao().getSubscribedPodcastsList()
+        val downloads = database.downloadedEpisodeDao().getCompletedDownloads(8)
+        val queue = queueRepository.getQueueSnapshot()
+        return PrewarmSnapshot(
+            history = history,
+            resumeItems = resumeItems,
+            subscriptions = subscriptions,
+            downloads = downloads,
+            queue = queue,
+        )
+    }
+
+    private suspend fun resolveMixtape(snapshot: PrewarmSnapshot): MixtapeEngine.Result {
+        var mixtape =
+            MixtapeEngine.build(
+                subscriptions = snapshot.subscriptions.map(toAutoPodcast),
+                history = snapshot.history,
+                adaptiveRanking =
+                    MixtapeEngine.AdaptiveRanking(
+                        scorer = adaptiveCandidateScorer,
+                        surface = RankingSurface.ANDROID_AUTO,
+                    ),
+            )
+        if (mixtape.episodes.size >= 3) return mixtape
+        val recommendations =
+            runCatching {
+                withTimeout(6_000L) {
+                    smartQueueSources.getPersonalizedRecommendations(
+                        history = smartQueueSources.getHistoryForRecommendations(25),
+                        interests = smartQueueSources.getInterests(),
+                        country = smartQueueSources.getRegion(),
+                        subscribedPodcastIds = snapshot.subscriptions.map { it.podcastId },
+                        subscribedGenres =
+                            snapshot.subscriptions.mapNotNull { it.genre }.distinct(),
                     )
+                }
+            }.getOrDefault(emptyList())
+        return MixtapeEngine.build(
+            subscriptions = snapshot.subscriptions.map(toAutoPodcast),
+            history = snapshot.history,
+            recommendations = recommendations,
+            adaptiveRanking =
+                MixtapeEngine.AdaptiveRanking(
+                    scorer = adaptiveCandidateScorer,
+                    surface = RankingSurface.ANDROID_AUTO,
+                ),
+        )
+    }
+
+    private fun notifyBrowseTree(
+        subscriptionCount: Int,
+        resumeCount: Int,
+    ) {
+        val session = mediaSessionProvider()
+        session?.notifyChildrenChanged(AutoBrowseContract.ROOT_ID, 4, null)
+        session?.notifyChildrenChanged(AutoBrowseContract.HOME_ID, 3, null)
+        session?.notifyChildrenChanged(
+            AutoBrowseContract.LIBRARY_ID,
+            subscriptionCount + 2,
+            null,
+        )
+        session?.notifyChildrenChanged(AutoBrowseContract.DISCOVER_ID, 3, null)
+        session?.notifyChildrenChanged(AutoBrowseContract.HOME_CONTINUE_ID, resumeCount, null)
+    }
+
+    private data class PrewarmSnapshot(
+        val history: List<ListeningHistoryEntity>,
+        val resumeItems: List<ListeningHistoryEntity>,
+        val subscriptions: List<PodcastEntity>,
+        val downloads: List<DownloadedEpisodeEntity>,
+        val queue: List<Episode>,
+    ) {
+        private val historyImages =
+            history.mapNotNull { it.episodeImageUrl ?: it.podcastImageUrl }
+        private val resumeImages =
+            resumeItems.mapNotNull { it.episodeImageUrl ?: it.podcastImageUrl }
+        private val subscriptionImages = subscriptions.mapNotNull { it.imageUrl }
+        private val downloadImages =
+            downloads.mapNotNull { it.episodeImageUrl ?: it.podcastImageUrl }
+        private val queueImages = queue.mapNotNull { it.imageUrl ?: it.podcastImageUrl }
+        private val newEpisodeImages =
+            subscriptions.mapNotNull { it.latestEpisode?.imageUrl ?: it.imageUrl }
+        private val newEpisodeKeys =
+            subscriptions.mapNotNull { podcast ->
+                podcast.latestEpisode?.id ?: podcast.podcastId.takeIf {
+                    podcast.latestEpisode != null || !podcast.imageUrl.isNullOrBlank()
+                }
             }
+
+        fun folderImages(mixtape: MixtapeEngine.Result): Map<String, List<String>> {
             val mixtapeImages =
                 mixtape.podcasts.mapNotNull { podcast ->
                     podcast.latestEpisode?.let { episode ->
                         episode.imageUrl ?: episode.podcastImageUrl ?: podcast.imageUrl
                     }
                 }
-            val newEpisodeKeys =
-                subscriptions.mapNotNull { podcast ->
-                    podcast.latestEpisode?.id ?: podcast.podcastId.takeIf {
-                        podcast.latestEpisode != null || !podcast.imageUrl.isNullOrBlank()
-                    }
-                }
-            val uris =
-                AutoCollageGenerator.generateAllCollages(
-                    context = context,
-                    folderImages =
-                        mapOf(
-                            AutoBrowseContract.HOME_ID to (historyImages + newEpisodeImages).take(4),
-                            AutoBrowseContract.LIBRARY_ID to subscriptionImages.take(4),
-                            AutoBrowseContract.DOWNLOADS_ID to downloadImages.take(4),
-                            AutoBrowseContract.DISCOVER_ID to subscriptionImages.asReversed().take(4),
-                            AutoBrowseContract.HOME_CONTINUE_ID to resumeImages.take(4),
-                            AutoBrowseContract.HOME_QUEUE_ID to queueImages.take(4),
-                            AutoBrowseContract.HOME_NEW_EPISODES_ID to newEpisodeImages.take(4),
-                            AutoBrowseContract.HOME_DRIVE_MIX_ID to mixtapeImages.take(4),
-                            AutoBrowseContract.DISCOVER_DRIVE_PICKS_ID to
-                                (queueImages + subscriptionImages).take(4),
-                            AutoBrowseContract.DISCOVER_TIME_PICKS_ID to emptyList(),
-                            AutoBrowseContract.DISCOVER_GENRES_ID to emptyList(),
-                        ),
-                    folderContentKeys =
-                        mapOf(
-                            AutoBrowseContract.HOME_ID to
-                                history.take(4).map { it.episodeId },
-                            AutoBrowseContract.LIBRARY_ID to
-                                subscriptions.take(4).map { it.podcastId },
-                            AutoBrowseContract.DOWNLOADS_ID to
-                                downloads.map { it.episodeId },
-                            AutoBrowseContract.DISCOVER_ID to
-                                subscriptions.asReversed().take(4).map { it.podcastId },
-                            AutoBrowseContract.HOME_CONTINUE_ID to
-                                resumeItems.map { it.episodeId },
-                            AutoBrowseContract.HOME_QUEUE_ID to
-                                queue.map { it.id },
-                            AutoBrowseContract.HOME_NEW_EPISODES_ID to
-                                newEpisodeKeys.take(4),
-                            AutoBrowseContract.HOME_DRIVE_MIX_ID to
-                                mixtape.episodes.map { it.id },
-                            AutoBrowseContract.DISCOVER_DRIVE_PICKS_ID to
-                                (
-                                    queue.map { it.id } +
-                                        subscriptions.map { it.podcastId }
-                                ).take(4),
-                            AutoBrowseContract.DISCOVER_TIME_PICKS_ID to
-                                listOf(AutoBrowseContract.DISCOVER_TIME_PICKS_ID),
-                            AutoBrowseContract.DISCOVER_GENRES_ID to
-                                listOf(AutoBrowseContract.DISCOVER_GENRES_ID),
-                        ),
-                )
-            onCollagesReady(uris)
-            val session = mediaSessionProvider()
-            session?.notifyChildrenChanged(AutoBrowseContract.ROOT_ID, 4, null)
-            session?.notifyChildrenChanged(AutoBrowseContract.HOME_ID, 3, null)
-            session?.notifyChildrenChanged(
-                AutoBrowseContract.LIBRARY_ID,
-                subscriptions.size + 2,
-                null,
+            return mapOf(
+                AutoBrowseContract.HOME_ID to (historyImages + newEpisodeImages).take(4),
+                AutoBrowseContract.LIBRARY_ID to subscriptionImages.take(4),
+                AutoBrowseContract.DOWNLOADS_ID to downloadImages.take(4),
+                AutoBrowseContract.DISCOVER_ID to subscriptionImages.asReversed().take(4),
+                AutoBrowseContract.HOME_CONTINUE_ID to resumeImages.take(4),
+                AutoBrowseContract.HOME_QUEUE_ID to queueImages.take(4),
+                AutoBrowseContract.HOME_NEW_EPISODES_ID to newEpisodeImages.take(4),
+                AutoBrowseContract.HOME_DRIVE_MIX_ID to mixtapeImages.take(4),
+                AutoBrowseContract.DISCOVER_DRIVE_PICKS_ID to
+                    (queueImages + subscriptionImages).take(4),
+                AutoBrowseContract.DISCOVER_TIME_PICKS_ID to emptyList(),
+                AutoBrowseContract.DISCOVER_GENRES_ID to emptyList(),
             )
-            session?.notifyChildrenChanged(AutoBrowseContract.DISCOVER_ID, 3, null)
-            session?.notifyChildrenChanged(AutoBrowseContract.HOME_CONTINUE_ID, resumeItems.size, null)
-        } catch (error: Exception) {
-            Log.w("AutoBrowse", "Unable to prewarm Android Auto artwork", error)
         }
+
+        fun folderContentKeys(mixtape: MixtapeEngine.Result): Map<String, List<String>> =
+            mapOf(
+                AutoBrowseContract.HOME_ID to history.take(4).map { it.episodeId },
+                AutoBrowseContract.LIBRARY_ID to subscriptions.take(4).map { it.podcastId },
+                AutoBrowseContract.DOWNLOADS_ID to downloads.map { it.episodeId },
+                AutoBrowseContract.DISCOVER_ID to
+                    subscriptions.asReversed().take(4).map { it.podcastId },
+                AutoBrowseContract.HOME_CONTINUE_ID to resumeItems.map { it.episodeId },
+                AutoBrowseContract.HOME_QUEUE_ID to queue.map { it.id },
+                AutoBrowseContract.HOME_NEW_EPISODES_ID to newEpisodeKeys.take(4),
+                AutoBrowseContract.HOME_DRIVE_MIX_ID to mixtape.episodes.map { it.id },
+                AutoBrowseContract.DISCOVER_DRIVE_PICKS_ID to
+                    (queue.map { it.id } + subscriptions.map { it.podcastId }).take(4),
+                AutoBrowseContract.DISCOVER_TIME_PICKS_ID to
+                    listOf(AutoBrowseContract.DISCOVER_TIME_PICKS_ID),
+                AutoBrowseContract.DISCOVER_GENRES_ID to
+                    listOf(AutoBrowseContract.DISCOVER_GENRES_ID),
+            )
     }
 
     companion object {

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollagePrewarmer.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollagePrewarmer.kt
@@ -10,6 +10,8 @@ import cx.aswin.boxlore.core.database.ListeningHistoryEntity
 import cx.aswin.boxlore.core.database.PodcastEntity
 import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.core.playback.AutoCollageFolderLogic
+import cx.aswin.boxlore.core.playback.AutoCollagePrewarmPolicy
 import cx.aswin.boxlore.core.playback.MixtapeEngine
 import cx.aswin.boxlore.core.playback.QueueRepository
 import cx.aswin.boxlore.core.playback.SmartQueueSources
@@ -39,12 +41,12 @@ internal class AutoCollagePrewarmer(
 
     suspend fun prewarm(force: Boolean = false) {
         val now = System.currentTimeMillis()
-        if (!force && now - lastPrewarmAtMs.get() < MIN_REFRESH_INTERVAL_MS) {
+        if (!AutoCollagePrewarmPolicy.shouldRun(force, lastPrewarmAtMs.get(), now)) {
             return
         }
         mutex.withLock {
             val lockedNow = System.currentTimeMillis()
-            if (!force && lockedNow - lastPrewarmAtMs.get() < MIN_REFRESH_INTERVAL_MS) {
+            if (!AutoCollagePrewarmPolicy.shouldRun(force, lastPrewarmAtMs.get(), lockedNow)) {
                 return
             }
             runPrewarm()
@@ -56,11 +58,12 @@ internal class AutoCollagePrewarmer(
         try {
             val snapshot = loadSnapshot()
             val mixtape = resolveMixtape(snapshot)
+            val folders = snapshot.buildFolderInputs(mixtape)
             val uris =
                 AutoCollageGenerator.generateAllCollages(
                     context = context,
-                    folderImages = snapshot.folderImages(mixtape),
-                    folderContentKeys = snapshot.folderContentKeys(mixtape),
+                    folderImages = folders.mapValues { AutoCollageFolderLogic.imagesOf(it.value) },
+                    folderContentKeys = folders.mapValues { AutoCollageFolderLogic.keysOf(it.value) },
                 )
             onCollagesReady(uris)
             notifyBrowseTree(snapshot.subscriptions.size, snapshot.resumeItems.size)
@@ -144,67 +147,70 @@ internal class AutoCollagePrewarmer(
         val downloads: List<DownloadedEpisodeEntity>,
         val queue: List<Episode>,
     ) {
-        private val historyImages =
-            history.mapNotNull { it.episodeImageUrl ?: it.podcastImageUrl }
-        private val resumeImages =
-            resumeItems.mapNotNull { it.episodeImageUrl ?: it.podcastImageUrl }
-        private val subscriptionImages = subscriptions.mapNotNull { it.imageUrl }
-        private val downloadImages =
-            downloads.mapNotNull { it.episodeImageUrl ?: it.podcastImageUrl }
-        private val queueImages = queue.mapNotNull { it.imageUrl ?: it.podcastImageUrl }
-        private val newEpisodeImages =
-            subscriptions.mapNotNull { it.latestEpisode?.imageUrl ?: it.imageUrl }
-        private val newEpisodeKeys =
-            subscriptions.mapNotNull { podcast ->
-                podcast.latestEpisode?.id ?: podcast.podcastId.takeIf {
-                    podcast.latestEpisode != null || !podcast.imageUrl.isNullOrBlank()
+        fun buildFolderInputs(mixtape: MixtapeEngine.Result): Map<String, List<AutoCollageFolderLogic.ArtPair>> {
+            val historyPairs =
+                history.mapNotNull {
+                    AutoCollageFolderLogic.pairOrNull(
+                        it.episodeId,
+                        it.episodeImageUrl ?: it.podcastImageUrl,
+                    )
                 }
-            }
-
-        fun folderImages(mixtape: MixtapeEngine.Result): Map<String, List<String>> {
-            val mixtapeImages =
+            val resumePairs =
+                resumeItems.mapNotNull {
+                    AutoCollageFolderLogic.pairOrNull(
+                        it.episodeId,
+                        it.episodeImageUrl ?: it.podcastImageUrl,
+                    )
+                }
+            val subscriptionPairs =
+                subscriptions.mapNotNull {
+                    AutoCollageFolderLogic.pairOrNull(it.podcastId, it.imageUrl)
+                }
+            val downloadPairs =
+                downloads.mapNotNull {
+                    AutoCollageFolderLogic.pairOrNull(
+                        it.episodeId,
+                        it.episodeImageUrl ?: it.podcastImageUrl,
+                    )
+                }
+            val queuePairs =
+                queue.mapNotNull {
+                    AutoCollageFolderLogic.pairOrNull(it.id, it.imageUrl ?: it.podcastImageUrl)
+                }
+            val newEpisodePairs =
+                subscriptions.mapNotNull { podcast ->
+                    val episode = podcast.latestEpisode
+                    AutoCollageFolderLogic.pairOrNull(
+                        episode?.id ?: podcast.podcastId,
+                        episode?.imageUrl ?: podcast.imageUrl,
+                    )
+                }
+            val mixtapePairs =
                 mixtape.podcasts.mapNotNull { podcast ->
-                    podcast.latestEpisode?.let { episode ->
-                        episode.imageUrl ?: episode.podcastImageUrl ?: podcast.imageUrl
-                    }
+                    val episode = podcast.latestEpisode ?: return@mapNotNull null
+                    AutoCollageFolderLogic.pairOrNull(
+                        episode.id,
+                        episode.imageUrl ?: episode.podcastImageUrl ?: podcast.imageUrl,
+                    )
                 }
+            val drivePairs =
+                AutoCollageFolderLogic.takeAligned(queuePairs + subscriptionPairs)
             return mapOf(
-                AutoBrowseContract.HOME_ID to (historyImages + newEpisodeImages).take(4),
-                AutoBrowseContract.LIBRARY_ID to subscriptionImages.take(4),
-                AutoBrowseContract.DOWNLOADS_ID to downloadImages.take(4),
-                AutoBrowseContract.DISCOVER_ID to subscriptionImages.asReversed().take(4),
-                AutoBrowseContract.HOME_CONTINUE_ID to resumeImages.take(4),
-                AutoBrowseContract.HOME_QUEUE_ID to queueImages.take(4),
-                AutoBrowseContract.HOME_NEW_EPISODES_ID to newEpisodeImages.take(4),
-                AutoBrowseContract.HOME_DRIVE_MIX_ID to mixtapeImages.take(4),
-                AutoBrowseContract.DISCOVER_DRIVE_PICKS_ID to
-                    (queueImages + subscriptionImages).take(4),
+                AutoBrowseContract.HOME_ID to
+                    AutoCollageFolderLogic.takeAligned(historyPairs + newEpisodePairs),
+                AutoBrowseContract.LIBRARY_ID to AutoCollageFolderLogic.takeAligned(subscriptionPairs),
+                AutoBrowseContract.DOWNLOADS_ID to AutoCollageFolderLogic.takeAligned(downloadPairs),
+                AutoBrowseContract.DISCOVER_ID to
+                    AutoCollageFolderLogic.takeAligned(subscriptionPairs.asReversed()),
+                AutoBrowseContract.HOME_CONTINUE_ID to AutoCollageFolderLogic.takeAligned(resumePairs),
+                AutoBrowseContract.HOME_QUEUE_ID to AutoCollageFolderLogic.takeAligned(queuePairs),
+                AutoBrowseContract.HOME_NEW_EPISODES_ID to
+                    AutoCollageFolderLogic.takeAligned(newEpisodePairs),
+                AutoBrowseContract.HOME_DRIVE_MIX_ID to AutoCollageFolderLogic.takeAligned(mixtapePairs),
+                AutoBrowseContract.DISCOVER_DRIVE_PICKS_ID to drivePairs,
                 AutoBrowseContract.DISCOVER_TIME_PICKS_ID to emptyList(),
                 AutoBrowseContract.DISCOVER_GENRES_ID to emptyList(),
             )
         }
-
-        fun folderContentKeys(mixtape: MixtapeEngine.Result): Map<String, List<String>> =
-            mapOf(
-                AutoBrowseContract.HOME_ID to history.take(4).map { it.episodeId },
-                AutoBrowseContract.LIBRARY_ID to subscriptions.take(4).map { it.podcastId },
-                AutoBrowseContract.DOWNLOADS_ID to downloads.map { it.episodeId },
-                AutoBrowseContract.DISCOVER_ID to
-                    subscriptions.asReversed().take(4).map { it.podcastId },
-                AutoBrowseContract.HOME_CONTINUE_ID to resumeItems.map { it.episodeId },
-                AutoBrowseContract.HOME_QUEUE_ID to queue.map { it.id },
-                AutoBrowseContract.HOME_NEW_EPISODES_ID to newEpisodeKeys.take(4),
-                AutoBrowseContract.HOME_DRIVE_MIX_ID to mixtape.episodes.map { it.id },
-                AutoBrowseContract.DISCOVER_DRIVE_PICKS_ID to
-                    (queue.map { it.id } + subscriptions.map { it.podcastId }).take(4),
-                AutoBrowseContract.DISCOVER_TIME_PICKS_ID to
-                    listOf(AutoBrowseContract.DISCOVER_TIME_PICKS_ID),
-                AutoBrowseContract.DISCOVER_GENRES_ID to
-                    listOf(AutoBrowseContract.DISCOVER_GENRES_ID),
-            )
-    }
-
-    companion object {
-        private const val MIN_REFRESH_INTERVAL_MS = 30_000L
     }
 }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollagePrewarmer.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollagePrewarmer.kt
@@ -4,16 +4,19 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import androidx.media3.session.MediaLibraryService.MediaLibrarySession
+import cx.aswin.boxlore.core.database.BoxLoreDatabase
+import cx.aswin.boxlore.core.database.PodcastEntity
+import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.core.playback.MixtapeEngine
 import cx.aswin.boxlore.core.playback.QueueRepository
 import cx.aswin.boxlore.core.playback.SmartQueueSources
-import cx.aswin.boxlore.core.database.BoxLoreDatabase
-import cx.aswin.boxlore.core.database.PodcastEntity
+import cx.aswin.boxlore.core.playback.service.auto.AutoBrowseContract
 import cx.aswin.boxlore.core.ranking.AdaptiveCandidateScorer
 import cx.aswin.boxlore.core.ranking.RankingSurface
-import cx.aswin.boxlore.core.playback.service.auto.AutoBrowseContract
-import cx.aswin.boxlore.core.model.Podcast
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Prewarms Android Auto folder collage artwork for [BoxLorePlaybackService].
@@ -28,7 +31,25 @@ internal class AutoCollagePrewarmer(
     private val mediaSessionProvider: () -> MediaLibrarySession?,
     private val onCollagesReady: (Map<String, Uri>) -> Unit,
 ) {
-    suspend fun prewarm() {
+    private val mutex = Mutex()
+    private val lastPrewarmAtMs = AtomicLong(0L)
+
+    suspend fun prewarm(force: Boolean = false) {
+        val now = System.currentTimeMillis()
+        if (!force && now - lastPrewarmAtMs.get() < MIN_REFRESH_INTERVAL_MS) {
+            return
+        }
+        mutex.withLock {
+            val lockedNow = System.currentTimeMillis()
+            if (!force && lockedNow - lastPrewarmAtMs.get() < MIN_REFRESH_INTERVAL_MS) {
+                return
+            }
+            runPrewarm()
+            lastPrewarmAtMs.set(System.currentTimeMillis())
+        }
+    }
+
+    private suspend fun runPrewarm() {
         try {
             val history = database.listeningHistoryDao().getRecentHistoryList(300)
             val resumeItems = database.listeningHistoryDao().getResumeItemsList()
@@ -94,6 +115,12 @@ internal class AutoCollagePrewarmer(
                         episode.imageUrl ?: episode.podcastImageUrl ?: podcast.imageUrl
                     }
                 }
+            val newEpisodeKeys =
+                subscriptions.mapNotNull { podcast ->
+                    podcast.latestEpisode?.id ?: podcast.podcastId.takeIf {
+                        podcast.latestEpisode != null || !podcast.imageUrl.isNullOrBlank()
+                    }
+                }
             val uris =
                 AutoCollageGenerator.generateAllCollages(
                     context = context,
@@ -114,10 +141,31 @@ internal class AutoCollagePrewarmer(
                         ),
                     folderContentKeys =
                         mapOf(
+                            AutoBrowseContract.HOME_ID to
+                                history.take(4).map { it.episodeId },
+                            AutoBrowseContract.LIBRARY_ID to
+                                subscriptions.take(4).map { it.podcastId },
+                            AutoBrowseContract.DOWNLOADS_ID to
+                                downloads.map { it.episodeId },
+                            AutoBrowseContract.DISCOVER_ID to
+                                subscriptions.asReversed().take(4).map { it.podcastId },
                             AutoBrowseContract.HOME_CONTINUE_ID to
                                 resumeItems.map { it.episodeId },
+                            AutoBrowseContract.HOME_QUEUE_ID to
+                                queue.map { it.id },
+                            AutoBrowseContract.HOME_NEW_EPISODES_ID to
+                                newEpisodeKeys.take(4),
                             AutoBrowseContract.HOME_DRIVE_MIX_ID to
                                 mixtape.episodes.map { it.id },
+                            AutoBrowseContract.DISCOVER_DRIVE_PICKS_ID to
+                                (
+                                    queue.map { it.id } +
+                                        subscriptions.map { it.podcastId }
+                                ).take(4),
+                            AutoBrowseContract.DISCOVER_TIME_PICKS_ID to
+                                listOf(AutoBrowseContract.DISCOVER_TIME_PICKS_ID),
+                            AutoBrowseContract.DISCOVER_GENRES_ID to
+                                listOf(AutoBrowseContract.DISCOVER_GENRES_ID),
                         ),
                 )
             onCollagesReady(uris)
@@ -130,8 +178,13 @@ internal class AutoCollagePrewarmer(
                 null,
             )
             session?.notifyChildrenChanged(AutoBrowseContract.DISCOVER_ID, 3, null)
+            session?.notifyChildrenChanged(AutoBrowseContract.HOME_CONTINUE_ID, resumeItems.size, null)
         } catch (error: Exception) {
             Log.w("AutoBrowse", "Unable to prewarm Android Auto artwork", error)
         }
+    }
+
+    companion object {
+        private const val MIN_REFRESH_INTERVAL_MS = 30_000L
     }
 }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageProvider.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageProvider.kt
@@ -8,8 +8,6 @@ import android.os.ParcelFileDescriptor
 import cx.aswin.boxlore.core.playback.AutoArtworkFetchLogic
 import cx.aswin.boxlore.core.playback.service.auto.AutoArtworkSourceStore
 import java.io.File
-import java.net.HttpURLConnection
-import java.net.InetAddress
 import java.net.URL
 import java.util.concurrent.ConcurrentHashMap
 
@@ -136,9 +134,9 @@ open class AutoCollageProvider : ContentProvider() {
             AutoArtworkSourceStore.get(context, key)
                 ?: return null
         val sourceUrl =
-            runCatching { java.net.URI(source).toURL() }
-                .getOrNull()
-                ?.takeIf(::isPublicHttpsUrl)
+            AutoArtworkDownloader
+                .parseHttpsUrl(source)
+                ?.takeIf(AutoArtworkDownloader::isPublicHttpsUrl)
                 ?: return null
         val lock = artworkLocks.getOrPut(key) { Any() }
         return try {
@@ -160,7 +158,7 @@ open class AutoCollageProvider : ContentProvider() {
     ): File? {
         val temp = File.createTempFile("artwork_", ".tmp", cacheDir)
         return try {
-            val bytes = downloadArtworkBytes(url) ?: return null
+            val bytes = AutoArtworkDownloader.downloadHttpsBytes(url) ?: return null
             if (!AutoArtworkFetchLogic.looksLikeImage(bytes.copyOf(minOf(12, bytes.size)))) {
                 return null
             }
@@ -190,79 +188,6 @@ open class AutoCollageProvider : ContentProvider() {
                 android.util.Log.w("CollageProvider", "Failed to delete temp file")
             }
         }
-    }
-
-    private fun downloadArtworkBytes(startUrl: URL): ByteArray? {
-        var current = startUrl
-        var redirects = 0
-        while (redirects <= AutoArtworkFetchLogic.MAX_REDIRECTS) {
-            if (!isPublicHttpsUrl(current)) return null
-            var connection: HttpURLConnection? = null
-            try {
-                connection = current.openConnection() as HttpURLConnection
-                connection.instanceFollowRedirects = false
-                connection.connectTimeout = AutoArtworkFetchLogic.CONNECT_TIMEOUT_MS
-                connection.readTimeout = AutoArtworkFetchLogic.READ_TIMEOUT_MS
-                connection.doInput = true
-                connection.connect()
-                val code = connection.responseCode
-                if (AutoArtworkFetchLogic.isRedirect(code)) {
-                    val location = connection.getHeaderField("Location") ?: return null
-                    val next =
-                        runCatching { java.net.URI(current.toURI().resolve(location).toString()).toURL() }
-                            .getOrNull()
-                            ?: return null
-                    redirects += 1
-                    current = next
-                    continue
-                }
-                val contentLength = connection.contentLengthLong
-                val contentType = connection.contentType
-                if (!AutoArtworkFetchLogic.shouldAcceptArtwork(code, contentType, contentLength)) {
-                    return null
-                }
-                return connection.inputStream.use { input ->
-                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                    val out = java.io.ByteArrayOutputStream()
-                    var total = 0L
-                    while (true) {
-                        val read = input.read(buffer)
-                        if (read < 0) break
-                        total += read
-                        if (total > AutoArtworkFetchLogic.MAX_ARTWORK_BYTES) return@use null
-                        out.write(buffer, 0, read)
-                    }
-                    out.toByteArray().takeIf { it.isNotEmpty() }
-                }
-            } catch (error: Exception) {
-                android.util.Log.w("CollageProvider", "Artwork download failed for $current", error)
-                return null
-            } finally {
-                connection?.disconnect()
-            }
-        }
-        return null
-    }
-
-    private fun isPublicHttpsUrl(url: URL): Boolean {
-        if (url.protocol != "https" || (url.port != -1 && url.port != 443)) return false
-        val addresses =
-            runCatching { InetAddress.getAllByName(url.host) }.getOrNull()
-                ?: return false
-        return addresses.isNotEmpty() &&
-            addresses.all { address ->
-                !address.isAnyLocalAddress &&
-                    !address.isLoopbackAddress &&
-                    !address.isLinkLocalAddress &&
-                    !address.isSiteLocalAddress &&
-                    !address.isMulticastAddress &&
-                    !address.isUniqueLocalIpv6()
-            }
-    }
-
-    private fun InetAddress.isUniqueLocalIpv6(): Boolean {
-        val bytes = address
-        return bytes.size == 16 && (bytes[0].toInt() and 0xFE) == 0xFC
     }
 
     private fun resolveCollage(

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageProvider.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageProvider.kt
@@ -139,15 +139,12 @@ open class AutoCollageProvider : ContentProvider() {
                 ?.takeIf(AutoArtworkDownloader::isPublicHttpsUrl)
                 ?: return null
         val lock = artworkLocks.getOrPut(key) { Any() }
-        return try {
-            synchronized(lock) {
-                cachedRemoteArtwork(context, key)?.let { return@synchronized it }
-                // One retry covers flaky CDNs / brief Auto host pipe races.
-                fetchRemoteArtwork(sourceUrl, cacheDir, target)
-                    ?: fetchRemoteArtwork(sourceUrl, cacheDir, target)
-            }
-        } finally {
-            artworkLocks.remove(key)
+        return synchronized(lock) {
+            cachedRemoteArtwork(context, key)?.let { return@synchronized it }
+            // One retry covers flaky CDNs / brief Auto host pipe races.
+            // Keep the lock stripe resident so concurrent openers share the same monitor.
+            fetchRemoteArtwork(sourceUrl, cacheDir, target)
+                ?: fetchRemoteArtwork(sourceUrl, cacheDir, target)
         }
     }
 

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageProvider.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/AutoCollageProvider.kt
@@ -5,6 +5,8 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import cx.aswin.boxlore.core.playback.AutoArtworkFetchLogic
+import cx.aswin.boxlore.core.playback.service.auto.AutoArtworkSourceStore
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.InetAddress
@@ -20,8 +22,6 @@ import java.util.concurrent.ConcurrentHashMap
  */
 open class AutoCollageProvider : ContentProvider() {
     companion object {
-        private const val SOURCE_PREFS = "android_auto_artwork_sources"
-        private const val MAX_ARTWORK_BYTES = 8L * 1024L * 1024L
         private const val MAX_CACHE_BYTES = 64L * 1024L * 1024L
         private const val MAX_CACHE_FILES = 200
         private val artworkLocks = ConcurrentHashMap<String, Any>()
@@ -30,14 +30,20 @@ open class AutoCollageProvider : ContentProvider() {
         fun getUri(
             context: android.content.Context,
             filename: String,
-        ): Uri =
-            Uri
-                .Builder()
-                .scheme("content")
-                .authority("${context.packageName}.collage")
-                .appendPath("collage")
-                .appendPath(filename)
-                .build()
+            version: String? = null,
+        ): Uri {
+            val builder =
+                Uri
+                    .Builder()
+                    .scheme("content")
+                    .authority("${context.packageName}.collage")
+                    .appendPath("collage")
+                    .appendPath(filename)
+            if (!version.isNullOrBlank()) {
+                builder.appendQueryParameter("v", version)
+            }
+            return builder.build()
+        }
     }
 
     override fun onCreate(): Boolean = true
@@ -104,7 +110,17 @@ open class AutoCollageProvider : ContentProvider() {
         if (!key.matches(HEX_64_PATTERN)) return null
         val cacheDir = File(context.cacheDir, "auto_artwork").apply { mkdirs() }
         return childFile(cacheDir, key)
-            ?.takeIf { it.isFile && it.length() in 1..MAX_ARTWORK_BYTES }
+            ?.takeIf { candidate ->
+                if (!candidate.isFile) return@takeIf false
+                val valid =
+                    candidate.length() in 1..AutoArtworkFetchLogic.MAX_ARTWORK_BYTES &&
+                        AutoArtworkFetchLogic.looksLikeImage(candidate.readHeader(12))
+                if (!valid) {
+                    // Drop corrupt / non-image leftovers so the next open retries the CDN.
+                    candidate.delete()
+                }
+                valid
+            }
     }
 
     private fun getOrFetchRemoteArtwork(
@@ -114,57 +130,26 @@ open class AutoCollageProvider : ContentProvider() {
         if (!key.matches(HEX_64_PATTERN)) return null
         val cacheDir = File(context.cacheDir, "auto_artwork").apply { mkdirs() }
         val target = childFile(cacheDir, key) ?: return null
-        if (target.isFile && target.length() in 1..MAX_ARTWORK_BYTES) return target
+        cachedRemoteArtwork(context, key)?.let { return it }
 
         val source =
-            context
-                .getSharedPreferences(SOURCE_PREFS, android.content.Context.MODE_PRIVATE)
-                .getString(key, null)
+            AutoArtworkSourceStore.get(context, key)
                 ?: return null
         val sourceUrl =
             runCatching { java.net.URI(source).toURL() }
                 .getOrNull()
                 ?.takeIf(::isPublicHttpsUrl)
                 ?: return null
-        return synchronized(artworkLocks.getOrPut(key) { Any() }) {
-            if (target.isFile && target.length() in 1..MAX_ARTWORK_BYTES) {
-                return@synchronized target
-            }
-            fetchRemoteArtwork(sourceUrl, cacheDir, target).also {
-                artworkLocks.remove(key)
-            }
-        }
-    }
-
-    private fun verifyConnection(connection: HttpURLConnection): Boolean {
-        val contentLength = connection.contentLengthLong
-        val contentType = connection.contentType.orEmpty().lowercase()
-        return connection.responseCode in 200..299 &&
-            contentType.startsWith("image/") &&
-            contentLength <= MAX_ARTWORK_BYTES
-    }
-
-    private fun downloadStream(
-        connection: HttpURLConnection,
-        temp: File,
-    ): Boolean {
+        val lock = artworkLocks.getOrPut(key) { Any() }
         return try {
-            connection.inputStream.use { input ->
-                temp.outputStream().use { output ->
-                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                    var totalBytes = 0L
-                    while (true) {
-                        val read = input.read(buffer)
-                        if (read < 0) break
-                        totalBytes += read
-                        if (totalBytes > MAX_ARTWORK_BYTES) return false
-                        output.write(buffer, 0, read)
-                    }
-                }
+            synchronized(lock) {
+                cachedRemoteArtwork(context, key)?.let { return@synchronized it }
+                // One retry covers flaky CDNs / brief Auto host pipe races.
+                fetchRemoteArtwork(sourceUrl, cacheDir, target)
+                    ?: fetchRemoteArtwork(sourceUrl, cacheDir, target)
             }
-            temp.length() > 0L
-        } catch (e: Exception) {
-            false
+        } finally {
+            artworkLocks.remove(key)
         }
     }
 
@@ -174,18 +159,13 @@ open class AutoCollageProvider : ContentProvider() {
         target: File,
     ): File? {
         val temp = File.createTempFile("artwork_", ".tmp", cacheDir)
-        var connection: HttpURLConnection? = null
         return try {
-            connection = url.openConnection() as HttpURLConnection
-            connection.connectTimeout = 4_000
-            connection.readTimeout = 5_000
-            connection.instanceFollowRedirects = false
-            connection.doInput = true
-            connection.connect()
-
-            if (!verifyConnection(connection) || !downloadStream(connection, temp)) {
+            val bytes = downloadArtworkBytes(url) ?: return null
+            if (!AutoArtworkFetchLogic.looksLikeImage(bytes.copyOf(minOf(12, bytes.size)))) {
                 return null
             }
+            temp.outputStream().use { it.write(bytes) }
+            if (temp.length() <= 0L) return null
 
             if (!temp.renameTo(target)) {
                 val staging = File.createTempFile("artwork_stage_", ".tmp", target.parentFile)
@@ -206,11 +186,62 @@ open class AutoCollageProvider : ContentProvider() {
             android.util.Log.w("CollageProvider", "Failed to cache artwork", error)
             null
         } finally {
-            connection?.disconnect()
             if (temp.exists() && !temp.delete()) {
                 android.util.Log.w("CollageProvider", "Failed to delete temp file")
             }
         }
+    }
+
+    private fun downloadArtworkBytes(startUrl: URL): ByteArray? {
+        var current = startUrl
+        var redirects = 0
+        while (redirects <= AutoArtworkFetchLogic.MAX_REDIRECTS) {
+            if (!isPublicHttpsUrl(current)) return null
+            var connection: HttpURLConnection? = null
+            try {
+                connection = current.openConnection() as HttpURLConnection
+                connection.instanceFollowRedirects = false
+                connection.connectTimeout = AutoArtworkFetchLogic.CONNECT_TIMEOUT_MS
+                connection.readTimeout = AutoArtworkFetchLogic.READ_TIMEOUT_MS
+                connection.doInput = true
+                connection.connect()
+                val code = connection.responseCode
+                if (AutoArtworkFetchLogic.isRedirect(code)) {
+                    val location = connection.getHeaderField("Location") ?: return null
+                    val next =
+                        runCatching { java.net.URI(current.toURI().resolve(location).toString()).toURL() }
+                            .getOrNull()
+                            ?: return null
+                    redirects += 1
+                    current = next
+                    continue
+                }
+                val contentLength = connection.contentLengthLong
+                val contentType = connection.contentType
+                if (!AutoArtworkFetchLogic.shouldAcceptArtwork(code, contentType, contentLength)) {
+                    return null
+                }
+                return connection.inputStream.use { input ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    val out = java.io.ByteArrayOutputStream()
+                    var total = 0L
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        total += read
+                        if (total > AutoArtworkFetchLogic.MAX_ARTWORK_BYTES) return@use null
+                        out.write(buffer, 0, read)
+                    }
+                    out.toByteArray().takeIf { it.isNotEmpty() }
+                }
+            } catch (error: Exception) {
+                android.util.Log.w("CollageProvider", "Artwork download failed for $current", error)
+                return null
+            } finally {
+                connection?.disconnect()
+            }
+        }
+        return null
     }
 
     private fun isPublicHttpsUrl(url: URL): Boolean {
@@ -247,11 +278,7 @@ open class AutoCollageProvider : ContentProvider() {
         key: String,
     ): File? {
         if (!key.matches(HEX_64_PATTERN)) return null
-        val path =
-            context
-                .getSharedPreferences(SOURCE_PREFS, android.content.Context.MODE_PRIVATE)
-                .getString(key, null)
-                ?: return null
+        val path = AutoArtworkSourceStore.get(context, key) ?: return null
         val candidate = runCatching { File(path).canonicalFile }.getOrNull() ?: return null
         val roots =
             listOfNotNull(
@@ -302,6 +329,13 @@ open class AutoCollageProvider : ContentProvider() {
             if (oldest.delete()) totalBytes -= size
         }
     }
+
+    private fun File.readHeader(maxBytes: Int): ByteArray =
+        inputStream().use { input ->
+            val buffer = ByteArray(maxBytes)
+            val read = input.read(buffer)
+            if (read <= 0) byteArrayOf() else buffer.copyOf(read)
+        }
 
     // Unused but required
     override fun query(

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/BoxLorePlaybackService.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/BoxLorePlaybackService.kt
@@ -878,6 +878,7 @@ open class BoxLorePlaybackService :
                             )
                         database.listeningHistoryDao().upsert(updated)
                         android.util.Log.d("BoxLorePlaybackService", "Marked current episode completed: $episodeId")
+                        requestAutoCollageRefresh(force = true)
 
                         telemetrySession.trackManualCompletion(
                             episodeId = episodeId,

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/BoxLorePlaybackService.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/BoxLorePlaybackService.kt
@@ -32,6 +32,10 @@ open class BoxLorePlaybackService :
     AutoBrowseLibraryHost {
     override fun asContext(): android.content.Context = this
 
+    override fun requestAutoCollageRefresh(force: Boolean) {
+        serviceScope.launch { autoCollagePrewarmer.prewarm(force = force) }
+    }
+
     override var mediaSession: MediaLibrarySession? = null
         protected set
     private var exoPlayer: ExoPlayer? = null
@@ -92,10 +96,11 @@ open class BoxLorePlaybackService :
         )
     }
     override val queueRepository by lazy {
-        cx.aswin.boxlore.core.playback.QueueRepository(database, podcastRepository)
+        cx.aswin.boxlore.core.playback
+            .QueueRepository(database, podcastRepository)
     }
     override var isRefilling = false
-    private val QUEUE_MAX_SIZE = 50
+    private val queueMaxSize = 50
     private val smartQueueRefillCoordinator by lazy {
         SmartQueueRefillCoordinator(
             database = database,
@@ -106,7 +111,7 @@ open class BoxLorePlaybackService :
             mainDispatcher = mainDispatcher,
             ioDispatcher = ioDispatcher,
             findPodcastIdForEpisode = ::findPodcastIdForEpisode,
-            queueMaxSize = QUEUE_MAX_SIZE,
+            queueMaxSize = queueMaxSize,
             mediaIdPrefixStripper = cx.aswin.boxlore.core.playback.SmartQueueRefillPolicy::stripQueuePrefixes,
         )
     }
@@ -189,7 +194,9 @@ open class BoxLorePlaybackService :
             adaptiveCandidateScorer = adaptiveCandidateScorer,
             toAutoPodcast = ::toAutoPodcast,
             mediaSessionProvider = { mediaSession },
-            onCollagesReady = { autoCollageUris = it },
+            onCollagesReady = { fresh ->
+                autoCollageUris = autoCollageUris + fresh
+            },
         )
     }
 
@@ -726,6 +733,8 @@ open class BoxLorePlaybackService :
         database.listeningHistoryDao().upsert(completed)
         mediaSession?.notifyChildrenChanged(AutoBrowseContract.HOME_CONTINUE_ID, 20, null)
         mediaSession?.notifyChildrenChanged(AutoBrowseContract.LIBRARY_HISTORY_ID, 50, null)
+        // Resume / Home collage tiles must track completed episodes, not stay on a stale PNG.
+        requestAutoCollageRefresh(force = true)
     }
 
     override fun observeManualCompletion(episodeId: String) {

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkRepository.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkRepository.kt
@@ -22,7 +22,7 @@ internal object AutoArtworkRepository {
         val normalized = source.replaceFirst("http://", "https://")
         if (!normalized.startsWith("https://")) return null
         val key = normalized.sha256()
-        AutoArtworkSourceStore.put(context, key, normalized)
+        if (!AutoArtworkSourceStore.put(context, key, normalized)) return null
         return Uri
             .Builder()
             .scheme("content")
@@ -46,7 +46,7 @@ internal object AutoArtworkRepository {
             ).mapNotNull { runCatching(it::getCanonicalFile).getOrNull() }
         if (allowedRoots.none { canonicalFile.isInside(it) } || !canonicalFile.isFile) return null
         val key = canonicalFile.path.sha256()
-        AutoArtworkSourceStore.put(context, key, canonicalFile.path)
+        if (!AutoArtworkSourceStore.put(context, key, canonicalFile.path)) return null
         return Uri
             .Builder()
             .scheme("content")

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkRepository.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkRepository.kt
@@ -6,8 +6,6 @@ import java.io.File
 import java.security.MessageDigest
 
 internal object AutoArtworkRepository {
-    private const val SOURCE_PREFS = "android_auto_artwork_sources"
-
     fun remoteUri(
         context: Context,
         remoteUrl: String?,
@@ -24,11 +22,7 @@ internal object AutoArtworkRepository {
         val normalized = source.replaceFirst("http://", "https://")
         if (!normalized.startsWith("https://")) return null
         val key = normalized.sha256()
-        context
-            .getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
-            .edit()
-            .putString(key, normalized)
-            .apply()
+        AutoArtworkSourceStore.put(context, key, normalized)
         return Uri
             .Builder()
             .scheme("content")
@@ -52,11 +46,7 @@ internal object AutoArtworkRepository {
             ).mapNotNull { runCatching(it::getCanonicalFile).getOrNull() }
         if (allowedRoots.none { canonicalFile.isInside(it) } || !canonicalFile.isFile) return null
         val key = canonicalFile.path.sha256()
-        context
-            .getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
-            .edit()
-            .putString(key, canonicalFile.path)
-            .apply()
+        AutoArtworkSourceStore.put(context, key, canonicalFile.path)
         return Uri
             .Builder()
             .scheme("content")
@@ -69,17 +59,29 @@ internal object AutoArtworkRepository {
     fun collageUri(
         context: Context,
         folderId: String,
+        version: String? = null,
     ): Uri? {
         val filename = "${folderId.safeFileName()}.png"
-        val file = File(File(context.cacheDir, "auto_collages"), filename)
+        val collageDir = File(context.cacheDir, "auto_collages")
+        val file = File(collageDir, filename)
         if (!file.exists()) return null
-        return Uri
-            .Builder()
-            .scheme("content")
-            .authority("${context.packageName}.collage")
-            .appendPath("collage")
-            .appendPath(filename)
-            .build()
+        val cacheBuster =
+            version?.takeIf { it.isNotBlank() }
+                ?: File(collageDir, "${folderId.safeFileName()}.signature")
+                    .takeIf { it.isFile }
+                    ?.readText()
+                    ?.takeIf { it.isNotBlank() }
+        val builder =
+            Uri
+                .Builder()
+                .scheme("content")
+                .authority("${context.packageName}.collage")
+                .appendPath("collage")
+                .appendPath(filename)
+        if (!cacheBuster.isNullOrBlank()) {
+            builder.appendQueryParameter("v", cacheBuster)
+        }
+        return builder.build()
     }
 
     private fun String.safeFileName(): String = replace(Regex("[^a-zA-Z0-9_]"), "_")

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
@@ -53,7 +53,13 @@ internal object AutoArtworkSourceStore {
                 done.countDown()
             }
         }
-        val finished = done.await(COMMIT_WAIT_MS, TimeUnit.MILLISECONDS)
+        val finished =
+            try {
+                done.await(COMMIT_WAIT_MS, TimeUnit.MILLISECONDS)
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
+                false
+            }
         if (!finished || !committed.get()) {
             memory.remove(key, value)
             Log.w(

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
@@ -6,13 +6,15 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Durable + immediately-visible registry of Android Auto artwork source URLs/paths.
  *
  * An in-process map makes sources visible to [cx.aswin.boxlore.core.playback.service.AutoCollageProvider]
  * as soon as [AutoArtworkRepository] returns a URI. Prefs are [commit]ted on a background thread;
- * [put] waits briefly so the mapping is usually durable before the content URI is handed to Auto.
+ * [put] waits briefly and only reports success when that commit lands, so callers can avoid handing
+ * Auto a content URI that would not survive process restart.
  */
 internal object AutoArtworkSourceStore {
     const val SOURCE_PREFS = "android_auto_artwork_sources"
@@ -25,28 +27,42 @@ internal object AutoArtworkSourceStore {
             Thread(runnable, "auto-artwork-prefs").apply { isDaemon = true }
         }
 
+    /**
+     * @return true when the in-memory mapping is published and prefs [commit] succeeded
+     * within [COMMIT_WAIT_MS].
+     */
     fun put(
         context: Context,
         key: String,
         value: String,
-    ) {
+    ): Boolean {
         memory[key] = value
         val appContext = context.applicationContext
+        val committed = AtomicBoolean(false)
         val done = CountDownLatch(1)
         persistExecutor.execute {
             try {
-                appContext
-                    .getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
-                    .edit()
-                    .putString(key, value)
-                    .commit()
+                committed.set(
+                    appContext
+                        .getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
+                        .edit()
+                        .putString(key, value)
+                        .commit(),
+                )
             } finally {
                 done.countDown()
             }
         }
-        if (!done.await(COMMIT_WAIT_MS, TimeUnit.MILLISECONDS)) {
-            Log.w(TAG, "Artwork source commit still pending for key=$key")
+        val finished = done.await(COMMIT_WAIT_MS, TimeUnit.MILLISECONDS)
+        if (!finished || !committed.get()) {
+            memory.remove(key, value)
+            Log.w(
+                TAG,
+                "Artwork source commit failed/pending for key=$key finished=$finished committed=${committed.get()}",
+            )
+            return false
         }
+        return true
     }
 
     fun get(

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
@@ -2,19 +2,23 @@ package cx.aswin.boxlore.core.playback.service.auto
 
 import android.content.Context
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
 
 /**
  * Durable + immediately-visible registry of Android Auto artwork source URLs/paths.
  *
- * [SharedPreferences.apply] is asynchronous; Auto hosts often open a content URI before the
- * mapping lands on disk, which produced blank artwork. This store keeps an in-process map and
- * [commit]s prefs so [cx.aswin.boxlore.core.playback.service.AutoCollageProvider] can resolve
- * sources as soon as [AutoArtworkRepository] returns a URI.
+ * An in-process map makes sources visible to [cx.aswin.boxlore.core.playback.service.AutoCollageProvider]
+ * as soon as [AutoArtworkRepository] returns a URI. Prefs are [commit]ted on a background thread so
+ * browse-tree work on the main dispatcher is not blocked.
  */
 internal object AutoArtworkSourceStore {
     const val SOURCE_PREFS = "android_auto_artwork_sources"
 
     private val memory = ConcurrentHashMap<String, String>()
+    private val persistExecutor =
+        Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "auto-artwork-prefs").apply { isDaemon = true }
+        }
 
     fun put(
         context: Context,
@@ -22,9 +26,14 @@ internal object AutoArtworkSourceStore {
         value: String,
     ) {
         memory[key] = value
-        val prefs = context.getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
-        // commit() so a ContentProvider open that races the browse-tree build still resolves.
-        prefs.edit().putString(key, value).commit()
+        val appContext = context.applicationContext
+        persistExecutor.execute {
+            appContext
+                .getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
+                .edit()
+                .putString(key, value)
+                .commit()
+        }
     }
 
     fun get(
@@ -44,5 +53,12 @@ internal object AutoArtworkSourceStore {
     /** Test-only: clear in-memory overlay without wiping SharedPreferences. */
     internal fun clearMemoryForTests() {
         memory.clear()
+    }
+
+    /** Test-only: wait for queued prefs commits to finish. */
+    internal fun flushPersistsForTests() {
+        val done = java.util.concurrent.CountDownLatch(1)
+        persistExecutor.execute { done.countDown() }
+        done.await(2, java.util.concurrent.TimeUnit.SECONDS)
     }
 }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
@@ -1,18 +1,23 @@
 package cx.aswin.boxlore.core.playback.service.auto
 
 import android.content.Context
+import android.util.Log
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 /**
  * Durable + immediately-visible registry of Android Auto artwork source URLs/paths.
  *
  * An in-process map makes sources visible to [cx.aswin.boxlore.core.playback.service.AutoCollageProvider]
- * as soon as [AutoArtworkRepository] returns a URI. Prefs are [commit]ted on a background thread so
- * browse-tree work on the main dispatcher is not blocked.
+ * as soon as [AutoArtworkRepository] returns a URI. Prefs are [commit]ted on a background thread;
+ * [put] waits briefly so the mapping is usually durable before the content URI is handed to Auto.
  */
 internal object AutoArtworkSourceStore {
     const val SOURCE_PREFS = "android_auto_artwork_sources"
+    private const val TAG = "AutoArtworkSources"
+    private const val COMMIT_WAIT_MS = 500L
 
     private val memory = ConcurrentHashMap<String, String>()
     private val persistExecutor =
@@ -27,12 +32,20 @@ internal object AutoArtworkSourceStore {
     ) {
         memory[key] = value
         val appContext = context.applicationContext
+        val done = CountDownLatch(1)
         persistExecutor.execute {
-            appContext
-                .getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
-                .edit()
-                .putString(key, value)
-                .commit()
+            try {
+                appContext
+                    .getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
+                    .edit()
+                    .putString(key, value)
+                    .commit()
+            } finally {
+                done.countDown()
+            }
+        }
+        if (!done.await(COMMIT_WAIT_MS, TimeUnit.MILLISECONDS)) {
+            Log.w(TAG, "Artwork source commit still pending for key=$key")
         }
     }
 
@@ -57,8 +70,10 @@ internal object AutoArtworkSourceStore {
 
     /** Test-only: wait for queued prefs commits to finish. */
     internal fun flushPersistsForTests() {
-        val done = java.util.concurrent.CountDownLatch(1)
+        val done = CountDownLatch(1)
         persistExecutor.execute { done.countDown() }
-        done.await(2, java.util.concurrent.TimeUnit.SECONDS)
+        check(done.await(2, TimeUnit.SECONDS)) {
+            "Timed out waiting for Auto artwork prefs commits"
+        }
     }
 }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStore.kt
@@ -1,0 +1,48 @@
+package cx.aswin.boxlore.core.playback.service.auto
+
+import android.content.Context
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Durable + immediately-visible registry of Android Auto artwork source URLs/paths.
+ *
+ * [SharedPreferences.apply] is asynchronous; Auto hosts often open a content URI before the
+ * mapping lands on disk, which produced blank artwork. This store keeps an in-process map and
+ * [commit]s prefs so [cx.aswin.boxlore.core.playback.service.AutoCollageProvider] can resolve
+ * sources as soon as [AutoArtworkRepository] returns a URI.
+ */
+internal object AutoArtworkSourceStore {
+    const val SOURCE_PREFS = "android_auto_artwork_sources"
+
+    private val memory = ConcurrentHashMap<String, String>()
+
+    fun put(
+        context: Context,
+        key: String,
+        value: String,
+    ) {
+        memory[key] = value
+        val prefs = context.getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
+        // commit() so a ContentProvider open that races the browse-tree build still resolves.
+        prefs.edit().putString(key, value).commit()
+    }
+
+    fun get(
+        context: Context,
+        key: String,
+    ): String? {
+        memory[key]?.let { return it }
+        val persisted =
+            context
+                .getSharedPreferences(SOURCE_PREFS, Context.MODE_PRIVATE)
+                .getString(key, null)
+                ?: return null
+        memory[key] = persisted
+        return persisted
+    }
+
+    /** Test-only: clear in-memory overlay without wiping SharedPreferences. */
+    internal fun clearMemoryForTests() {
+        memory.clear()
+    }
+}

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoBrowseLibraryCallback.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoBrowseLibraryCallback.kt
@@ -196,6 +196,7 @@ internal class AutoBrowseLibraryCallback(
         )
         host.mediaSession?.notifyChildrenChanged(AutoBrowseContract.HOME_CONTINUE_ID, 20, null)
         host.mediaSession?.notifyChildrenChanged(AutoBrowseContract.LIBRARY_HISTORY_ID, 50, null)
+        host.requestAutoCollageRefresh(force = true)
         return true
     }
 
@@ -249,6 +250,7 @@ internal class AutoBrowseLibraryCallback(
         }
         if (queuedEpisode == null) host.queueRepository.replaceQueue(existingQueue + episode)
         host.mediaSession?.notifyChildrenChanged(AutoBrowseContract.HOME_QUEUE_ID, 50, null)
+        host.requestAutoCollageRefresh(force = true)
         return true
     }
 
@@ -318,7 +320,6 @@ internal class AutoBrowseLibraryCallback(
         val resultParams = LibraryParams.Builder().setExtras(rootExtras).build()
         return Futures.immediateFuture(LibraryResult.ofItem(rootItem, resultParams))
     }
-
 
     override fun onGetChildren(
         session: MediaLibrarySession,
@@ -390,7 +391,6 @@ internal class AutoBrowseLibraryCallback(
         }
     }
 
-
     override fun onSearch(
         session: MediaLibrarySession,
         browser: MediaSession.ControllerInfo,
@@ -436,7 +436,6 @@ internal class AutoBrowseLibraryCallback(
             }
         }
     }
-
 
     override fun onGetItem(
         session: MediaLibrarySession,
@@ -568,9 +567,8 @@ internal class AutoBrowseLibraryCallback(
     ): MutableList<MediaItem> {
         android.util.Log.d(
             "BoxCastPlayer",
-            "onAddMediaItems: selectedItem.mediaId=${selectedItem.mediaId}, extrasKeys=${selectedItem.mediaMetadata.extras?.keySet()?.joinToString(
-                ", ",
-            )}",
+            "onAddMediaItems: selectedItem.mediaId=${selectedItem.mediaId}, " +
+                "extrasKeys=${selectedItem.mediaMetadata.extras?.keySet()?.joinToString(", ")}",
         )
         cx.aswin.boxlore.core.analytics.PendingEntryPoint.set(
             mapOf("entry_point" to "android_auto_$source"),
@@ -594,5 +592,4 @@ internal class AutoBrowseLibraryCallback(
         }
         return mutableListOf(resolvedItem)
     }
-
 }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoBrowseLibraryHost.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/auto/AutoBrowseLibraryHost.kt
@@ -34,6 +34,9 @@ interface AutoBrowseLibraryHost {
 
     fun asContext(): Context
 
+    /** Rebuild folder collage tiles when resume/history/queue content changes. */
+    fun requestAutoCollageRefresh(force: Boolean = false)
+
     fun getString(
         @StringRes id: Int,
         vararg formatArgs: Any,

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/AutoArtworkFetchLogicTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/AutoArtworkFetchLogicTest.kt
@@ -1,0 +1,109 @@
+package cx.aswin.boxlore.core.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoArtworkFetchLogicTest {
+    @Test
+    fun acceptsImageContentTypesAndLenientFallbacks() {
+        assertTrue(AutoArtworkFetchLogic.isAcceptableImageContentType("image/jpeg"))
+        assertTrue(AutoArtworkFetchLogic.isAcceptableImageContentType("image/png; charset=binary"))
+        assertTrue(AutoArtworkFetchLogic.isAcceptableImageContentType(null))
+        assertTrue(AutoArtworkFetchLogic.isAcceptableImageContentType(""))
+        assertTrue(AutoArtworkFetchLogic.isAcceptableImageContentType("application/octet-stream"))
+        assertFalse(AutoArtworkFetchLogic.isAcceptableImageContentType("text/html"))
+        assertFalse(AutoArtworkFetchLogic.isAcceptableImageContentType("application/json"))
+    }
+
+    @Test
+    fun detectsCommonImageMagicBytes() {
+        assertTrue(AutoArtworkFetchLogic.looksLikeImage(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xE0.toByte())))
+        assertTrue(
+            AutoArtworkFetchLogic.looksLikeImage(
+                byteArrayOf(
+                    0x89.toByte(),
+                    0x50,
+                    0x4E,
+                    0x47,
+                    0x0D,
+                    0x0A,
+                    0x1A,
+                    0x0A,
+                ),
+            ),
+        )
+        assertTrue(AutoArtworkFetchLogic.looksLikeImage("GIF89a........".toByteArray()))
+        val webp = ByteArray(12)
+        "RIFF".toByteArray().copyInto(webp, 0)
+        "WEBP".toByteArray().copyInto(webp, 8)
+        assertTrue(AutoArtworkFetchLogic.looksLikeImage(webp))
+        assertFalse(AutoArtworkFetchLogic.looksLikeImage("<html>".toByteArray()))
+        assertFalse(AutoArtworkFetchLogic.looksLikeImage(byteArrayOf(1, 2)))
+    }
+
+    @Test
+    fun shouldAcceptArtworkEnforcesStatusSizeAndType() {
+        assertTrue(
+            AutoArtworkFetchLogic.shouldAcceptArtwork(
+                responseCode = 200,
+                contentType = "image/jpeg",
+                contentLength = 1024,
+            ),
+        )
+        assertTrue(
+            AutoArtworkFetchLogic.shouldAcceptArtwork(
+                responseCode = 200,
+                contentType = "application/octet-stream",
+                contentLength = -1,
+                headerBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte()),
+            ),
+        )
+        assertFalse(
+            AutoArtworkFetchLogic.shouldAcceptArtwork(
+                responseCode = 404,
+                contentType = "image/jpeg",
+                contentLength = 10,
+            ),
+        )
+        assertFalse(
+            AutoArtworkFetchLogic.shouldAcceptArtwork(
+                responseCode = 200,
+                contentType = "image/jpeg",
+                contentLength = AutoArtworkFetchLogic.MAX_ARTWORK_BYTES + 1,
+            ),
+        )
+        assertFalse(
+            AutoArtworkFetchLogic.shouldAcceptArtwork(
+                responseCode = 200,
+                contentType = "text/html",
+                contentLength = 10,
+            ),
+        )
+        assertFalse(
+            AutoArtworkFetchLogic.shouldAcceptArtwork(
+                responseCode = 200,
+                contentType = "image/jpeg",
+                contentLength = 10,
+                headerBytes = "<html>".toByteArray(),
+            ),
+        )
+    }
+
+    @Test
+    fun recognizesRedirectStatusCodes() {
+        assertTrue(AutoArtworkFetchLogic.isRedirect(301))
+        assertTrue(AutoArtworkFetchLogic.isRedirect(302))
+        assertTrue(AutoArtworkFetchLogic.isRedirect(307))
+        assertFalse(AutoArtworkFetchLogic.isRedirect(200))
+        assertFalse(AutoArtworkFetchLogic.isRedirect(404))
+    }
+
+    @Test
+    fun timeoutConstantsAreReasonableForAutoHosts() {
+        assertTrue(AutoArtworkFetchLogic.CONNECT_TIMEOUT_MS >= 5_000)
+        assertTrue(AutoArtworkFetchLogic.READ_TIMEOUT_MS >= 8_000)
+        assertEquals(5, AutoArtworkFetchLogic.MAX_REDIRECTS)
+    }
+}

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/AutoCollageFolderLogicTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/AutoCollageFolderLogicTest.kt
@@ -1,0 +1,57 @@
+package cx.aswin.boxlore.core.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AutoCollageFolderLogicTest {
+    @Test
+    fun pairOrNullRequiresBothKeyAndImage() {
+        assertNull(AutoCollageFolderLogic.pairOrNull(null, "https://cdn/a.jpg"))
+        assertNull(AutoCollageFolderLogic.pairOrNull("ep-1", null))
+        assertNull(AutoCollageFolderLogic.pairOrNull("  ", "https://cdn/a.jpg"))
+        assertNull(AutoCollageFolderLogic.pairOrNull("ep-1", "  "))
+        val pair = AutoCollageFolderLogic.pairOrNull("ep-1", "https://cdn/a.jpg")!!
+        assertEquals("ep-1", pair.contentKey)
+        assertEquals("https://cdn/a.jpg", pair.imageUrl)
+    }
+
+    @Test
+    fun takeAlignedKeepsKeysAndImagesInLockstep() {
+        val pairs =
+            listOf(
+                AutoCollageFolderLogic.ArtPair("a", "https://cdn/a.jpg"),
+                AutoCollageFolderLogic.ArtPair("", "https://cdn/drop.jpg"),
+                AutoCollageFolderLogic.ArtPair("b", ""),
+                AutoCollageFolderLogic.ArtPair("c", "https://cdn/c.jpg"),
+                AutoCollageFolderLogic.ArtPair("d", "https://cdn/d.jpg"),
+                AutoCollageFolderLogic.ArtPair("e", "https://cdn/e.jpg"),
+            )
+        val taken = AutoCollageFolderLogic.takeAligned(pairs, limit = 3)
+        assertEquals(listOf("a", "c", "d"), AutoCollageFolderLogic.keysOf(taken))
+        assertEquals(
+            listOf("https://cdn/a.jpg", "https://cdn/c.jpg", "https://cdn/d.jpg"),
+            AutoCollageFolderLogic.imagesOf(taken),
+        )
+    }
+
+    @Test
+    fun homeStyleConcatUsesSameFilterThenTake() {
+        val history =
+            listOf(
+                AutoCollageFolderLogic.ArtPair("h1", "https://cdn/h1.jpg"),
+                AutoCollageFolderLogic.ArtPair("h2", ""), // dropped
+            )
+        val newest =
+            listOf(
+                AutoCollageFolderLogic.ArtPair("n1", "https://cdn/n1.jpg"),
+                AutoCollageFolderLogic.ArtPair("n2", "https://cdn/n2.jpg"),
+            )
+        val home = AutoCollageFolderLogic.takeAligned(history + newest, limit = 3)
+        assertEquals(listOf("h1", "n1", "n2"), AutoCollageFolderLogic.keysOf(home))
+        assertEquals(
+            listOf("https://cdn/h1.jpg", "https://cdn/n1.jpg", "https://cdn/n2.jpg"),
+            AutoCollageFolderLogic.imagesOf(home),
+        )
+    }
+}

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/AutoCollageFreshnessLogicTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/AutoCollageFreshnessLogicTest.kt
@@ -1,0 +1,127 @@
+package cx.aswin.boxlore.core.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoCollageFreshnessLogicTest {
+    @Test
+    fun signatureChangesWhenContentKeysChange() {
+        val a =
+            AutoCollageFreshnessLogic.buildSignature(
+                contentKeysOrUrls = listOf("ep-1", "ep-2"),
+                loadedImageCount = 2,
+                expectedImageCount = 2,
+            )
+        val b =
+            AutoCollageFreshnessLogic.buildSignature(
+                contentKeysOrUrls = listOf("ep-3", "ep-2"),
+                loadedImageCount = 2,
+                expectedImageCount = 2,
+            )
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun signatureChangesWhenLoadedCountChanges() {
+        val partial =
+            AutoCollageFreshnessLogic.buildSignature(
+                contentKeysOrUrls = listOf("ep-1"),
+                loadedImageCount = 0,
+                expectedImageCount = 1,
+            )
+        val full =
+            AutoCollageFreshnessLogic.buildSignature(
+                contentKeysOrUrls = listOf("ep-1"),
+                loadedImageCount = 1,
+                expectedImageCount = 1,
+            )
+        assertNotEquals(partial, full)
+    }
+
+    @Test
+    fun fullCollageStaysFreshWithinFullTtl() {
+        val signature =
+            AutoCollageFreshnessLogic.buildSignature(
+                contentKeysOrUrls = listOf("a"),
+                loadedImageCount = 1,
+                expectedImageCount = 1,
+            )
+        assertTrue(
+            AutoCollageFreshnessLogic.isFresh(
+                ageMs = AutoCollageFreshnessLogic.FULL_TTL_MS - 1,
+                storedSignature = signature,
+                currentSignature = signature,
+                loadedImageCount = 1,
+                expectedImageCount = 1,
+            ),
+        )
+        assertFalse(
+            AutoCollageFreshnessLogic.isFresh(
+                ageMs = AutoCollageFreshnessLogic.FULL_TTL_MS + 1,
+                storedSignature = signature,
+                currentSignature = signature,
+                loadedImageCount = 1,
+                expectedImageCount = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun partialCollageExpiresSoonerThanFull() {
+        val signature =
+            AutoCollageFreshnessLogic.buildSignature(
+                contentKeysOrUrls = listOf("a", "b"),
+                loadedImageCount = 1,
+                expectedImageCount = 2,
+            )
+        assertTrue(
+            AutoCollageFreshnessLogic.isFresh(
+                ageMs = AutoCollageFreshnessLogic.PARTIAL_TTL_MS - 1,
+                storedSignature = signature,
+                currentSignature = signature,
+                loadedImageCount = 1,
+                expectedImageCount = 2,
+            ),
+        )
+        assertFalse(
+            AutoCollageFreshnessLogic.isFresh(
+                ageMs = AutoCollageFreshnessLogic.PARTIAL_TTL_MS + 1,
+                storedSignature = signature,
+                currentSignature = signature,
+                loadedImageCount = 1,
+                expectedImageCount = 2,
+            ),
+        )
+    }
+
+    @Test
+    fun mismatchedSignatureIsNeverFresh() {
+        assertFalse(
+            AutoCollageFreshnessLogic.isFresh(
+                ageMs = 0,
+                storedSignature = "old",
+                currentSignature = "new",
+                loadedImageCount = 4,
+                expectedImageCount = 4,
+            ),
+        )
+        assertFalse(
+            AutoCollageFreshnessLogic.isFresh(
+                ageMs = 0,
+                storedSignature = null,
+                currentSignature = "new",
+                loadedImageCount = 4,
+                expectedImageCount = 4,
+            ),
+        )
+    }
+
+    @Test
+    fun partialTtlIsShorterThanFullTtl() {
+        assertTrue(AutoCollageFreshnessLogic.PARTIAL_TTL_MS < AutoCollageFreshnessLogic.FULL_TTL_MS)
+        assertEquals("collage-v4", AutoCollageFreshnessLogic.SIGNATURE_VERSION)
+    }
+}

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/AutoCollagePrewarmPolicyTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/AutoCollagePrewarmPolicyTest.kt
@@ -1,0 +1,37 @@
+package cx.aswin.boxlore.core.playback
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AutoCollagePrewarmPolicyTest {
+    @Test
+    fun forceAlwaysRuns() {
+        assertTrue(
+            AutoCollagePrewarmPolicy.shouldRun(
+                force = true,
+                lastPrewarmAtMs = 1_000L,
+                nowMs = 1_001L,
+            ),
+        )
+    }
+
+    @Test
+    fun throttlesWithinInterval() {
+        val last = 10_000L
+        assertFalse(
+            AutoCollagePrewarmPolicy.shouldRun(
+                force = false,
+                lastPrewarmAtMs = last,
+                nowMs = last + AutoCollagePrewarmPolicy.MIN_REFRESH_INTERVAL_MS - 1,
+            ),
+        )
+        assertTrue(
+            AutoCollagePrewarmPolicy.shouldRun(
+                force = false,
+                lastPrewarmAtMs = last,
+                nowMs = last + AutoCollagePrewarmPolicy.MIN_REFRESH_INTERVAL_MS,
+            ),
+        )
+    }
+}

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloaderTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloaderTest.kt
@@ -1,0 +1,48 @@
+package cx.aswin.boxlore.core.playback.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.net.URI
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AutoArtworkDownloaderTest {
+    @Test
+    fun parseHttpsUrlUpgradesHttpAndRejectsJunk() {
+        val https = AutoArtworkDownloader.parseHttpsUrl("https://cdn.example/art.jpg")!!
+        assertEquals("https", https.protocol)
+        assertEquals("cdn.example", https.host)
+
+        val upgraded = AutoArtworkDownloader.parseHttpsUrl("http://cdn.example/art.jpg")!!
+        assertEquals("https", upgraded.protocol)
+        assertEquals("cdn.example", upgraded.host)
+
+        assertNull(AutoArtworkDownloader.parseHttpsUrl("not a url"))
+        assertNull(AutoArtworkDownloader.parseHttpsUrl("ftp://cdn.example/x.jpg"))
+    }
+
+    @Test
+    fun isPublicHttpsUrlRejectsLoopbackAndNonHttps() {
+        val loopback = URI("https://127.0.0.1/cover.jpg").toURL()
+        assertFalse(AutoArtworkDownloader.isPublicHttpsUrl(loopback))
+
+        val http = URI("http://example.com/cover.jpg").toURL()
+        assertFalse(AutoArtworkDownloader.isPublicHttpsUrl(http))
+
+        val weirdPort = URI("https://example.com:8443/cover.jpg").toURL()
+        assertFalse(AutoArtworkDownloader.isPublicHttpsUrl(weirdPort))
+    }
+
+    @Test
+    fun isPublicHttpsUrlAcceptsPublicHttpsHost() {
+        // example.com resolves to documentation IPs that are not site-local.
+        val url = URI("https://example.com/cover.jpg").toURL()
+        assertTrue(AutoArtworkDownloader.isPublicHttpsUrl(url))
+    }
+}

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloaderTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/AutoArtworkDownloaderTest.kt
@@ -8,6 +8,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import java.net.InetAddress
 import java.net.URI
 
 @RunWith(RobolectricTestRunner::class)
@@ -28,10 +29,7 @@ class AutoArtworkDownloaderTest {
     }
 
     @Test
-    fun isPublicHttpsUrlRejectsLoopbackAndNonHttps() {
-        val loopback = URI("https://127.0.0.1/cover.jpg").toURL()
-        assertFalse(AutoArtworkDownloader.isPublicHttpsUrl(loopback))
-
+    fun isPublicHttpsUrlRejectsNonHttpsAndNon443WithoutDns() {
         val http = URI("http://example.com/cover.jpg").toURL()
         assertFalse(AutoArtworkDownloader.isPublicHttpsUrl(http))
 
@@ -40,9 +38,18 @@ class AutoArtworkDownloaderTest {
     }
 
     @Test
-    fun isPublicHttpsUrlAcceptsPublicHttpsHost() {
-        // example.com resolves to documentation IPs that are not site-local.
-        val url = URI("https://example.com/cover.jpg").toURL()
-        assertTrue(AutoArtworkDownloader.isPublicHttpsUrl(url))
+    fun isPublicAddressClassifiesLocalRangesWithoutDns() {
+        val loopback = InetAddress.getByAddress(byteArrayOf(127, 0, 0, 1))
+        assertFalse(AutoArtworkDownloader.isPublicAddress(loopback))
+
+        val siteLocal = InetAddress.getByAddress(byteArrayOf(192.toByte(), 168.toByte(), 1, 1))
+        assertFalse(AutoArtworkDownloader.isPublicAddress(siteLocal))
+
+        val linkLocal = InetAddress.getByAddress(byteArrayOf(169.toByte(), 254.toByte(), 1, 1))
+        assertFalse(AutoArtworkDownloader.isPublicAddress(linkLocal))
+
+        // 8.8.8.8 is a well-known public address used only as a classifier fixture.
+        val publicV4 = InetAddress.getByAddress(byteArrayOf(8, 8, 8, 8))
+        assertTrue(AutoArtworkDownloader.isPublicAddress(publicV4))
     }
 }

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkRepositoryTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkRepositoryTest.kt
@@ -106,6 +106,16 @@ class AutoArtworkRepositoryTest {
     }
 
     @Test
+    fun collageUriIncludesCacheBusterFromSignatureFile() {
+        val dir = File(context.cacheDir, "auto_collages").apply { mkdirs() }
+        File(dir, "folder_1.png").writeBytes(byteArrayOf(1))
+        File(dir, "folder_1.signature").writeText("sig-123")
+
+        val uri = AutoArtworkRepository.collageUri(context, "folder-1")!!
+        assertEquals("sig-123", uri.getQueryParameter("v"))
+    }
+
+    @Test
     fun collageUriSanitizesFolderIdIntoFilename() {
         val dir = File(context.cacheDir, "auto_collages").apply { mkdirs() }
         // "a/b c" → "a_b_c" per safeFileName().

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStoreTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStoreTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,8 +28,14 @@ class AutoArtworkSourceStoreTest {
     }
 
     @Test
+    fun putReturnsTrueWhenCommitSucceeds() {
+        assertTrue(AutoArtworkSourceStore.put(context, "ok", "https://cdn.example/ok.jpg"))
+        assertEquals("https://cdn.example/ok.jpg", AutoArtworkSourceStore.get(context, "ok"))
+    }
+
+    @Test
     fun putIsReadableImmediatelyFromMemoryAndPrefs() {
-        AutoArtworkSourceStore.put(context, "abc", "https://cdn.example/cover.jpg")
+        assertTrue(AutoArtworkSourceStore.put(context, "abc", "https://cdn.example/cover.jpg"))
 
         assertEquals(
             "https://cdn.example/cover.jpg",
@@ -53,7 +60,6 @@ class AutoArtworkSourceStoreTest {
         val uri = AutoArtworkRepository.remoteUri(context, "https://cdn.example/art.png")!!
         val key = uri.pathSegments.last()
 
-        // Memory answers immediately; prefs catch up via background commit.
         assertEquals(
             "https://cdn.example/art.png",
             AutoArtworkSourceStore.get(context, key),

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStoreTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStoreTest.kt
@@ -35,6 +35,7 @@ class AutoArtworkSourceStoreTest {
             AutoArtworkSourceStore.get(context, "abc"),
         )
         // Simulate a fresh reader that only has prefs (e.g. after process restart).
+        AutoArtworkSourceStore.flushPersistsForTests()
         AutoArtworkSourceStore.clearMemoryForTests()
         assertEquals(
             "https://cdn.example/cover.jpg",
@@ -52,7 +53,12 @@ class AutoArtworkSourceStoreTest {
         val uri = AutoArtworkRepository.remoteUri(context, "https://cdn.example/art.png")!!
         val key = uri.pathSegments.last()
 
-        // Even with memory cleared, commit() must have landed the source for the provider.
+        // Memory answers immediately; prefs catch up via background commit.
+        assertEquals(
+            "https://cdn.example/art.png",
+            AutoArtworkSourceStore.get(context, key),
+        )
+        AutoArtworkSourceStore.flushPersistsForTests()
         AutoArtworkSourceStore.clearMemoryForTests()
         assertEquals(
             "https://cdn.example/art.png",

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStoreTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/service/auto/AutoArtworkSourceStoreTest.kt
@@ -1,0 +1,62 @@
+package cx.aswin.boxlore.core.playback.service.auto
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AutoArtworkSourceStoreTest {
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        AutoArtworkSourceStore.clearMemoryForTests()
+        context
+            .getSharedPreferences(AutoArtworkSourceStore.SOURCE_PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+    }
+
+    @Test
+    fun putIsReadableImmediatelyFromMemoryAndPrefs() {
+        AutoArtworkSourceStore.put(context, "abc", "https://cdn.example/cover.jpg")
+
+        assertEquals(
+            "https://cdn.example/cover.jpg",
+            AutoArtworkSourceStore.get(context, "abc"),
+        )
+        // Simulate a fresh reader that only has prefs (e.g. after process restart).
+        AutoArtworkSourceStore.clearMemoryForTests()
+        assertEquals(
+            "https://cdn.example/cover.jpg",
+            AutoArtworkSourceStore.get(context, "abc"),
+        )
+    }
+
+    @Test
+    fun getReturnsNullWhenUnset() {
+        assertNull(AutoArtworkSourceStore.get(context, "missing"))
+    }
+
+    @Test
+    fun remoteUriPersistsMappingBeforeReturning() {
+        val uri = AutoArtworkRepository.remoteUri(context, "https://cdn.example/art.png")!!
+        val key = uri.pathSegments.last()
+
+        // Even with memory cleared, commit() must have landed the source for the provider.
+        AutoArtworkSourceStore.clearMemoryForTests()
+        assertEquals(
+            "https://cdn.example/art.png",
+            AutoArtworkSourceStore.get(context, key),
+        )
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Android Auto Home/Resume (and other) section tiles were showing stale collage art, and cover images inside browse rows failed roughly half the time. This revamp hardens the artwork pipeline in `:core:playback` without changing Media IDs or service FQCNs.

### Root causes addressed
- **Blank episode art:** `SharedPreferences.apply()` raced the Auto host opening `content://…/art/…` before the source URL was durable; provider also refused CDN redirects and non-`image/*` content types.
- **Stale section collages:** 6h PNG cache signed even on partial/fallback downloads; most folders lacked content keys; Auto hosts cached unchanging collage URIs; collages were not rebuilt when resume/queue changed.

### What changed
- Durable + in-memory `AutoArtworkSourceStore` (background `commit`, bounded wait, fail closed if not durable) before returning art URIs
- Shared `AutoArtworkDownloader` (validated HTTPS redirects, public-host checks) used by collage generation and the ContentProvider
- Lenient image content-types, magic-byte checks, retry, corrupt-cache eviction; resident per-key fetch locks
- Collage signatures use aligned content-key/image pairs, shorter TTL for partial/fallback tiles, and `v=` URI cache-busters
- `requestAutoCollageRefresh` on natural completion, mark-complete / mark-complete-and-skip, and queue add
- Hermetic tests for fetch policy, freshness, folder pairing, prewarm throttle, downloader helpers, and source-store durability
- Follow-ups cleared detekt/Sonar complexity+duplication and addressed CodeRabbit findings

## Listener impact
### What changes in the user’s life
On Android Auto, Home Resume and other section tiles should show the right show art after you finish or queue episodes, and episode covers inside those lists should load reliably instead of staying blank.

## Test plan
- [x] `./gradlew :core:playback:ktlintCheck`
- [x] `./gradlew detekt`
- [x] `./gradlew :core:playback:testDebugUnitTest` (Auto artwork / collage / source-store tests)
- [ ] Manual Android Auto smoke: open Home → Resume collage matches current in-progress shows; open Resume children and confirm covers load; mark complete and confirm Resume tile refreshes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0089f70-ea74-4eec-a86b-63e24101002f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0089f70-ea74-4eec-a86b-63e24101002f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

