### PR TITLE
feat(home): rebuild personalization learning and Home candidate slate

### DIFF
--- a/app/src/main/java/cx/aswin/boxlore/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxlore/BoxLoreApplication.kt
@@ -17,6 +17,7 @@ import cx.aswin.boxlore.core.catalog.EngagementPromptCoordinator
 import cx.aswin.boxlore.core.catalog.SharedAppDependenciesHolder
 import cx.aswin.boxlore.core.prefs.UserPreferencesRepository
 import cx.aswin.boxlore.core.downloads.DownloadsDependenciesHolder
+import cx.aswin.boxlore.core.ranking.AdaptiveRankingRepository
 import cx.aswin.boxlore.core.ranking.LearningEventLog
 import cx.aswin.boxlore.core.network.NetworkModule
 import cx.aswin.boxlore.surveys.BoxcastPostHogSurveysDelegate
@@ -62,6 +63,22 @@ class BoxLoreApplication : Application(), Configuration.Provider {
         // fallback if Room initialization fails — same startup behavior as before, without
         // a second RankingFeedbackRepository client diverging from the container.
         container.rankingFeedbackRepository
+
+        // One-shot destructive wipe of prior personalization models/caches when the
+        // Home personalization pipeline version advances.
+        applicationScope.launch {
+            val runtimePrefs =
+                getSharedPreferences(
+                    AdaptiveRankingRepository.RUNTIME_PREFS_NAME,
+                    Context.MODE_PRIVATE,
+                )
+            val wiped =
+                container.adaptiveRankingRepository.ensurePipelineMigrated(runtimePrefs)
+            if (wiped) {
+                cx.aswin.boxlore.core.prefs.BoxcastPrefs(this@BoxLoreApplication)
+                    .clearPersonalizationCaches()
+            }
+        }
 
         // Live learner signal log: on by default in debug; release stays off unless the
         // user explicitly opts in via the debug-screen toggle (persisted true).

--- a/core/analytics/README.md
+++ b/core/analytics/README.md
@@ -10,7 +10,8 @@ Owns analytics event capture and non-fatal error reporting for Boxlore. The modu
 - `AnalyticsHelper` is the PostHog-backed production singleton.
 - `RecordingAnalytics` is an in-memory test double.
 - `ErrorReporter` is the non-fatal error facade; `:app` may install Crashlytics-backed reporting.
-- `PendingEntryPoint` bridges playback entry-point context across MediaController boundaries.
+- `PendingEntryPoint` bridges playback entry-point context across MediaController boundaries (includes `KEY_EXPOSURE_ID` for exact recommendation attribution).
+- Discovery tracks include Home recommendation feedback (`trackHomeRecommendationFeedback`) and personalization-mode health (`trackHomePersonalizationMode`) on existing `home_surface_*` events.
 - `PlayerSessionAggregator` batches per-episode player interaction events.
 - Event names and property expectations are documented in [`docs/ANALYTICS_EVENT_GLOSSARY.md`](../../docs/ANALYTICS_EVENT_GLOSSARY.md).
 - Glossary façades include growth/session (`trackOnboardingAbandoned`, `trackSessionRestorePrompt`), library ops (`trackDownloadRequested`, `trackShareContent`, `trackBackupRestoreResult`, `trackQueueModified`), discovery (`trackExploreSearchPerformed` with `search_mode`, `trackSearchResultTapped`), and onboarding (`trackOnboardingStepViewed` with optional `step_index`).

--- a/core/analytics/src/main/java/cx/aswin/boxlore/core/analytics/AnalyticsHelper.kt
+++ b/core/analytics/src/main/java/cx/aswin/boxlore/core/analytics/AnalyticsHelper.kt
@@ -491,6 +491,32 @@ object AnalyticsHelper : Analytics {
         timeBlockTitle,
     )
 
+    fun trackHomeRecommendationFeedback(
+        episodeId: String,
+        podcastId: String,
+        action: String,
+        personalizationMode: String?,
+        exposureId: String? = null,
+    ) = DiscoveryAnalyticsTracks.trackHomeRecommendationFeedback(
+        episodeId,
+        podcastId,
+        action,
+        personalizationMode,
+        exposureId,
+    )
+
+    fun trackHomePersonalizationMode(
+        mode: String,
+        meaningfulPlayCount: Int,
+        isFallback: Boolean,
+        candidateRequestOk: Boolean,
+    ) = DiscoveryAnalyticsTracks.trackHomePersonalizationMode(
+        mode,
+        meaningfulPlayCount,
+        isFallback,
+        candidateRequestOk,
+    )
+
     fun trackExploreRecommendationsImpression(
         recommendationsCount: Int,
         episodeIds: List<String>,

--- a/core/analytics/src/main/java/cx/aswin/boxlore/core/analytics/DiscoveryAnalyticsTracks.kt
+++ b/core/analytics/src/main/java/cx/aswin/boxlore/core/analytics/DiscoveryAnalyticsTracks.kt
@@ -143,6 +143,49 @@ internal object DiscoveryAnalyticsTracks {
         AnalyticsEmit.event("home_surface_tapped", props)
     }
 
+    /**
+     * Explicit long-press / menu feedback on a Home recommendation card.
+     * Uses [home_surface_tapped] with surface_component=recommendation_feedback.
+     */
+    fun trackHomeRecommendationFeedback(
+        episodeId: String,
+        podcastId: String,
+        action: String,
+        personalizationMode: String?,
+        exposureId: String? = null,
+    ) {
+        val props =
+            mutableMapOf<String, Any>(
+                "surface_component" to "recommendation_feedback",
+                "content_id" to episodeId,
+                "episode_id" to episodeId,
+                "podcast_id" to podcastId,
+                "feedback_action" to action,
+            )
+        personalizationMode?.let { props["personalization_mode"] = it }
+        exposureId?.let { props["exposure_id"] = it }
+        AnalyticsEmit.event("home_surface_tapped", props)
+    }
+
+    fun trackHomePersonalizationMode(
+        mode: String,
+        meaningfulPlayCount: Int,
+        isFallback: Boolean,
+        candidateRequestOk: Boolean,
+    ) {
+        AnalyticsEmit.event(
+            "home_surface_impression",
+            mapOf(
+                "surface_component" to "personalization_mode",
+                "personalization_mode" to mode,
+                "meaningful_play_count" to meaningfulPlayCount,
+                "is_fallback" to isFallback,
+                "candidate_request_ok" to candidateRequestOk,
+                "items_count" to 0,
+            ),
+        )
+    }
+
     fun trackExploreRecommendationsImpression(
         recommendationsCount: Int,
         episodeIds: List<String>,

--- a/core/analytics/src/main/java/cx/aswin/boxlore/core/analytics/PendingEntryPoint.kt
+++ b/core/analytics/src/main/java/cx/aswin/boxlore/core/analytics/PendingEntryPoint.kt
@@ -10,9 +10,14 @@ package cx.aswin.boxlore.core.analytics
  * context before calling controller.play(), and
  * BoxLorePlaybackService consumes it in startPlaybackSession().
  *
+ * Also carries ranking attribution via [KEY_EXPOSURE_ID] so background
+ * playback can resolve the exact Home/Learn impression that produced a play.
+ *
  * Thread-safe via @Synchronized.
  */
 object PendingEntryPoint {
+    const val KEY_EXPOSURE_ID = "exposure_id"
+
     private var pending: Map<String, Any>? = null
 
     @Synchronized

--- a/core/catalog/README.md
+++ b/core/catalog/README.md
@@ -38,11 +38,17 @@ src/main/java/cx/aswin/boxlore/core/catalog/
   InstallReferrerManager.kt
   backup/
   content/
+  home/                 # HomeCandidatesRequestBuilder + HomePersonalizationCoordinator
   crosspromo/
   ports/
   privacy/
 ```
 
+Public Home APIs:
+
+- `recommendationLanguagesForCountry` maps region → language tags for retrieval (not English-only).
+- `PodcastRepository.getHomeCandidatesV1` calls `POST /home/candidates/v1` with a ≥4h module cache; null body means fall back to legacy recommendation routes.
+- `home.HomePersonalizationCoordinator` builds requests and maps module pools for Home slate allocation.
 Main Kotlin files should remain below 1000 lines; extracted helpers keep repository mapping, network lookups, content cache, recommendations, and stream handling reviewable.
 
 ## Dependencies

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/PodcastRepository.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/PodcastRepository.kt
@@ -23,6 +23,10 @@ import cx.aswin.boxlore.core.network.model.CuratedCuriosityResponseDto
 import cx.aswin.boxlore.core.network.model.ContentSectionRecentSeedDto
 import cx.aswin.boxlore.core.network.model.ContentSectionSeedFallbackDto
 import cx.aswin.boxlore.core.network.model.ContentSectionsV1Request
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Request
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Response
+import cx.aswin.boxlore.core.catalog.home.HomeCandidatesRequestBuilder
+import cx.aswin.boxlore.core.catalog.home.HomePersonalizationCoordinator
 import cx.aswin.boxlore.core.catalog.BuildConfig
 import cx.aswin.boxlore.core.prefs.PrefsFileMigrator
 import cx.aswin.boxlore.core.rss.RssPodcastRepository
@@ -573,6 +577,41 @@ class PodcastRepository(
         }
     }
 
+    /**
+     * Versioned Home candidate pools. Cached ≥4h keyed by module scope + seeds + revision.
+     * Returns null body when the endpoint is unavailable so callers can fall back to legacy
+     * `/recommendations` and `/recommendations/because-you-like`.
+     */
+    suspend fun getHomeCandidatesV1(
+        request: HomeCandidatesV1Request,
+    ): Pair<HomeCandidatesV1Response?, Boolean> = withContext(Dispatchers.IO) {
+        val cacheKey = HomePersonalizationCoordinator.cacheKey(request)
+        val now = System.currentTimeMillis()
+        val cached = homeCandidatesCache[cacheKey]
+        if (cached != null && now - cached.second < HomeCandidatesRequestBuilder.CACHE_TTL_MILLIS) {
+            return@withContext cached.first to true
+        }
+        try {
+            val response =
+                api.getHomeCandidatesV1(
+                    publicKey,
+                    getOrCreateDeviceUuid(),
+                    request,
+                )
+            if (HomeCandidatesRequestBuilder.isValid(response)) {
+                homeCandidatesCache[cacheKey] = response to now
+                response to false
+            } else {
+                null to false
+            }
+        } catch (error: kotlinx.coroutines.CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            android.util.Log.w("PodcastRepository", "home/candidates/v1 unavailable", error)
+            null to false
+        }
+    }
+
     suspend fun getPersonalizedRecommendations(
         history: List<cx.aswin.boxlore.core.network.model.HistoryItem>,
         interests: List<String> = emptyList(),
@@ -934,5 +973,7 @@ class PodcastRepository(
         private val episodesCache = java.util.concurrent.ConcurrentHashMap<String, Pair<EpisodePage, Long>>()
         private val recommendationsCache = java.util.concurrent.ConcurrentHashMap<String, Pair<List<Episode>, Long>>()
         private val becauseYouLikeCache = java.util.concurrent.ConcurrentHashMap<String, Pair<BecauseYouLikeData, Long>>()
+        private val homeCandidatesCache =
+            java.util.concurrent.ConcurrentHashMap<String, Pair<HomeCandidatesV1Response, Long>>()
     }
 }

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/PodcastRepositoryContentMapping.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/PodcastRepositoryContentMapping.kt
@@ -37,7 +37,7 @@ data class PersonalizedContentSectionInputs(
     val recentSectionIds: List<String> = emptyList(),
     val excludedPodcastIds: List<String> = emptyList(),
     val excludedEpisodeIds: List<String> = emptyList(),
-    val languages: List<String> = listOf("en"),
+    val languages: List<String> = emptyList(),
 )
 
 internal val semanticMarkupPattern = Regex("<[^>]+>")

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/PodcastRepositoryRecommendations.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/PodcastRepositoryRecommendations.kt
@@ -9,13 +9,15 @@ internal fun PodcastRepository.fetchRecommendationV2(
     interests: List<String>,
     country: String?,
     subscribedPodcastIds: List<String>,
+    languages: List<String> = recommendationLanguagesForCountry(country),
 ): List<Episode>? {
     val seeds = buildRecommendationSeeds(history, subscribedPodcastIds)
     val boundedInterests = interests.map(String::trim).filter(String::isNotEmpty).distinct().take(12)
     if (seeds.isEmpty() && boundedInterests.isEmpty()) return null
     val request = cx.aswin.boxlore.core.network.model.RecommendationsV2Request(
         country = country?.lowercase()?.takeIf { it.length in 2..3 } ?: "us",
-        languages = listOf("en"),
+        languages = languages.map(String::trim).filter(String::isNotEmpty).distinct().take(8)
+            .ifEmpty { recommendationLanguagesForCountry(country) },
         seeds = seeds,
         interests = boundedInterests,
         subscribedPodcastIds = subscribedPodcastIds.mapNotNull(String::toLongOrNull)
@@ -97,6 +99,19 @@ internal fun buildRecommendationSeeds(
         .take(maximumSeeds - episodeSeeds.size)
         .toList()
     return episodeSeeds.take(maximumSeeds) + podcastSeeds
+}
+
+/**
+ * Maps region codes to language tags for recommendation retrieval.
+ * English remains included as a fallback so sparse non-EN inventory still works.
+ */
+fun recommendationLanguagesForCountry(country: String?): List<String> {
+    return when (country?.lowercase()) {
+        "fr" -> listOf("fr", "en")
+        "in" -> listOf("en", "hi")
+        "gb", "uk", "us", "au", "ca", "ie", "nz" -> listOf("en")
+        else -> listOf("en")
+    }
 }
 
 internal fun PodcastRepository.fetchLegacyRecommendations(

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomeCandidatesMapper.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomeCandidatesMapper.kt
@@ -1,0 +1,42 @@
+package cx.aswin.boxlore.core.catalog.home
+
+import cx.aswin.boxlore.core.catalog.toHttps
+import cx.aswin.boxlore.core.model.Episode
+import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.core.network.model.HomeCandidateItemDto
+
+internal fun HomeCandidateItemDto.toEpisodeOrNull(
+    algorithmVersion: String?,
+): Episode? {
+    val id = episodeId?.takeIf { it.isNotBlank() } ?: return null
+    val audio = audioUrl?.takeIf { it.isNotBlank() }?.toHttps() ?: return null
+    return Episode(
+        id = id,
+        title = title?.takeIf { it.isNotBlank() } ?: "Episode",
+        description = "",
+        audioUrl = audio,
+        imageUrl = imageUrl?.toHttps()?.takeIf { it.isNotBlank() },
+        podcastImageUrl = (podcastImageUrl ?: imageUrl)?.toHttps()?.takeIf { it.isNotBlank() },
+        podcastTitle = podcastTitle,
+        podcastId = podcastId,
+        podcastGenre = genre,
+        duration = durationSeconds ?: 0,
+        publishedDate = publishedDate ?: 0L,
+        retrievalScore = retrievalScore,
+        recommendationSource = source,
+        recommendationReason = reason,
+        recommendationAlgorithmVersion = algorithmVersion,
+    )
+}
+
+internal fun HomeCandidateItemDto.toPodcastOrNull(): Podcast? {
+    val id = podcastId?.takeIf { it.isNotBlank() } ?: return null
+    return Podcast(
+        id = id,
+        title = podcastTitle?.takeIf { it.isNotBlank() } ?: title ?: "Podcast",
+        artist = "",
+        imageUrl = (podcastImageUrl ?: imageUrl)?.toHttps().orEmpty(),
+        description = "",
+        genre = genre ?: "Podcast",
+    )
+}

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomeCandidatesRequestBuilder.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomeCandidatesRequestBuilder.kt
@@ -1,0 +1,100 @@
+package cx.aswin.boxlore.core.catalog.home
+
+import cx.aswin.boxlore.core.network.model.HomeCandidateItemDto
+import cx.aswin.boxlore.core.network.model.HomeCandidateSeedDto
+import cx.aswin.boxlore.core.network.model.HomeCandidateSeedFallbackDto
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Request
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Response
+import cx.aswin.boxlore.core.network.model.HistoryItem
+
+/**
+ * Builds bounded Home candidate requests and maps module pools for the
+ * Android-owned slate allocator. Network I/O stays on [PodcastRepository].
+ */
+object HomeCandidatesRequestBuilder {
+    const val CACHE_TTL_MILLIS: Long = 4L * 60L * 60L * 1_000L
+
+    fun build(
+        modules: List<String>,
+        country: String,
+        languages: List<String>,
+        history: List<HistoryItem>,
+        anchorPodcastId: String?,
+        missionId: String?,
+        excludedPodcastIds: List<String>,
+        excludedEpisodeIds: List<String>,
+        noveltyPreference: Double?,
+        daypart: String?,
+        revision: String?,
+    ): HomeCandidatesV1Request {
+        return HomeCandidatesV1Request(
+            requestedModules = modules.distinct().take(4),
+            country = country.lowercase().takeIf { it.length in 2..3 } ?: "us",
+            languages = languages,
+            seeds = buildSeeds(history),
+            anchorPodcastId = anchorPodcastId,
+            missionId = missionId,
+            excludedPodcastIds = excludedPodcastIds.distinct().take(250),
+            excludedEpisodeIds = excludedEpisodeIds.distinct().take(250),
+            noveltyPreference = noveltyPreference,
+            daypart = daypart,
+            revision = revision,
+        )
+    }
+
+    fun buildSeeds(
+        history: List<HistoryItem>,
+        maximumSeeds: Int = 12,
+    ): List<HomeCandidateSeedDto> {
+        return history.mapNotNull { item ->
+            val episodeId = item.episodeId?.takeIf { it.isNotBlank() }
+            val podcastId = item.podcastId?.takeIf { it.isNotBlank() }
+            if (episodeId == null && podcastId == null) return@mapNotNull null
+            val durationMs = item.durationMs ?: 0L
+            val progressRatio = if (durationMs > 0L) {
+                (item.progressMs ?: 0L).toDouble() / durationMs
+            } else {
+                0.0
+            }
+            val weight = when {
+                item.isLiked == true -> 0.95
+                item.isCompleted == true -> 0.9
+                progressRatio >= 0.5 -> 0.75
+                progressRatio >= 0.2 -> 0.55
+                else -> 0.35
+            }
+            HomeCandidateSeedDto(
+                episodeId = episodeId,
+                podcastId = podcastId,
+                weight = weight,
+                fallback = HomeCandidateSeedFallbackDto(
+                    episodeTitle = item.episodeTitle.take(180),
+                    podcastTitle = item.podcastTitle.take(180),
+                    description = item.episodeDescription?.take(400),
+                ),
+            )
+        }
+            .sortedByDescending { it.weight }
+            .distinctBy { it.episodeId ?: "p:${it.podcastId}" }
+            .take(maximumSeeds)
+    }
+
+    fun moduleItems(
+        response: HomeCandidatesV1Response,
+        module: String,
+    ): List<HomeCandidateItemDto> {
+        return when (module) {
+            "taste" -> response.modules.taste
+            "because_you_like" -> response.modules.becauseYouLike
+            "mission" -> response.modules.mission
+            "regional" -> response.modules.regional
+            else -> emptyList()
+        }
+    }
+
+    fun isValid(response: HomeCandidatesV1Response): Boolean {
+        return response.status == "true" &&
+            response.contractVersion == 1 &&
+            !response.algorithmVersion.isNullOrBlank()
+    }
+}

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomeCandidatesRequestBuilder.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomeCandidatesRequestBuilder.kt
@@ -14,31 +14,33 @@ import cx.aswin.boxlore.core.network.model.HistoryItem
 object HomeCandidatesRequestBuilder {
     const val CACHE_TTL_MILLIS: Long = 4L * 60L * 60L * 1_000L
 
-    fun build(
-        modules: List<String>,
-        country: String,
-        languages: List<String>,
-        history: List<HistoryItem>,
-        anchorPodcastId: String?,
-        missionId: String?,
-        excludedPodcastIds: List<String>,
-        excludedEpisodeIds: List<String>,
-        noveltyPreference: Double?,
-        daypart: String?,
-        revision: String?,
-    ): HomeCandidatesV1Request {
+    data class BuildInput(
+        val modules: List<String>,
+        val country: String,
+        val languages: List<String>,
+        val history: List<HistoryItem>,
+        val anchorPodcastId: String?,
+        val missionId: String?,
+        val excludedPodcastIds: List<String>,
+        val excludedEpisodeIds: List<String>,
+        val noveltyPreference: Double?,
+        val daypart: String?,
+        val revision: String?,
+    )
+
+    fun build(input: BuildInput): HomeCandidatesV1Request {
         return HomeCandidatesV1Request(
-            requestedModules = modules.distinct().take(4),
-            country = country.lowercase().takeIf { it.length in 2..3 } ?: "us",
-            languages = languages,
-            seeds = buildSeeds(history),
-            anchorPodcastId = anchorPodcastId,
-            missionId = missionId,
-            excludedPodcastIds = excludedPodcastIds.distinct().take(250),
-            excludedEpisodeIds = excludedEpisodeIds.distinct().take(250),
-            noveltyPreference = noveltyPreference,
-            daypart = daypart,
-            revision = revision,
+            requestedModules = input.modules.distinct().take(4),
+            country = input.country.lowercase().takeIf { it.length in 2..3 } ?: "us",
+            languages = input.languages,
+            seeds = buildSeeds(input.history),
+            anchorPodcastId = input.anchorPodcastId,
+            missionId = input.missionId,
+            excludedPodcastIds = input.excludedPodcastIds.distinct().take(250),
+            excludedEpisodeIds = input.excludedEpisodeIds.distinct().take(250),
+            noveltyPreference = input.noveltyPreference,
+            daypart = input.daypart,
+            revision = input.revision,
         )
     }
 

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomePersonalizationCoordinator.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomePersonalizationCoordinator.kt
@@ -1,0 +1,135 @@
+package cx.aswin.boxlore.core.catalog.home
+
+import cx.aswin.boxlore.core.catalog.PodcastRepository
+import cx.aswin.boxlore.core.model.Episode
+import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.core.network.model.HistoryItem
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Request
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Response
+
+/**
+ * Android-owned Home candidate retrieval + module cache coordination.
+ * Final scoring / allocation stay in `:feature:home` and `:core:ranking`.
+ */
+class HomePersonalizationCoordinator(
+    private val podcastRepository: PodcastRepository,
+) {
+    data class SlateRequest(
+        val modules: List<String>,
+        val country: String,
+        val languages: List<String>,
+        val history: List<HistoryItem>,
+        val anchorPodcastId: String?,
+        val missionId: String?,
+        val excludedPodcastIds: List<String>,
+        val excludedEpisodeIds: List<String>,
+        val noveltyPreference: Double?,
+        val daypart: String?,
+        val revision: String?,
+        /** When true, only refresh BYL — keep taste/mission exclusions in request. */
+        val becauseYouLikeOnly: Boolean = false,
+    )
+
+    data class SlateResult(
+        val taste: List<Episode>,
+        val becauseYouLikeEpisodes: List<Episode>,
+        val becauseYouLikePodcasts: List<Podcast>,
+        val mission: List<Episode>,
+        val regional: List<Episode>,
+        val isFallback: Boolean,
+        val algorithmVersion: String?,
+        val requestId: String?,
+        val fromCache: Boolean,
+    )
+
+    suspend fun loadSlate(request: SlateRequest): SlateResult {
+        val modules =
+            if (request.becauseYouLikeOnly) {
+                listOf("because_you_like")
+            } else {
+                request.modules.ifEmpty {
+                    listOf("taste", "because_you_like", "mission", "regional")
+                }
+            }
+        val body =
+            HomeCandidatesRequestBuilder.build(
+                modules = modules,
+                country = request.country,
+                languages = request.languages,
+                history = request.history,
+                anchorPodcastId = request.anchorPodcastId,
+                missionId = request.missionId,
+                excludedPodcastIds = request.excludedPodcastIds,
+                excludedEpisodeIds = request.excludedEpisodeIds,
+                noveltyPreference = request.noveltyPreference,
+                daypart = request.daypart,
+                revision = request.revision,
+            )
+        val (response, fromCache) = podcastRepository.getHomeCandidatesV1(body)
+        return mapResponse(response, fromCache)
+    }
+
+    private fun mapResponse(
+        response: HomeCandidatesV1Response?,
+        fromCache: Boolean,
+    ): SlateResult {
+        if (response == null || !HomeCandidatesRequestBuilder.isValid(response)) {
+            return SlateResult(
+                taste = emptyList(),
+                becauseYouLikeEpisodes = emptyList(),
+                becauseYouLikePodcasts = emptyList(),
+                mission = emptyList(),
+                regional = emptyList(),
+                isFallback = true,
+                algorithmVersion = null,
+                requestId = null,
+                fromCache = fromCache,
+            )
+        }
+        val version = response.algorithmVersion
+        fun mapEpisodes(items: List<cx.aswin.boxlore.core.network.model.HomeCandidateItemDto>) =
+            items.mapNotNull { it.toEpisodeOrNull(version) }
+                .distinctBy { it.id }
+
+        val bylEpisodes = mapEpisodes(response.modules.becauseYouLike)
+        val bylPodcasts =
+            response.modules.becauseYouLike
+                .mapNotNull { it.toPodcastOrNull() }
+                .distinctBy { it.id }
+        val taste = mapEpisodes(response.modules.taste)
+        val regional = mapEpisodes(response.modules.regional)
+        val isRegionalOnly = taste.isEmpty() && regional.isNotEmpty()
+        return SlateResult(
+            taste = if (isRegionalOnly) regional else taste,
+            becauseYouLikeEpisodes = bylEpisodes,
+            becauseYouLikePodcasts = bylPodcasts,
+            mission = mapEpisodes(response.modules.mission),
+            regional = regional,
+            isFallback = isRegionalOnly || taste.isEmpty(),
+            algorithmVersion = version,
+            requestId = response.requestId,
+            fromCache = fromCache,
+        )
+    }
+
+    companion object {
+        fun cacheKey(request: HomeCandidatesV1Request): String =
+            buildString {
+                append(request.requestedModules.sorted().joinToString(","))
+                append('|')
+                append(request.country)
+                append('|')
+                append(request.languages.sorted().joinToString(","))
+                append('|')
+                append(request.anchorPodcastId.orEmpty())
+                append('|')
+                append(request.missionId.orEmpty())
+                append('|')
+                append(request.revision.orEmpty())
+                append('|')
+                append(request.seeds.joinToString(",") { "${it.episodeId}:${it.podcastId}:${it.weight}" })
+                append('|')
+                append(request.excludedPodcastIds.sorted().take(40).joinToString(","))
+            }
+    }
+}

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomePersonalizationCoordinator.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/home/HomePersonalizationCoordinator.kt
@@ -53,17 +53,19 @@ class HomePersonalizationCoordinator(
             }
         val body =
             HomeCandidatesRequestBuilder.build(
-                modules = modules,
-                country = request.country,
-                languages = request.languages,
-                history = request.history,
-                anchorPodcastId = request.anchorPodcastId,
-                missionId = request.missionId,
-                excludedPodcastIds = request.excludedPodcastIds,
-                excludedEpisodeIds = request.excludedEpisodeIds,
-                noveltyPreference = request.noveltyPreference,
-                daypart = request.daypart,
-                revision = request.revision,
+                HomeCandidatesRequestBuilder.BuildInput(
+                    modules = modules,
+                    country = request.country,
+                    languages = request.languages,
+                    history = request.history,
+                    anchorPodcastId = request.anchorPodcastId,
+                    missionId = request.missionId,
+                    excludedPodcastIds = request.excludedPodcastIds,
+                    excludedEpisodeIds = request.excludedEpisodeIds,
+                    noveltyPreference = request.noveltyPreference,
+                    daypart = request.daypart,
+                    revision = request.revision,
+                ),
             )
         val (response, fromCache) = podcastRepository.getHomeCandidatesV1(body)
         return mapResponse(response, fromCache)

--- a/core/catalog/src/test/java/cx/aswin/boxlore/core/catalog/home/HomeCandidatesRequestBuilderTest.kt
+++ b/core/catalog/src/test/java/cx/aswin/boxlore/core/catalog/home/HomeCandidatesRequestBuilderTest.kt
@@ -1,0 +1,68 @@
+package cx.aswin.boxlore.core.catalog.home
+
+import cx.aswin.boxlore.core.network.model.HistoryItem
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Response
+import cx.aswin.boxlore.core.network.model.HomeCandidateModulesDto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeCandidatesRequestBuilderTest {
+    @Test
+    fun buildSeedsPreferCompletedAndLiked() {
+        val seeds =
+            HomeCandidatesRequestBuilder.buildSeeds(
+                listOf(
+                    HistoryItem(
+                        episodeId = "1",
+                        podcastId = "a",
+                        episodeTitle = "Weak",
+                        podcastTitle = "A",
+                        progressMs = 1_000L,
+                        durationMs = 100_000L,
+                    ),
+                    HistoryItem(
+                        episodeId = "2",
+                        podcastId = "b",
+                        episodeTitle = "Liked",
+                        podcastTitle = "B",
+                        isLiked = true,
+                    ),
+                    HistoryItem(
+                        episodeId = "3",
+                        podcastId = "c",
+                        episodeTitle = "Done",
+                        podcastTitle = "C",
+                        isCompleted = true,
+                    ),
+                ),
+            )
+        assertEquals("2", seeds.first().episodeId)
+        assertTrue(seeds.first().weight >= 0.9)
+    }
+
+    @Test
+    fun isValidRequiresSuccessfulContract() {
+        assertFalse(
+            HomeCandidatesRequestBuilder.isValid(
+                HomeCandidatesV1Response(status = "false"),
+            ),
+        )
+        assertTrue(
+            HomeCandidatesRequestBuilder.isValid(
+                HomeCandidatesV1Response(
+                    status = "true",
+                    contractVersion = 1,
+                    algorithmVersion = "home-candidates-v1",
+                    modules = HomeCandidateModulesDto(),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun cacheTtlIsAtLeastFourHours() {
+        assertTrue(HomeCandidatesRequestBuilder.CACHE_TTL_MILLIS >= 4L * 60L * 60L * 1_000L)
+    }
+}

--- a/core/network/README.md
+++ b/core/network/README.md
@@ -8,7 +8,8 @@ Owns the Retrofit API boundary, OkHttp/Retrofit construction, request and respon
 
 - `BoxLoreApi` defines the Retrofit service surface.
 - `NetworkModule` creates OkHttp, Retrofit, and related network clients.
-- DTOs under `cx.aswin.boxlore.core.network.model`, including content-section, recommendation, history, sync, and request payload models.
+- DTOs under `cx.aswin.boxlore.core.network.model`, including content-section, recommendation, Home candidates (`HomeCandidatesV1Request` / `HomeCandidatesV1Response`), history, sync, and request payload models.
+- `BoxLoreApi.getHomeCandidatesV1` for `POST /home/candidates/v1` (additive; legacy recommendation routes remain).
 - App Check, app version, public-key, and device-header hooks used by application wiring.
 
 ## Internal structure

--- a/core/network/src/main/java/cx/aswin/boxlore/core/network/BoxLoreApi.kt
+++ b/core/network/src/main/java/cx/aswin/boxlore/core/network/BoxLoreApi.kt
@@ -28,6 +28,8 @@ import cx.aswin.boxlore.core.network.model.ContentSectionsV1Request
 import cx.aswin.boxlore.core.network.model.ContentSectionsV1Response
 import cx.aswin.boxlore.core.network.model.RecommendationsV2Request
 import cx.aswin.boxlore.core.network.model.RecommendationsV2Response
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Request
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Response
 import cx.aswin.boxlore.core.network.model.CuratedCuriosityResponseDto
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -156,6 +158,13 @@ interface BoxLoreApi {
         @Header("X-Device-UUID") deviceUuid: String,
         @Body request: RecommendationsV2Request,
     ): retrofit2.Call<RecommendationsV2Response>
+
+    @POST("home/candidates/v1")
+    suspend fun getHomeCandidatesV1(
+        @Header("X-App-Key") publicKey: String,
+        @Header("X-Device-UUID") deviceUuid: String,
+        @Body request: HomeCandidatesV1Request,
+    ): HomeCandidatesV1Response
 
     @GET("content/catalog/v3")
     fun getContentCatalog(

--- a/core/network/src/main/java/cx/aswin/boxlore/core/network/model/HomeCandidatesModels.kt
+++ b/core/network/src/main/java/cx/aswin/boxlore/core/network/model/HomeCandidatesModels.kt
@@ -1,0 +1,74 @@
+package cx.aswin.boxlore.core.network.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HomeCandidatesV1Request(
+    val contractVersion: Int = 1,
+    val requestedModules: List<String> = listOf("taste", "because_you_like", "mission"),
+    val country: String = "us",
+    val languages: List<String> = emptyList(),
+    val seeds: List<HomeCandidateSeedDto> = emptyList(),
+    val anchorPodcastId: String? = null,
+    val missionId: String? = null,
+    val excludedPodcastIds: List<String> = emptyList(),
+    val excludedEpisodeIds: List<String> = emptyList(),
+    val noveltyPreference: Double? = null,
+    val tasteBudget: Int = 24,
+    val becauseYouLikeBudget: Int = 18,
+    val missionBudget: Int = 12,
+    val daypart: String? = null,
+    val revision: String? = null,
+)
+
+@Serializable
+data class HomeCandidateSeedDto(
+    val episodeId: String? = null,
+    val podcastId: String? = null,
+    val weight: Double = 0.5,
+    val fallback: HomeCandidateSeedFallbackDto? = null,
+)
+
+@Serializable
+data class HomeCandidateSeedFallbackDto(
+    val episodeTitle: String? = null,
+    val podcastTitle: String? = null,
+    val description: String? = null,
+)
+
+@Serializable
+data class HomeCandidatesV1Response(
+    val status: String = "false",
+    val contractVersion: Int = 1,
+    val algorithmVersion: String? = null,
+    val inventoryVersion: String? = null,
+    val requestId: String? = null,
+    val modules: HomeCandidateModulesDto = HomeCandidateModulesDto(),
+)
+
+@Serializable
+data class HomeCandidateModulesDto(
+    val taste: List<HomeCandidateItemDto> = emptyList(),
+    val becauseYouLike: List<HomeCandidateItemDto> = emptyList(),
+    val mission: List<HomeCandidateItemDto> = emptyList(),
+    val regional: List<HomeCandidateItemDto> = emptyList(),
+)
+
+@Serializable
+data class HomeCandidateItemDto(
+    val episodeId: String? = null,
+    val podcastId: String? = null,
+    val title: String? = null,
+    val podcastTitle: String? = null,
+    val imageUrl: String? = null,
+    val podcastImageUrl: String? = null,
+    val audioUrl: String? = null,
+    val durationSeconds: Int? = null,
+    val publishedDate: Long? = null,
+    val genre: String? = null,
+    val priorScore: Double = 0.0,
+    val retrievalScore: Double = 0.0,
+    val source: String? = null,
+    val reason: String? = null,
+    val isNovel: Boolean = false,
+)

--- a/core/network/src/test/java/cx/aswin/boxlore/core/network/BoxLoreApiContractTest.kt
+++ b/core/network/src/test/java/cx/aswin/boxlore/core/network/BoxLoreApiContractTest.kt
@@ -2,6 +2,8 @@ package cx.aswin.boxlore.core.network
 
 import cx.aswin.boxlore.core.network.model.BootstrapRequest
 import cx.aswin.boxlore.core.network.model.ContentSectionsV1Request
+import cx.aswin.boxlore.core.network.model.HomeCandidateSeedDto
+import cx.aswin.boxlore.core.network.model.HomeCandidatesV1Request
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -219,6 +221,64 @@ class BoxLoreApiContractTest {
             assertEquals("POST", recorded.method)
             assertEquals("/content/sections/v1", recorded.path)
             assertEquals(DEVICE_UUID, recorded.getHeader("X-Device-UUID"))
+        }
+
+    @Test
+    fun `getHomeCandidatesV1 encodes request and decodes modules`() =
+        runTest {
+            enqueueFixture("fixtures/home_candidates_v1.json")
+
+            val body =
+                api.getHomeCandidatesV1(
+                    publicKey = APP_KEY,
+                    deviceUuid = DEVICE_UUID,
+                    request =
+                        HomeCandidatesV1Request(
+                            contractVersion = 1,
+                            requestedModules = listOf("taste", "because_you_like"),
+                            country = "us",
+                            languages = listOf("en"),
+                            seeds =
+                                listOf(
+                                    HomeCandidateSeedDto(
+                                        episodeId = "42",
+                                        podcastId = "7",
+                                        weight = 0.85,
+                                    ),
+                                ),
+                            anchorPodcastId = "7",
+                            tasteBudget = 12,
+                            becauseYouLikeBudget = 8,
+                            missionBudget = 6,
+                        ),
+                )
+
+            assertEquals("true", body.status)
+            assertEquals(1, body.contractVersion)
+            assertEquals("home-candidates-v1.0", body.algorithmVersion)
+            assertEquals(1, body.modules.taste.size)
+            assertEquals(1, body.modules.becauseYouLike.size)
+            assertEquals(0, body.modules.mission.size)
+
+            val taste = body.modules.taste.single()
+            assertEquals("1001", taste.episodeId)
+            assertEquals("500", taste.podcastId)
+            assertEquals("https://audio.example/taste.mp3", taste.audioUrl)
+            assertEquals(1800, taste.durationSeconds)
+            assertEquals("semantic_seed", taste.source)
+            assertEquals("matches_your_listening", taste.reason)
+
+            val recorded = server.takeRequest()
+            assertEquals("POST", recorded.method)
+            assertEquals("/home/candidates/v1", recorded.path)
+            assertEquals(DEVICE_UUID, recorded.getHeader("X-Device-UUID"))
+            val requestBody = recorded.body.readUtf8()
+            // Android emits camelCase per kotlinx.serialization defaults; these are
+            // the field names the proxy `parseHomeCandidatesRequest` expects.
+            assertTrue(requestBody.contains("\"requestedModules\""))
+            assertTrue(requestBody.contains("\"tasteBudget\":12"))
+            assertTrue(requestBody.contains("\"becauseYouLikeBudget\":8"))
+            assertTrue(requestBody.contains("\"anchorPodcastId\":\"7\""))
         }
 
     @Test

--- a/core/network/src/test/resources/fixtures/home_candidates_v1.json
+++ b/core/network/src/test/resources/fixtures/home_candidates_v1.json
@@ -1,0 +1,49 @@
+{
+  "status": "true",
+  "contractVersion": 1,
+  "algorithmVersion": "home-candidates-v1.0",
+  "inventoryVersion": "sync-2026-07-21",
+  "requestId": "abc123def456",
+  "modules": {
+    "taste": [
+      {
+        "episodeId": "1001",
+        "podcastId": "500",
+        "title": "Taste Episode",
+        "podcastTitle": "Taste Show",
+        "imageUrl": "https://img.example/taste.jpg",
+        "podcastImageUrl": "https://img.example/taste-show.jpg",
+        "audioUrl": "https://audio.example/taste.mp3",
+        "durationSeconds": 1800,
+        "publishedDate": 1750000000,
+        "genre": "News",
+        "priorScore": 0.0,
+        "retrievalScore": 0.87,
+        "source": "semantic_seed",
+        "reason": "matches_your_listening",
+        "isNovel": false
+      }
+    ],
+    "becauseYouLike": [
+      {
+        "episodeId": "2001",
+        "podcastId": "600",
+        "title": "BYL Episode",
+        "podcastTitle": "BYL Neighbor Show",
+        "imageUrl": null,
+        "podcastImageUrl": "https://img.example/byl-show.jpg",
+        "audioUrl": "https://audio.example/byl.mp3",
+        "durationSeconds": 1200,
+        "publishedDate": 1750001000,
+        "genre": "Tech",
+        "priorScore": 0.0,
+        "retrievalScore": 0.72,
+        "source": "because_you_like",
+        "reason": "neighbor_of_anchor",
+        "isNovel": false
+      }
+    ],
+    "mission": [],
+    "regional": []
+  }
+}

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackTelemetrySession.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackTelemetrySession.kt
@@ -66,6 +66,8 @@ internal class PlaybackTelemetrySession(
         private set
     var contextSourceId: String? = null
         private set
+    var exposureId: String? = null
+        private set
 
     private var bufferingStartTimeMs: Long = 0L
     private var totalBufferedTimeMs: Long = 0L
@@ -135,17 +137,22 @@ internal class PlaybackTelemetrySession(
         val pendingEntryPoint = PendingEntryPoint.consume()
         if (pendingEntryPoint != null) {
             entryPoint = pendingEntryPoint["entry_point"] as? String
-            val contextMap = pendingEntryPoint.filterKeys { it != "entry_point" }
+            exposureId = pendingEntryPoint[PendingEntryPoint.KEY_EXPOSURE_ID] as? String
+            val contextMap =
+                pendingEntryPoint.filterKeys {
+                    it != "entry_point" && it != PendingEntryPoint.KEY_EXPOSURE_ID
+                }
             entryPointContext = contextMap.ifEmpty { null }
         } else {
             extras?.keySet()?.forEach { key ->
                 @Suppress("DEPRECATION")
                 val value = extras.get(key)
-                if (value != null && key != "entry_point") {
+                if (value != null && key != "entry_point" && key != PendingEntryPoint.KEY_EXPOSURE_ID) {
                     bundleMap[key] = value
                 }
             }
             entryPoint = extras?.getString("entry_point")
+            exposureId = extras?.getString(PendingEntryPoint.KEY_EXPOSURE_ID)
             entryPointContext = if (bundleMap.isNotEmpty()) bundleMap else null
         }
 
@@ -314,6 +321,7 @@ internal class PlaybackTelemetrySession(
         val sessionTotalDurationMs = totalDurationMs
         val sessionEntryPoint = entryPoint
         val sessionEntryPointContext = entryPointContext
+        val currentExposureId = exposureId
 
         var isCompleted = forceCompleted
         if (!isCompleted) {
@@ -435,6 +443,7 @@ internal class PlaybackTelemetrySession(
                         podcastId = currentPodcastId.orEmpty(),
                         genre = currentPodcastGenre,
                         source = adaptiveSource,
+                        exposureId = currentExposureId,
                     ),
                 listenSeconds = consumedAudioSeconds.toLong().coerceAtLeast(0L),
                 durationSeconds = (sessionTotalDurationMs / 1_000L).coerceAtLeast(0L),
@@ -492,6 +501,7 @@ internal class PlaybackTelemetrySession(
         isRepeating = false
         entryPoint = null
         entryPointContext = null
+        exposureId = null
     }
 
     fun updateConsumedAudio(player: Player) {

--- a/core/prefs/src/main/java/cx/aswin/boxlore/core/prefs/BoxcastPrefs.kt
+++ b/core/prefs/src/main/java/cx/aswin/boxlore/core/prefs/BoxcastPrefs.kt
@@ -79,6 +79,21 @@ class BoxcastPrefs(context: Context) {
             .apply()
     }
 
+    /**
+     * Clears Home recommendation and Because You Like caches only.
+     * Used by the personalization pipeline migration; does not touch listening
+     * history, subscriptions, queue, downloads, or onboarding prefs.
+     */
+    fun clearPersonalizationCaches() {
+        prefs.edit()
+            .remove(KEY_CACHED_RECOMMENDATIONS)
+            .remove(KEY_IS_RECOMMENDATIONS_FALLBACK)
+            .remove(KEY_CACHED_BYL_RECOMMENDATIONS)
+            .remove(KEY_CACHED_BYL_PODCASTS)
+            .remove(KEY_CACHED_BYL_PODCAST_ID)
+            .apply()
+    }
+
     // ── Learn curiosity history ─────────────────────────────────────────────
 
     fun getLearnCuriosityHistoryJson(): String? =

--- a/core/prefs/src/test/java/cx/aswin/boxlore/core/prefs/BoxcastPrefsTest.kt
+++ b/core/prefs/src/test/java/cx/aswin/boxlore/core/prefs/BoxcastPrefsTest.kt
@@ -52,6 +52,19 @@ class BoxcastPrefsTest {
     }
 
     @Test
+    fun clearPersonalizationCachesRemovesRecsAndByl() {
+        prefs.saveRecommendationsCache("""[{"id":1}]""", isFallback = false)
+        prefs.saveBylCache(episodesJson = "[]", podcastsJson = "[]", podcastId = "42")
+        prefs.setOnboardingCompleted(true)
+        prefs.clearPersonalizationCaches()
+        assertNull(prefs.getCachedRecommendationsJson())
+        assertTrue(prefs.isRecommendationsFallback())
+        assertNull(prefs.getCachedBylPodcastId())
+        assertNull(prefs.getCachedBylRecommendationsJson())
+        assertTrue(prefs.isOnboardingCompleted())
+    }
+
+    @Test
     fun bylCacheRoundTrip() {
         assertNull(prefs.getCachedBylPodcastId())
         prefs.saveBylCache(episodesJson = "[]", podcastsJson = "[]", podcastId = "42")

--- a/core/ranking/README.md
+++ b/core/ranking/README.md
@@ -7,11 +7,12 @@ Owns adaptive recommendation and candidate scoring: Bayesian facet preferences, 
 ## Public API
 
 - `AdaptiveCandidateScorer` scores podcasts and episodes for home, explore, queue, and downloads.
-- `AdaptiveRankingRepository` owns ranking state, exposure recording, facet affinities, backup, and restore.
-- `RankingFeedbackRepository` records user actions and implements `RankingResetPort`.
+- `AdaptiveRankingRepository` owns ranking state, exposure recording, facet affinities, hard-hide exclusions, the outcome ledger, backup/restore, and the destructive `ensurePipelineMigrated` gate on `PERSONALIZATION_PIPELINE_VERSION`.
+- `RankingFeedbackRepository` records user actions and explicit boosts/penalties (`hideShow`, `moreLikeThis`, `notForMe`, `recordManualAnchor`), applies exact-token exposure attribution with delta reward when a settled exposure receives a later signal, and implements `RankingResetPort`.
 - `RankingRuntimeControls` exposes runtime toggles for ranking surfaces.
 - `RankingObjective`, `RankingSurface`, and `CandidateSource` define scoring context.
-- `RankingAction`, `RankingOutcome`, and `RankingReward` define feedback and reward semantics.
+- `RankingAction`, `RankingOutcome`, and `RankingReward` define feedback and reward semantics (including `MORE_LIKE_THIS`, `NOT_FOR_ME`, `HIDE_SHOW`, `MANUAL_ANCHOR`).
+- `BayesianPreferenceFacet.belief(now)` and `FacetBelief(affinity, confidence, evidence)` expose evidence-weighted taste readings.
 - `DiversityPolicy` and `DiversityReranker` shape scored candidate lists.
 - `AdaptiveRankingBackup`, `LearningEventLog`, and `RankingShadowDiagnostics` support backup and diagnostics.
 
@@ -33,7 +34,7 @@ src/main/java/cx/aswin/boxlore/core/ranking/
   database/
     AdaptiveRankingDao.kt
     AdaptiveRankingDatabase.kt
-    AdaptiveRankingEntities.kt
+    AdaptiveRankingEntities.kt  # Model, facet, exposure, hard exclusion, and outcome ledger entities
 ```
 
 ## Dependencies
@@ -51,8 +52,8 @@ src/main/java/cx/aswin/boxlore/core/ranking/
 
 ## Persistence & identity
 
-- Room filename `adaptive_ranking_database` stores ranking models, facets, and exposures.
-- SharedPreferences file `adaptive_ranking_runtime` stores runtime control values.
+- Room filename `adaptive_ranking_database` stores ranking models, facets, exposures, hard-hide exclusions, and the outcome ledger. Schema version 2 uses `fallbackToDestructiveMigration(dropAllTables = true)` — personalization state is disposable across the Home rebuild.
+- SharedPreferences file `adaptive_ranking_runtime` stores runtime control values and the `personalization_pipeline_version` key gating one-shot pipeline wipes.
 - Package root is `cx.aswin.boxlore.core.ranking`.
 - App backup rules exclude the adaptive database from automatic platform backup; explicit encrypted backup support is handled through ranking backup models.
 

--- a/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/AdaptiveRankingRepository.kt
+++ b/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/AdaptiveRankingRepository.kt
@@ -2,10 +2,13 @@ package cx.aswin.boxlore.core.ranking
 
 import android.content.Context
 import androidx.room.withTransaction
+import android.content.SharedPreferences
 import cx.aswin.boxlore.core.ranking.database.AdaptiveModelEntity
 import cx.aswin.boxlore.core.ranking.database.AdaptiveRankingDatabase
+import cx.aswin.boxlore.core.ranking.database.HardShowExclusionEntity
 import cx.aswin.boxlore.core.ranking.database.PreferenceFacetEntity
 import cx.aswin.boxlore.core.ranking.database.RankingExposureEntity
+import cx.aswin.boxlore.core.ranking.database.RankingOutcomeEntity
 import cx.aswin.boxlore.core.model.PodcastGenres
 import cx.aswin.boxlore.core.model.RankingAggregateTelemetry
 import java.util.UUID
@@ -27,6 +30,11 @@ data class RankingExposure(
     val entryPoint: String? = null,
     val online: Boolean,
     val shownAt: Long = System.currentTimeMillis(),
+    val sessionId: String? = null,
+    val rankPosition: Int? = null,
+    val intentId: String? = null,
+    val retrievalReason: String? = null,
+    val revision: String? = null,
 )
 
 data class RankingDebugSnapshot(
@@ -150,6 +158,12 @@ class AdaptiveRankingRepository private constructor(
                 listenSeconds = 0,
                 entryPoint = exposure.entryPoint,
                 online = exposure.online,
+                sessionId = exposure.sessionId,
+                rankPosition = exposure.rankPosition,
+                intentId = exposure.intentId,
+                retrievalReason = exposure.retrievalReason,
+                revision = exposure.revision,
+                accumulatedReward = null,
             ),
         )
         val insertCount = exposureInsertCount.incrementAndGet()
@@ -257,6 +271,146 @@ class AdaptiveRankingRepository private constructor(
             return false
         }
         return resolveExposure(exposure.exposureId, reward, listenSeconds, resolvedAt)
+    }
+
+    /**
+     * Applies a reward delta to an already-resolved exposure using its stored feature vector.
+     * Used when later outcomes (like/complete) arrive after the first settle.
+     */
+    suspend fun applyRewardDelta(
+        exposureId: String,
+        newReward: Double,
+        listenSeconds: Long = 0,
+        resolvedAt: Long = System.currentTimeMillis(),
+    ): Boolean {
+        val exposure = dao.getExposure(exposureId) ?: return false
+        if (exposure.resolvedAt == null) return false
+        val previousReward = exposure.accumulatedReward ?: exposure.reward ?: 0.0
+        val boundedNew = newReward.coerceIn(-1.0, 1.0)
+        val delta = (boundedNew - previousReward).coerceIn(-1.0, 1.0)
+        if (kotlin.math.abs(delta) < 1e-9) {
+            dao.updateResolvedReward(exposureId, boundedNew, listenSeconds.coerceAtLeast(0))
+            return true
+        }
+        val objective = runCatching { RankingObjective.valueOf(exposure.objective) }.getOrNull()
+            ?: return false
+        if (exposure.featureSchemaVersion != RankingFeatureSchema.VERSION) return false
+        val features = runCatching {
+            RankingFeatures(
+                schemaVersion = exposure.featureSchemaVersion,
+                values = RankingSerialization.decode(
+                    exposure.featureVector,
+                    RankingFeatureSchema.dimension,
+                ),
+            )
+        }.getOrNull() ?: return false
+        return objectiveLock(objective).withLock {
+            database.withTransaction {
+                val changed = dao.updateResolvedReward(
+                    exposureId = exposureId,
+                    reward = boundedNew,
+                    listenSeconds = listenSeconds.coerceAtLeast(0),
+                )
+                if (changed == 0) return@withTransaction false
+                val previous = loadState(objective)
+                val updated = model.update(features, delta, previous)
+                dao.upsertModel(updated.toEntity(objective, resolvedAt))
+                true
+            }
+        }
+    }
+
+    suspend fun appendOutcome(outcome: RankingOutcomeEntity) {
+        dao.insertOutcome(outcome)
+    }
+
+    suspend fun excludeShow(
+        podcastId: String,
+        reason: String,
+        sourceExposureId: String? = null,
+        now: Long = System.currentTimeMillis(),
+    ) {
+        val normalized = podcastId.trim()
+        if (normalized.isEmpty()) return
+        dao.upsertExclusion(
+            HardShowExclusionEntity(
+                podcastId = normalized,
+                reason = reason.take(64),
+                createdAt = now,
+                sourceExposureId = sourceExposureId,
+            ),
+        )
+    }
+
+    suspend fun isHardExcluded(podcastId: String): Boolean {
+        val normalized = podcastId.trim()
+        if (normalized.isEmpty()) return false
+        return dao.getExclusion(normalized) != null
+    }
+
+    suspend fun hardExcludedPodcastIds(): Set<String> =
+        dao.getExcludedPodcastIds().toSet()
+
+    /**
+     * One-shot destructive personalization wipe when pipeline version advances.
+     * Returns true when a wipe ran.
+     */
+    suspend fun ensurePipelineMigrated(prefs: SharedPreferences): Boolean {
+        val stored = prefs.getInt(PIPELINE_VERSION_KEY, 0)
+        if (stored >= PERSONALIZATION_PIPELINE_VERSION) return false
+        dao.clearAll()
+        RankingShadowDiagnostics.clear()
+        LearningEventLog.clear()
+        prefs.edit().putInt(PIPELINE_VERSION_KEY, PERSONALIZATION_PIPELINE_VERSION).apply()
+        return true
+    }
+
+    suspend fun facetBelief(
+        type: PreferenceFacetType,
+        key: String,
+        now: Long = System.currentTimeMillis(),
+    ): FacetBelief {
+        val normalizedKey = key.normalizedFacetKey()
+        if (normalizedKey.isEmpty()) {
+            return FacetBelief(affinity = 0.0, confidence = 0.0, evidence = 0.0)
+        }
+        return dao.getFacet(type.name, normalizedKey)
+            ?.toFacet()
+            ?.belief(now)
+            ?: FacetBelief(affinity = 0.0, confidence = 0.0, evidence = 0.0)
+    }
+
+    suspend fun facetBeliefs(
+        keys: Set<PreferenceFacetKey>,
+        now: Long = System.currentTimeMillis(),
+    ): Map<PreferenceFacetKey, FacetBelief> {
+        if (keys.isEmpty()) return emptyMap()
+        val stored = dao.getAllFacets().associateBy { entity ->
+            entity.facetType to entity.facetKey
+        }
+        return keys.associateWith { request ->
+            stored[request.type.name to request.key.normalizedFacetKey()]
+                ?.toFacet()
+                ?.belief(now)
+                ?: FacetBelief(affinity = 0.0, confidence = 0.0, evidence = 0.0)
+        }
+    }
+
+    /**
+     * All decayed SHOW facet beliefs for Home anchor selection.
+     * Bounded to keep Home cold-start selection cheap.
+     */
+    suspend fun showFacetBeliefs(
+        now: Long = System.currentTimeMillis(),
+        limit: Int = 64,
+    ): List<Pair<String, FacetBelief>> {
+        return dao.getFacetsByType(PreferenceFacetType.SHOW.name)
+            .mapNotNull { entity ->
+                val key = entity.facetKey.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                key to entity.toFacet().belief(now)
+            }
+            .sortedByDescending { (_, belief) -> belief.affinity * belief.confidence }
+            .take(limit)
     }
 
     suspend fun facetAffinity(
@@ -599,6 +753,9 @@ class AdaptiveRankingRepository private constructor(
         private const val EXPOSURE_PRUNE_INTERVAL = 25L
         private const val EXPOSURE_RETENTION_MILLIS = 30L * 24L * 60L * 60L * 1_000L
         private const val MIN_EXPORTED_GENRE_AFFINITY = 0.01
+        const val PERSONALIZATION_PIPELINE_VERSION = 2
+        const val PIPELINE_VERSION_KEY = "personalization_pipeline_version"
+        const val RUNTIME_PREFS_NAME = "adaptive_ranking_runtime"
 
         @Volatile
         private var instance: AdaptiveRankingRepository? = null

--- a/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/BayesianPreferenceFacet.kt
+++ b/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/BayesianPreferenceFacet.kt
@@ -1,5 +1,6 @@
 package cx.aswin.boxlore.core.ranking
 
+import kotlin.math.exp
 import kotlin.math.pow
 
 enum class PreferenceFacetType {
@@ -10,6 +11,12 @@ enum class PreferenceFacetType {
     TIME_CONTEXT,
     INTENT,
 }
+
+data class FacetBelief(
+    val affinity: Double,
+    val confidence: Double,
+    val evidence: Double,
+)
 
 data class BayesianPreferenceFacet(
     val positiveEvidence: Double = 0.0,
@@ -54,7 +61,25 @@ data class BayesianPreferenceFacet(
         return ((posterior - 0.5) * 2.0).coerceIn(-1.0, 1.0)
     }
 
+    fun belief(
+        now: Long,
+        priorStrength: Double = 2.0,
+        evidenceScale: Double = 3.0,
+    ): FacetBelief {
+        val current = decayed(now)
+        val evidence = (current.positiveEvidence + current.negativeEvidence).coerceAtLeast(0.0)
+        val confidence = (1.0 - exp(-evidence / evidenceScale.coerceAtLeast(0.001)))
+            .coerceIn(0.0, 1.0)
+        return FacetBelief(
+            affinity = affinity(now, priorStrength),
+            confidence = confidence,
+            evidence = evidence,
+        )
+    }
+
     companion object {
         const val DEFAULT_HALF_LIFE_MILLIS: Long = 90L * 24L * 60L * 60L * 1_000L
+        /** Shorter half-life for temporary intent / daypart facets. */
+        const val INTENT_HALF_LIFE_MILLIS: Long = 3L * 24L * 60L * 60L * 1_000L
     }
 }

--- a/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/RankingFeedbackRepository.kt
+++ b/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/RankingFeedbackRepository.kt
@@ -2,6 +2,8 @@ package cx.aswin.boxlore.core.ranking
 
 import android.content.Context
 import android.util.Log
+import cx.aswin.boxlore.core.ranking.database.RankingOutcomeEntity
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CancellationException
 
@@ -10,12 +12,14 @@ data class FeedbackTarget(
     val podcastId: String,
     val genre: String? = null,
     val source: CandidateSource? = null,
+    val exposureId: String? = null,
 )
 
 class RankingFeedbackRepository private constructor(
     private val adaptiveRankingRepository: AdaptiveRankingRepository?,
 ) : cx.aswin.boxlore.core.domain.ports.RankingResetPort {
     private val recentActions = ConcurrentHashMap<String, Long>()
+    private val manualAnchors = ConcurrentHashMap<String, Long>()
 
     suspend fun recordExposure(exposure: RankingExposure): String {
         return safely("record exposure", "") {
@@ -62,11 +66,14 @@ class RankingFeedbackRepository private constructor(
             }
             updateTasteFacets(target, reward)
             if (action in terminalExposureActions) {
-                adaptiveRankingRepository?.resolveLatestExposure(
-                    episodeId = target.episodeId,
-                    reward = reward,
+                appendOutcomeLedger(
+                    target = target,
+                    action = action,
+                    partialReward = reward,
                     listenSeconds = listenSeconds,
+                    durationSeconds = durationSeconds,
                 )
+                settleOrApplyDelta(target, reward, listenSeconds)
             }
         }
     }
@@ -96,12 +103,12 @@ class RankingFeedbackRepository private constructor(
                     durationSeconds = durationSeconds,
                 ),
             )
+            val primary = when {
+                RankingAction.COMPLETE in actions -> RankingAction.COMPLETE
+                RankingAction.EARLY_SKIP in actions -> RankingAction.EARLY_SKIP
+                else -> RankingAction.MEANINGFUL_PLAY
+            }
             LearningEventLog.record { id, ts ->
-                val primary = when {
-                    RankingAction.COMPLETE in actions -> RankingAction.COMPLETE
-                    RankingAction.EARLY_SKIP in actions -> RankingAction.EARLY_SKIP
-                    else -> RankingAction.MEANINGFUL_PLAY
-                }
                 LearningEvent.ActionReceived(
                     id = id,
                     timestamp = ts,
@@ -114,11 +121,95 @@ class RankingFeedbackRepository private constructor(
                 )
             }
             updateTasteFacets(target, reward)
-            adaptiveRankingRepository?.resolveLatestExposure(
-                episodeId = target.episodeId,
-                reward = reward,
+            appendOutcomeLedger(
+                target = target,
+                action = primary,
+                partialReward = reward,
                 listenSeconds = listenSeconds,
+                durationSeconds = durationSeconds,
             )
+            settleOrApplyDelta(target, reward, listenSeconds)
+        }
+    }
+
+    /**
+     * Hard-hide a show from personalization surfaces and record a strong negative signal
+     * against SHOW / SOURCE / GENRE facets. The optional [exposureId] links the exclusion
+     * back to the impression that triggered it so telemetry can trace attribution.
+     */
+    suspend fun hideShow(
+        podcastId: String,
+        exposureId: String? = null,
+        episodeId: String = "",
+        genre: String? = null,
+        source: CandidateSource? = null,
+    ) {
+        safely("hide show", Unit) {
+            val repo = adaptiveRankingRepository ?: return@safely
+            repo.excludeShow(podcastId, reason = "hide_show", sourceExposureId = exposureId)
+            val target = FeedbackTarget(
+                episodeId = episodeId,
+                podcastId = podcastId,
+                genre = genre,
+                source = source,
+                exposureId = exposureId,
+            )
+            recordExplicitFeedback(target, RankingAction.HIDE_SHOW)
+        }
+    }
+
+    /**
+     * Record an explicit "more like this" boost against the podcast, source, and genre facets.
+     */
+    suspend fun moreLikeThis(target: FeedbackTarget) {
+        safely("more like this", Unit) {
+            recordExplicitFeedback(target, RankingAction.MORE_LIKE_THIS)
+        }
+    }
+
+    /**
+     * Record an explicit "not for me" penalty against the podcast, source, and genre facets.
+     */
+    suspend fun notForMe(target: FeedbackTarget) {
+        safely("not for me", Unit) {
+            recordExplicitFeedback(target, RankingAction.NOT_FOR_ME)
+        }
+    }
+
+    /**
+     * Anchor a show as an explicit personalization pin. Bounded once per podcast to prevent
+     * runaway boosts if the user opens the same anchor sheet repeatedly.
+     */
+    suspend fun recordManualAnchor(
+        podcastId: String,
+        genre: String? = null,
+    ) {
+        safely("record manual anchor", Unit) {
+            val normalized = podcastId.trim()
+            if (normalized.isEmpty()) return@safely
+            val now = System.currentTimeMillis()
+            val previous = manualAnchors.put(normalized, now)
+            if (previous != null && now - previous < MANUAL_ANCHOR_WINDOW_MILLIS) {
+                LearningEventLog.record { id, ts ->
+                    LearningEvent.DuplicateIgnored(
+                        id = id,
+                        timestamp = ts,
+                        action = RankingAction.MANUAL_ANCHOR,
+                        episodeId = normalized,
+                    )
+                }
+                return@safely
+            }
+            val repo = adaptiveRankingRepository ?: return@safely
+            val reward = RankingReward.partialForAction(RankingAction.MANUAL_ANCHOR)
+            repo.updateFacet(PreferenceFacetType.SHOW, normalized, reward, now)
+            genre?.let { repo.updateFacet(PreferenceFacetType.GENRE, it, GENRE_CREDIT * reward, now) }
+        }
+    }
+
+    suspend fun hardExcludedPodcastIds(): Set<String> {
+        return safely("hard exclusions", emptySet()) {
+            adaptiveRankingRepository?.hardExcludedPodcastIds() ?: emptySet()
         }
     }
 
@@ -126,10 +217,91 @@ class RankingFeedbackRepository private constructor(
         return safely("reset recommendations", false) {
             adaptiveRankingRepository?.reset()
             recentActions.clear()
+            manualAnchors.clear()
             RankingShadowDiagnostics.clear()
             LearningEventLog.clear()
             adaptiveRankingRepository != null
         }
+    }
+
+    private suspend fun recordExplicitFeedback(
+        target: FeedbackTarget,
+        action: RankingAction,
+    ) {
+        val reward = RankingReward.partialForAction(action)
+        LearningEventLog.record { id, ts ->
+            LearningEvent.ActionReceived(
+                id = id,
+                timestamp = ts,
+                action = action,
+                reward = reward,
+                podcastId = target.podcastId,
+                genre = target.genre,
+                source = target.source?.name,
+                listenSeconds = 0,
+            )
+        }
+        updateTasteFacets(target, reward)
+        appendOutcomeLedger(
+            target = target,
+            action = action,
+            partialReward = reward,
+            listenSeconds = 0,
+            durationSeconds = 0,
+        )
+        if (target.exposureId != null) {
+            settleOrApplyDelta(target, reward, listenSeconds = 0)
+        }
+    }
+
+    /**
+     * Resolve the pending exposure with the given reward when possible; if the exposure
+     * has already been settled by an earlier outcome, apply the reward delta on top so
+     * later signals nudge the model without double-counting the impression.
+     */
+    private suspend fun settleOrApplyDelta(
+        target: FeedbackTarget,
+        reward: Double,
+        listenSeconds: Long,
+    ) {
+        val repo = adaptiveRankingRepository ?: return
+        val exposureId = target.exposureId
+        if (exposureId != null) {
+            val resolved = repo.resolveExposure(exposureId, reward, listenSeconds)
+            if (!resolved) {
+                repo.applyRewardDelta(exposureId, reward, listenSeconds)
+            }
+            return
+        }
+        repo.resolveLatestExposure(
+            episodeId = target.episodeId,
+            reward = reward,
+            listenSeconds = listenSeconds,
+        )
+    }
+
+    private suspend fun appendOutcomeLedger(
+        target: FeedbackTarget,
+        action: RankingAction,
+        partialReward: Double,
+        listenSeconds: Long,
+        durationSeconds: Long,
+    ) {
+        val repo = adaptiveRankingRepository ?: return
+        repo.appendOutcome(
+            RankingOutcomeEntity(
+                outcomeId = UUID.randomUUID().toString(),
+                exposureId = target.exposureId,
+                episodeId = target.episodeId,
+                podcastId = target.podcastId,
+                action = action.name,
+                partialReward = partialReward.coerceIn(-1.0, 1.0),
+                listenSeconds = listenSeconds.coerceAtLeast(0L),
+                durationSeconds = durationSeconds.coerceAtLeast(0L),
+                recordedAt = System.currentTimeMillis(),
+                appliedToModel = target.exposureId != null || target.episodeId.isNotEmpty(),
+            ),
+        )
     }
 
     private suspend fun updateTasteFacets(
@@ -137,16 +309,15 @@ class RankingFeedbackRepository private constructor(
         reward: Double,
     ) {
         val repository = adaptiveRankingRepository ?: return
-        repository.updateFacet(PreferenceFacetType.SHOW, target.podcastId, reward)
-        // Skip placeholder "Podcast" / unknown labels — only canonical genres learn.
+        repository.updateFacet(PreferenceFacetType.SHOW, target.podcastId, SHOW_CREDIT * reward)
         target.genre?.let { genre ->
-            repository.updateFacet(PreferenceFacetType.GENRE, genre, reward)
+            repository.updateFacet(PreferenceFacetType.GENRE, genre, GENRE_CREDIT * reward)
         }
         target.source?.let { source ->
             repository.updateFacet(
                 PreferenceFacetType.SOURCE,
                 source.name,
-                reward,
+                SOURCE_CREDIT * reward,
             )
         }
     }
@@ -183,8 +354,14 @@ class RankingFeedbackRepository private constructor(
         private const val MEANINGFUL_PLAY_SECONDS = 60L
         private const val MEANINGFUL_PROGRESS_RATIO = 0.2
         private const val ACTION_DEDUP_WINDOW_MILLIS = 5_000L
+        private const val MANUAL_ANCHOR_WINDOW_MILLIS = 24L * 60L * 60L * 1_000L
         private const val MAX_RECENT_ACTIONS = 500
         private const val TAG = "RankingFeedback"
+
+        /** Facet credit shares — SHOW carries full reward; SOURCE / GENRE dampened. */
+        private const val SHOW_CREDIT = 1.0
+        private const val SOURCE_CREDIT = 0.5
+        private const val GENRE_CREDIT = 0.25
 
         private val terminalExposureActions = setOf(
             RankingAction.MEANINGFUL_PLAY,
@@ -200,6 +377,10 @@ class RankingFeedbackRepository private constructor(
             RankingAction.MOVE_UP,
             RankingAction.MOVE_DOWN,
             RankingAction.DISMISS,
+            RankingAction.MORE_LIKE_THIS,
+            RankingAction.NOT_FOR_ME,
+            RankingAction.HIDE_SHOW,
+            RankingAction.MANUAL_ANCHOR,
         )
 
         @Volatile

--- a/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/RankingFeedbackRepository.kt
+++ b/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/RankingFeedbackRepository.kt
@@ -15,6 +15,7 @@ data class FeedbackTarget(
     val exposureId: String? = null,
 )
 
+@Suppress("TooManyFunctions") // Feedback surface API: exposure, actions, anchors, exclusions, ledger.
 class RankingFeedbackRepository private constructor(
     private val adaptiveRankingRepository: AdaptiveRankingRepository?,
 ) : cx.aswin.boxlore.core.domain.ports.RankingResetPort {

--- a/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/RankingReward.kt
+++ b/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/RankingReward.kt
@@ -17,6 +17,10 @@ enum class RankingAction {
     MOVE_UP,
     MOVE_DOWN,
     DISMISS,
+    MORE_LIKE_THIS,
+    NOT_FOR_ME,
+    HIDE_SHOW,
+    MANUAL_ANCHOR,
 }
 
 data class RankingOutcome(
@@ -41,6 +45,10 @@ object RankingReward {
         RankingAction.MOVE_UP to 0.25,
         RankingAction.MOVE_DOWN to -0.25,
         RankingAction.DISMISS to -0.75,
+        RankingAction.MORE_LIKE_THIS to 0.55,
+        RankingAction.NOT_FOR_ME to -0.7,
+        RankingAction.HIDE_SHOW to -0.85,
+        RankingAction.MANUAL_ANCHOR to 0.35,
     )
 
     fun calculate(outcome: RankingOutcome): Double {
@@ -48,6 +56,9 @@ object RankingReward {
         val listenReward = listeningValue(outcome.listenSeconds, outcome.durationSeconds)
         return (actionReward + listenReward).coerceIn(-1.0, 1.0)
     }
+
+    fun partialForAction(action: RankingAction): Double =
+        (actionWeights[action] ?: 0.0).coerceIn(-1.0, 1.0)
 
     private fun listeningValue(
         listenSeconds: Long,

--- a/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/database/AdaptiveRankingDao.kt
+++ b/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/database/AdaptiveRankingDao.kt
@@ -74,13 +74,31 @@ interface AdaptiveRankingDao {
     @Query(
         """
         UPDATE ranking_exposures
-        SET resolvedAt = :resolvedAt, reward = :reward, listenSeconds = :listenSeconds
+        SET resolvedAt = :resolvedAt,
+            reward = :reward,
+            listenSeconds = :listenSeconds,
+            accumulatedReward = :reward
         WHERE exposureId = :exposureId AND resolvedAt IS NULL
         """,
     )
     suspend fun resolveExposure(
         exposureId: String,
         resolvedAt: Long,
+        reward: Double,
+        listenSeconds: Long,
+    ): Int
+
+    @Query(
+        """
+        UPDATE ranking_exposures
+        SET reward = :reward,
+            accumulatedReward = :reward,
+            listenSeconds = :listenSeconds
+        WHERE exposureId = :exposureId AND resolvedAt IS NOT NULL
+        """,
+    )
+    suspend fun updateResolvedReward(
+        exposureId: String,
         reward: Double,
         listenSeconds: Long,
     ): Int
@@ -100,6 +118,30 @@ interface AdaptiveRankingDao {
     )
     suspend fun pruneExposuresToCount(keepCount: Int): Int
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertExclusion(exclusion: HardShowExclusionEntity)
+
+    @Query("SELECT * FROM hard_show_exclusions")
+    suspend fun getAllExclusions(): List<HardShowExclusionEntity>
+
+    @Query("SELECT podcastId FROM hard_show_exclusions")
+    suspend fun getExcludedPodcastIds(): List<String>
+
+    @Query("SELECT * FROM hard_show_exclusions WHERE podcastId = :podcastId LIMIT 1")
+    suspend fun getExclusion(podcastId: String): HardShowExclusionEntity?
+
+    @Query("DELETE FROM hard_show_exclusions WHERE podcastId = :podcastId")
+    suspend fun deleteExclusion(podcastId: String)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertOutcome(outcome: RankingOutcomeEntity)
+
+    @Query("SELECT * FROM ranking_outcomes WHERE exposureId = :exposureId ORDER BY recordedAt ASC")
+    suspend fun getOutcomesForExposure(exposureId: String): List<RankingOutcomeEntity>
+
+    @Query("SELECT * FROM ranking_outcomes ORDER BY recordedAt DESC LIMIT :limit")
+    suspend fun getRecentOutcomes(limit: Int): List<RankingOutcomeEntity>
+
     @Query("DELETE FROM adaptive_models")
     suspend fun clearModels()
 
@@ -109,11 +151,19 @@ interface AdaptiveRankingDao {
     @Query("DELETE FROM ranking_exposures")
     suspend fun clearExposures()
 
+    @Query("DELETE FROM hard_show_exclusions")
+    suspend fun clearExclusions()
+
+    @Query("DELETE FROM ranking_outcomes")
+    suspend fun clearOutcomes()
+
     @Transaction
     suspend fun clearAll() {
         clearModels()
         clearFacets()
         clearExposures()
+        clearExclusions()
+        clearOutcomes()
     }
 
     @Transaction

--- a/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/database/AdaptiveRankingDatabase.kt
+++ b/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/database/AdaptiveRankingDatabase.kt
@@ -10,8 +10,10 @@ import androidx.room.RoomDatabase
         AdaptiveModelEntity::class,
         PreferenceFacetEntity::class,
         RankingExposureEntity::class,
+        HardShowExclusionEntity::class,
+        RankingOutcomeEntity::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = false,
 )
 abstract class AdaptiveRankingDatabase : RoomDatabase() {
@@ -29,7 +31,10 @@ abstract class AdaptiveRankingDatabase : RoomDatabase() {
                     context.applicationContext,
                     AdaptiveRankingDatabase::class.java,
                     DATABASE_NAME,
-                ).build()
+                )
+                    // Personalization state is disposable across this rebuild; wipe on schema bump.
+                    .fallbackToDestructiveMigration(dropAllTables = true)
+                    .build()
                     .also { instance = it }
             }
         }

--- a/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/database/AdaptiveRankingEntities.kt
+++ b/core/ranking/src/main/java/cx/aswin/boxlore/core/ranking/database/AdaptiveRankingEntities.kt
@@ -48,4 +48,38 @@ data class RankingExposureEntity(
     val listenSeconds: Long,
     val entryPoint: String?,
     val online: Boolean,
+    val sessionId: String? = null,
+    val rankPosition: Int? = null,
+    val intentId: String? = null,
+    val retrievalReason: String? = null,
+    val revision: String? = null,
+    val accumulatedReward: Double? = null,
+)
+
+@Entity(
+    tableName = "hard_show_exclusions",
+    primaryKeys = ["podcastId"],
+)
+data class HardShowExclusionEntity(
+    val podcastId: String,
+    val reason: String,
+    val createdAt: Long,
+    val sourceExposureId: String? = null,
+)
+
+@Entity(
+    tableName = "ranking_outcomes",
+    primaryKeys = ["outcomeId"],
+)
+data class RankingOutcomeEntity(
+    val outcomeId: String,
+    val exposureId: String?,
+    val episodeId: String,
+    val podcastId: String,
+    val action: String,
+    val partialReward: Double,
+    val listenSeconds: Long,
+    val durationSeconds: Long,
+    val recordedAt: Long,
+    val appliedToModel: Boolean,
 )

--- a/core/ranking/src/test/java/cx/aswin/boxlore/core/ranking/AdaptiveRankingRepositoryTest.kt
+++ b/core/ranking/src/test/java/cx/aswin/boxlore/core/ranking/AdaptiveRankingRepositoryTest.kt
@@ -7,6 +7,8 @@ import cx.aswin.boxlore.core.ranking.database.AdaptiveModelEntity
 import cx.aswin.boxlore.core.ranking.database.AdaptiveRankingDatabase
 import cx.aswin.boxlore.core.ranking.database.PreferenceFacetEntity
 import cx.aswin.boxlore.core.ranking.database.RankingExposureEntity
+import cx.aswin.boxlore.core.ranking.database.RankingOutcomeEntity
+import java.util.UUID
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -431,6 +433,134 @@ class AdaptiveRankingRepositoryTest {
             assertEquals(0.4, score.finalScore, 1e-9)
             assertEquals(0.0, score.learnedBlend, 0.0)
             assertEquals(0L, score.updateCount)
+        }
+
+    @Test
+    fun applyRewardDeltaMovesResolvedExposureRewardOnLaterSignal() =
+        runTest {
+            val id = repository.recordExposure(exposure())
+            assertTrue(repository.resolveExposure(id, reward = 0.3, listenSeconds = 30, resolvedAt = 1_000L))
+
+            val delta = repository.applyRewardDelta(id, newReward = 0.9, listenSeconds = 60, resolvedAt = 2_000L)
+
+            assertTrue(delta)
+            val stored = database.adaptiveRankingDao().getExposure(id)!!
+            assertEquals(0.9, stored.reward!!, 1e-9)
+            assertEquals(0.9, stored.accumulatedReward!!, 1e-9)
+            assertEquals(60L, stored.listenSeconds)
+            val model = database.adaptiveRankingDao().getModel(RankingObjective.DISCOVERY.name)!!
+            // First resolve incremented updateCount to 1; delta apply pushes it to 2.
+            assertEquals(2L, model.updateCount)
+        }
+
+    @Test
+    fun applyRewardDeltaFailsForUnresolvedExposure() =
+        runTest {
+            val id = repository.recordExposure(exposure())
+
+            assertFalse(repository.applyRewardDelta(id, newReward = 0.5))
+        }
+
+    @Test
+    fun applyRewardDeltaFailsForUnknownExposure() =
+        runTest {
+            assertFalse(repository.applyRewardDelta("missing", newReward = 0.5))
+        }
+
+    @Test
+    fun hardExclusionRoundTripsAndClearsOnReset() =
+        runTest {
+            repository.excludeShow("pod-blocked", reason = "hide_show", sourceExposureId = "exp-1", now = 1_000L)
+
+            assertTrue(repository.isHardExcluded("pod-blocked"))
+            assertEquals(setOf("pod-blocked"), repository.hardExcludedPodcastIds())
+
+            repository.reset()
+
+            assertFalse(repository.isHardExcluded("pod-blocked"))
+            assertTrue(repository.hardExcludedPodcastIds().isEmpty())
+        }
+
+    @Test
+    fun appendOutcomePersistsOutcomeLedger() =
+        runTest {
+            repository.appendOutcome(
+                RankingOutcomeEntity(
+                    outcomeId = UUID.randomUUID().toString(),
+                    exposureId = "exp-1",
+                    episodeId = "ep-1",
+                    podcastId = "pod-1",
+                    action = RankingAction.LIKE.name,
+                    partialReward = 0.65,
+                    listenSeconds = 0,
+                    durationSeconds = 0,
+                    recordedAt = 1_000L,
+                    appliedToModel = true,
+                ),
+            )
+
+            val outcomes = database.adaptiveRankingDao().getOutcomesForExposure("exp-1")
+            assertEquals(1, outcomes.size)
+            assertEquals(RankingAction.LIKE.name, outcomes.single().action)
+        }
+
+    @Test
+    fun facetBeliefConfidenceGrowsWithEvidence() =
+        runTest {
+            repository.updateFacet(PreferenceFacetType.SHOW, "pod-belief", reward = 1.0, now = 1_000L)
+            val single = repository.facetBelief(PreferenceFacetType.SHOW, "pod-belief", now = 1_000L)
+
+            repeat(6) { repository.updateFacet(PreferenceFacetType.SHOW, "pod-belief", reward = 1.0, now = 1_000L) }
+            val many = repository.facetBelief(PreferenceFacetType.SHOW, "pod-belief", now = 1_000L)
+
+            assertTrue("single=$single many=$many", many.confidence > single.confidence)
+            assertTrue(many.confidence in 0.0..1.0)
+            assertTrue(many.evidence > single.evidence)
+        }
+
+    @Test
+    fun facetBeliefsBulkLookupReturnsZeroForMissingKeys() =
+        runTest {
+            repository.updateFacet(PreferenceFacetType.SHOW, "pod-1", reward = 1.0, now = 1_000L)
+            val keys = setOf(
+                PreferenceFacetKey(PreferenceFacetType.SHOW, "pod-1"),
+                PreferenceFacetKey(PreferenceFacetType.SHOW, "pod-missing"),
+            )
+
+            val beliefs = repository.facetBeliefs(keys, now = 1_000L)
+
+            assertTrue(beliefs.getValue(PreferenceFacetKey(PreferenceFacetType.SHOW, "pod-1")).confidence > 0.0)
+            assertEquals(0.0, beliefs.getValue(PreferenceFacetKey(PreferenceFacetType.SHOW, "pod-missing")).confidence, 0.0)
+            assertEquals(0.0, beliefs.getValue(PreferenceFacetKey(PreferenceFacetType.SHOW, "pod-missing")).evidence, 0.0)
+        }
+
+    @Test
+    fun ensurePipelineMigratedWipesOnFirstRunAndIsIdempotent() =
+        runTest {
+            val id = repository.recordExposure(exposure())
+            repository.resolveExposure(id, reward = 0.4)
+            repository.excludeShow("pod-blocked", reason = "hide")
+            repository.updateFacet(PreferenceFacetType.SHOW, "pod-1", reward = 1.0)
+
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            val prefs = context.getSharedPreferences("adaptive_ranking_pipeline_test", Context.MODE_PRIVATE)
+            prefs.edit().clear().apply()
+
+            val wiped = repository.ensurePipelineMigrated(prefs)
+
+            assertTrue(wiped)
+            val dao = database.adaptiveRankingDao()
+            assertTrue(dao.getAllExposures().isEmpty())
+            assertTrue(dao.getAllFacets().isEmpty())
+            assertTrue(dao.getAllModels().isEmpty())
+            assertTrue(dao.getAllExclusions().isEmpty())
+            assertEquals(
+                AdaptiveRankingRepository.PERSONALIZATION_PIPELINE_VERSION,
+                prefs.getInt(AdaptiveRankingRepository.PIPELINE_VERSION_KEY, 0),
+            )
+
+            // Second run is a no-op.
+            assertFalse(repository.ensurePipelineMigrated(prefs))
         }
 
     @Test

--- a/core/ranking/src/test/java/cx/aswin/boxlore/core/ranking/RankingFeedbackRepositoryTest.kt
+++ b/core/ranking/src/test/java/cx/aswin/boxlore/core/ranking/RankingFeedbackRepositoryTest.kt
@@ -237,4 +237,154 @@ class RankingFeedbackRepositoryTest {
 
             assertFalse(orphan.reset())
         }
+
+    @Test
+    fun recordActionWithExposureIdSettlesExactImpressionInsteadOfLatest() =
+        runTest {
+            val olderId = adaptive.recordExposure(exposureFor("ep-token", podcastId = "pod-t").copy(shownAt = 1L))
+            val newerId = adaptive.recordExposure(exposureFor("ep-token", podcastId = "pod-t").copy(shownAt = 100L))
+
+            feedback.recordAction(
+                target =
+                    FeedbackTarget(
+                        episodeId = "ep-token",
+                        podcastId = "pod-t",
+                        exposureId = olderId,
+                    ),
+                action = RankingAction.LIKE,
+            )
+
+            val older = database.adaptiveRankingDao().getExposure(olderId)!!
+            val newer = database.adaptiveRankingDao().getExposure(newerId)!!
+            assertEquals("exact token wins over latest", older.resolvedAt != null, true)
+            assertEquals("newer stays pending", newer.resolvedAt, null)
+        }
+
+    @Test
+    fun recordActionWithExposureIdAppliesDeltaWhenAlreadyResolved() =
+        runTest {
+            val exposureId = adaptive.recordExposure(exposureFor("ep-delta", podcastId = "pod-d"))
+
+            // First terminal signal settles the impression.
+            feedback.recordPlayback(
+                target =
+                    FeedbackTarget(
+                        episodeId = "ep-delta",
+                        podcastId = "pod-d",
+                        exposureId = exposureId,
+                    ),
+                listenSeconds = 120,
+                durationSeconds = 600,
+                completed = false,
+                earlySkip = false,
+            )
+            val afterSettle = database.adaptiveRankingDao().getExposure(exposureId)!!
+            assertTrue(afterSettle.resolvedAt != null)
+            val settledReward = afterSettle.reward!!
+
+            // Second signal (LIKE) arrives after settle → delta path bumps reward upward.
+            feedback.recordAction(
+                target =
+                    FeedbackTarget(
+                        episodeId = "ep-delta",
+                        podcastId = "pod-d",
+                        exposureId = exposureId,
+                    ),
+                action = RankingAction.LIKE,
+                listenSeconds = 120,
+                durationSeconds = 600,
+            )
+
+            val afterDelta = database.adaptiveRankingDao().getExposure(exposureId)!!
+            assertTrue("reward should climb after LIKE arrives late", afterDelta.reward!! > settledReward)
+            assertEquals(afterDelta.reward, afterDelta.accumulatedReward)
+        }
+
+    @Test
+    fun hideShowExcludesPodcastAndPenalisesFacet() =
+        runTest {
+            val exposureId = adaptive.recordExposure(exposureFor("ep-hide", podcastId = "pod-h"))
+
+            feedback.hideShow(
+                podcastId = "pod-h",
+                exposureId = exposureId,
+                genre = "Science",
+                source = CandidateSource.SERVER_RECOMMENDATION,
+            )
+
+            assertTrue("pod-h" in feedback.hardExcludedPodcastIds())
+            assertTrue(adaptive.facetAffinity(PreferenceFacetType.SHOW, "pod-h") < 0.0)
+        }
+
+    @Test
+    fun moreLikeThisBoostsFacet() =
+        runTest {
+            feedback.moreLikeThis(
+                FeedbackTarget(
+                    episodeId = "",
+                    podcastId = "pod-love",
+                    genre = "Science",
+                    source = CandidateSource.SERVER_RECOMMENDATION,
+                ),
+            )
+
+            assertTrue(adaptive.facetAffinity(PreferenceFacetType.SHOW, "pod-love") > 0.0)
+            assertTrue(adaptive.genreAffinities().containsKey("Science"))
+        }
+
+    @Test
+    fun notForMePenalisesFacet() =
+        runTest {
+            feedback.notForMe(
+                FeedbackTarget(
+                    episodeId = "",
+                    podcastId = "pod-meh",
+                    source = CandidateSource.SERVER_RECOMMENDATION,
+                ),
+            )
+
+            assertTrue(adaptive.facetAffinity(PreferenceFacetType.SHOW, "pod-meh") < 0.0)
+        }
+
+    @Test
+    fun recordManualAnchorBoostsShowOnceWithinWindow() =
+        runTest {
+            feedback.recordManualAnchor(podcastId = "pod-anchor", genre = "Science")
+            val first = adaptive.facetAffinity(PreferenceFacetType.SHOW, "pod-anchor")
+
+            // A second call inside the dedup window should not stack further boost.
+            feedback.recordManualAnchor(podcastId = "pod-anchor", genre = "Science")
+            val second = adaptive.facetAffinity(PreferenceFacetType.SHOW, "pod-anchor")
+
+            assertTrue(first > 0.0)
+            assertEquals(first, second, 1e-9)
+        }
+
+    @Test
+    fun resetClearsHardExclusions() =
+        runTest {
+            feedback.hideShow(podcastId = "pod-blocked")
+            assertTrue("pod-blocked" in feedback.hardExcludedPodcastIds())
+
+            feedback.reset()
+
+            assertTrue(feedback.hardExcludedPodcastIds().isEmpty())
+        }
+
+    @Test
+    fun recordActionWithExposureIdAppendsOutcomeToLedger() =
+        runTest {
+            val exposureId = adaptive.recordExposure(exposureFor("ep-ledger", podcastId = "pod-l"))
+
+            feedback.recordAction(
+                target = FeedbackTarget(episodeId = "ep-ledger", podcastId = "pod-l", exposureId = exposureId),
+                action = RankingAction.COMPLETE,
+                listenSeconds = 600,
+                durationSeconds = 600,
+            )
+
+            val outcomes = database.adaptiveRankingDao().getOutcomesForExposure(exposureId)
+            assertEquals(1, outcomes.size)
+            assertEquals(RankingAction.COMPLETE.name, outcomes.single().action)
+        }
 }

--- a/docs/ANALYTICS_EVENT_GLOSSARY.md
+++ b/docs/ANALYTICS_EVENT_GLOSSARY.md
@@ -80,8 +80,8 @@ Launch enrichment (subscription bucket, onboarding status) goes on **person prop
 | `identity_reset` | Analytics identity cleared/reset | — | reason:string | none |
 | `app_check_status` | App Check token attempt result | token_obtained:bool; provider:string | — | none |
 | `first_episode_played` | First-ever play milestone | — | episode_id:string; podcast_id:string; entry_point:enum; hours_since_install:float | none |
-| `home_surface_tapped` | First-class Home component tap | surface_component:string | rail_intent:string; content_id:string; position_index:int | none |
-| `home_surface_impression` | Home rail/block became visible | surface_component:string | items_count:int | none |
+| `home_surface_tapped` | First-class Home component tap | surface_component:string | rail_intent:string; content_id:string; position_index:int; feedback_action:string; personalization_mode:string; exposure_id:string | none |
+| `home_surface_impression` | Home rail/block became visible | surface_component:string | items_count:int; personalization_mode:string; meaningful_play_count:int; is_fallback:bool; candidate_request_ok:bool | none |
 | `search_performed` | User ran show or episode search | surface:string; search_mode:enum; search_query:string; results_count:int | result_quality:enum; query_length:int | logged_by_policy |
 | `search_result_tapped` | User tapped a search result | surface:string; result_type:enum | search_mode:enum; podcast_id:string; episode_id:string; position_index:int; search_query:string | logged_by_policy |
 | `learn_card_action` | User acted on a Learn card | action:string; episode_id:string; podcast_id:string | position_index:int | none |

--- a/docs/recommendation-system.md
+++ b/docs/recommendation-system.md
@@ -1,4 +1,16 @@
-# boxlore Recommendation & Personalization System
+## Home personalization rebuild (v2 pipeline)
+
+Home Taste / Because You Like / greeting mission now share one candidate + slate path:
+
+1. Android builds a bounded seed/exclusion request via `HomeCandidatesRequestBuilder`.
+2. The API serves `POST /home/candidates/v1` (legacy `/recommendations` and `/recommendations/because-you-like` remain for older builds).
+3. `HomePersonalizationCoordinator` caches module pools ≥4h and supports Because-You-Like-only refresh on anchor change.
+4. `:feature:home` derives durable `HomePersonalizationMode` (`REGIONAL` → `PERSONALIZING` → `PERSONALIZED`) from meaningful-listen counts + learner SHOW facets, allocates rails with `HomeSlateAllocationLogic`, and attributes outcomes through exact exposure tokens in `:core:ranking`.
+5. Explicit long-press feedback (`More like this` / `Not for me` / `Hide this show`) and manual BYL anchor selection update the same learner.
+
+Never relabel regional charts as “Based on Your Taste.” Pipeline upgrades may wipe personalization Room state once while preserving listening history, subscriptions, queue, and downloads.
+
+---
 
 > How boxlore decides what to show you, and how it learns from what you do.
 

--- a/feature/home/README.md
+++ b/feature/home/README.md
@@ -10,7 +10,8 @@ Owns Home feed presentation, Settings screens, RSS-add UI, and local debug surfa
 - `settings.SettingsScreen`, `SettingsViewModel`, and `SettingsViewModelAssembler` for Settings.
 - `DebugScreen` and `DebugViewModel` for local learner and runtime diagnostics.
 - Extracted Home UI pieces such as `LibrarySectionRows`, `LibrarySection`, and section/card components.
-- Pure logic helpers under `logic/` for Home assembly, discovery, hero ordering, selection, playback-state mapping, serial episodes, and affinity behavior.
+- Pure logic helpers under `logic/` for Home assembly, discovery, hero ordering, selection, playback-state mapping, serial episodes, affinity behavior, personalization mode, discovery missions, BYL anchor selection, and slate allocation.
+- Long-press recommendation feedback (`RecommendationFeedbackMenu`) and durable `HomePersonalizationMode` for Taste / Because You Like labeling.
 
 ## Internal structure
 

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/DiscoveryGreeting.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/DiscoveryGreeting.kt
@@ -2,6 +2,7 @@ package cx.aswin.boxlore.feature.home
 
 import androidx.compose.runtime.Immutable
 import cx.aswin.boxlore.core.catalog.content.ContentDaypart
+import cx.aswin.boxlore.feature.home.logic.HomeDiscoveryMission
 import java.time.DayOfWeek
 import java.time.LocalDate
 
@@ -10,46 +11,58 @@ data class DiscoveryGreeting(
     val title: String,
     val subtitle: String,
     val daypart: ContentDaypart,
+    val mission: HomeDiscoveryMission? = null,
 )
 
 /** Pure daypart → home discovery greeting (weekend / Friday copy variants). */
 internal fun discoveryGreetingFor(
     daypart: ContentDaypart,
     date: LocalDate = LocalDate.now(),
-): DiscoveryGreeting =
-    when (daypart) {
-        ContentDaypart.MORNING ->
-            DiscoveryGreeting(
-                title = "Good Morning",
-                subtitle =
-                    if (date.dayOfWeek in setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)) {
-                        "Catch up on the week."
-                    } else {
-                        "Start your day with these updates."
-                    },
-                daypart = daypart,
-            )
-        ContentDaypart.AFTERNOON ->
-            DiscoveryGreeting(
-                title = "Afternoon Break",
-                subtitle = "Smart conversations to keep you going.",
-                daypart = daypart,
-            )
-        ContentDaypart.EVENING ->
-            DiscoveryGreeting(
-                title = "Evening Unwind",
-                subtitle =
-                    if (date.dayOfWeek == DayOfWeek.FRIDAY) {
-                        "Kick off the weekend."
-                    } else {
-                        "Relax, laugh, and catch up."
-                    },
-                daypart = daypart,
-            )
-        ContentDaypart.LATE_NIGHT ->
-            DiscoveryGreeting(
-                title = "Late Night Listen",
-                subtitle = "Stories for the dark hours.",
-                daypart = daypart,
-            )
+    mission: HomeDiscoveryMission? = null,
+): DiscoveryGreeting {
+    val base =
+        when (daypart) {
+            ContentDaypart.MORNING ->
+                DiscoveryGreeting(
+                    title = "Good Morning",
+                    subtitle =
+                        if (date.dayOfWeek in setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)) {
+                            "Catch up on the week."
+                        } else {
+                            "Start your day with these updates."
+                        },
+                    daypart = daypart,
+                )
+            ContentDaypart.AFTERNOON ->
+                DiscoveryGreeting(
+                    title = "Afternoon Break",
+                    subtitle = "Smart conversations to keep you going.",
+                    daypart = daypart,
+                )
+            ContentDaypart.EVENING ->
+                DiscoveryGreeting(
+                    title = "Evening Unwind",
+                    subtitle =
+                        if (date.dayOfWeek == DayOfWeek.FRIDAY) {
+                            "Kick off the weekend."
+                        } else {
+                            "Relax, laugh, and catch up."
+                        },
+                    daypart = daypart,
+                )
+            ContentDaypart.LATE_NIGHT ->
+                DiscoveryGreeting(
+                    title = "Late Night Listen",
+                    subtitle = "Stories for the dark hours.",
+                    daypart = daypart,
+                )
+        }
+    return if (mission == null) {
+        base
+    } else {
+        base.copy(
+            subtitle = mission.subtitle,
+            mission = mission,
+        )
     }
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeed.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeed.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import cx.aswin.boxlore.core.model.Briefing
 import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.feature.home.components.HeroCarousel
+import cx.aswin.boxlore.feature.home.logic.HomePersonalizationModeLogic
 
 @androidx.compose.runtime.Stable
 internal data class PodcastFeedContent(
@@ -48,6 +49,8 @@ internal data class PodcastFeedRecommendationState(
     val becauseYouLikePodcasts: StablePodcastList,
     val isRecommendationsLoading: Boolean = true,
     val isRecommendationsFallback: Boolean = true,
+    val personalizationMode: cx.aswin.boxlore.feature.home.logic.HomePersonalizationMode =
+        cx.aswin.boxlore.feature.home.logic.HomePersonalizationMode.REGIONAL,
     val onChangePodcastClick: () -> Unit = {},
 )
 
@@ -139,10 +142,14 @@ private fun rememberPodcastFeedDerivedState(
 private fun hasBecauseYouLike(
     feedState: PodcastFeedUiState,
     recommendationState: PodcastFeedRecommendationState,
-): Boolean =
-    feedState.seemsToLikePodcast != null &&
+): Boolean {
+    if (!HomePersonalizationModeLogic.showBecauseYouLike(recommendationState.personalizationMode)) {
+        return false
+    }
+    return feedState.seemsToLikePodcast != null &&
         (recommendationState.becauseYouLikeRecommendations.list.isNotEmpty() ||
             recommendationState.becauseYouLikePodcasts.list.isNotEmpty())
+}
 
 private fun LazyStaggeredGridScope.smartHeroItem(
     content: PodcastFeedContent,

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeedRecommendations.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeedRecommendations.kt
@@ -50,6 +50,8 @@ internal fun LazyStaggeredGridScope.curatedForYouItems(
             discoveryContextTitle = feedState.discoveryGreeting.title,
             showTasteHeader = derivedState.hasBecauseYouLike,
             isFallback = recommendationState.isRecommendationsFallback,
+            personalizationMode = recommendationState.personalizationMode,
+            onRecommendationFeedback = callbacks.onRecommendationFeedback,
         )
     }
 }
@@ -210,8 +212,7 @@ private fun DiscoveryGreetingHeader(
         }
     HomeTopLevelSectionHeader(
         title = greeting.title,
-        // Personalized rails are no longer daypart-specific; omit time-claiming subcopy.
-        subtitle = null,
+        subtitle = greeting.mission?.subtitle ?: greeting.subtitle.takeIf { it.isNotBlank() },
         icon = icon,
         seeAllIcon = Icons.Rounded.ChevronRight,
         seeAllContentDescription = "See all discoveries",

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeScreen.kt
@@ -126,6 +126,9 @@ data class HomeFeedCallbacks(
     val onDismissBriefing: () -> Unit,
     val onDismissBriefingForever: () -> Unit,
     val onFeedbackClick: () -> Unit,
+    val onRecommendationFeedback: (
+        (Episode, cx.aswin.boxlore.feature.home.components.RecommendationFeedbackAction) -> Unit
+    )? = null,
 )
 
 @androidx.compose.runtime.Stable
@@ -285,6 +288,9 @@ fun HomeRoute(
                         onDismissBriefing = viewModel::dismissBriefingForToday,
                         onDismissBriefingForever = viewModel::dismissBriefingForever,
                         onFeedbackClick = viewModel::triggerFeedback,
+                        onRecommendationFeedback = { episode, action ->
+                            viewModel.onRecommendationFeedback(episode, action)
+                        },
                     ),
                 onNavigateToSettings = onNavigateToSettings,
                 onForceReviewPrompt = viewModel::forceReviewPrompt,
@@ -302,7 +308,13 @@ fun HomeRoute(
                 },
                 onSubmitFeedback = onSubmitFeedback,
                 onNavigateToDebug = onNavigateToDebug,
-                onOverrideRecommendationPodcast = viewModel::setOverriddenRecPodcast,
+                onOverrideRecommendationPodcast = { podcastId ->
+                    if (podcastId != null) {
+                        viewModel.onManualAnchorSelected(podcastId)
+                    } else {
+                        viewModel.setOverriddenRecPodcast(null)
+                    }
+                },
                 onNavigateToLatestEpisodes = onNavigateToLatestEpisodes,
             )
         }
@@ -386,6 +398,7 @@ private fun HomeScreenFeedContent(
                 becauseYouLikePodcasts = StablePodcastList(uiState.becauseYouLikePodcasts),
                 isRecommendationsLoading = uiState.isRecommendationsLoading,
                 isRecommendationsFallback = uiState.isRecommendationsFallback,
+                personalizationMode = uiState.personalizationMode,
                 onChangePodcastClick = onChangePodcastClick,
             ),
         loadingState =

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeUiModels.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeUiModels.kt
@@ -50,6 +50,9 @@ data class HomeUiState(
     val becauseYouLikePodcasts: List<Podcast> = emptyList(),
     val isBecauseYouLikeLoading: Boolean = false,
     val isRecommendationsFallback: Boolean = true,
+    val personalizationMode: cx.aswin.boxlore.feature.home.logic.HomePersonalizationMode =
+        cx.aswin.boxlore.feature.home.logic.HomePersonalizationMode.REGIONAL,
+    val activeDiscoveryMissionId: String? = null,
     val adaptiveSections: List<ContentSection> = emptyList(),
     val isAdaptiveSectionsLoading: Boolean = false,
 )

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModel.kt
@@ -21,8 +21,11 @@ import cx.aswin.boxlore.core.catalog.content.ContentSectionsDaypartResolver
 import cx.aswin.boxlore.core.catalog.content.RecentSectionIntentStore
 import cx.aswin.boxlore.core.catalog.content.ServerGroupedSectionProvider
 import cx.aswin.boxlore.core.catalog.content.ServerIntentCandidateProvider
+import cx.aswin.boxlore.core.catalog.content.ContentDaypart
 import cx.aswin.boxlore.core.ranking.AdaptiveCandidateScorer
 import cx.aswin.boxlore.core.ranking.AdaptiveRankingRepository
+import cx.aswin.boxlore.core.ranking.CandidateSource
+import cx.aswin.boxlore.core.ranking.FeedbackTarget
 import cx.aswin.boxlore.core.ranking.RankingFeedbackRepository
 import cx.aswin.boxlore.core.domain.ports.AlwaysOnlineConnectivity
 import cx.aswin.boxlore.core.domain.ports.ConnectivityStatusPort
@@ -31,7 +34,10 @@ import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.feature.home.logic.FilterSelectionAction
 import cx.aswin.boxlore.feature.home.logic.HomeBecauseYouLikeLogic
+import cx.aswin.boxlore.feature.home.logic.HomeDiscoveryMissionLogic
 import cx.aswin.boxlore.feature.home.logic.HomeFilterSelectionLogic
+import cx.aswin.boxlore.feature.home.logic.HomePersonalizationMode
+import cx.aswin.boxlore.feature.home.logic.HomePersonalizationModeLogic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -115,8 +121,15 @@ class HomeViewModel(
     internal val _becauseYouLikePodcasts = MutableStateFlow<List<Podcast>>(emptyList())
     internal val _isBecauseYouLikeLoading = MutableStateFlow(false)
     internal val _isRecommendationsFallback = MutableStateFlow(true)
+    internal val _personalizationMode =
+        MutableStateFlow(HomePersonalizationMode.REGIONAL)
+    internal val _personalizedCandidatesLoaded = MutableStateFlow(false)
+    internal val _personalizedRequestFailed = MutableStateFlow(false)
     internal val _adaptiveSections = MutableStateFlow<List<ContentSection>>(emptyList())
     internal val _isAdaptiveSectionsLoading = MutableStateFlow(true)
+
+    internal val homePersonalizationCoordinator =
+        cx.aswin.boxlore.core.catalog.home.HomePersonalizationCoordinator(podcastRepository)
 
     @Volatile
     internal var preferCachedAdaptiveSections: Boolean = false
@@ -526,11 +539,85 @@ class HomeViewModel(
                 .map { clock -> clock.daypart to clock.date }
                 .distinctUntilChanged()
                 .collect { (daypart, date) ->
+                    val mission =
+                        HomeDiscoveryMissionLogic.select(
+                            context =
+                                HomeDiscoveryMissionLogic.MissionContext(
+                                    daypart = daypart.name.lowercase(),
+                                    preferShort = daypart == ContentDaypart.MORNING,
+                                ),
+                            nowSlotKey =
+                                HomeDiscoveryMissionLogic.slotKey(
+                                    daypart.name.lowercase(),
+                                    date.toString(),
+                                ),
+                            stickyMissionId = _uiState.value.activeDiscoveryMissionId,
+                            stickySlotKey = _uiState.value.discoveryGreeting.mission?.let {
+                                HomeDiscoveryMissionLogic.slotKey(
+                                    _uiState.value.discoveryGreeting.daypart.name.lowercase(),
+                                    date.toString(),
+                                )
+                            },
+                        )
                     _uiState.update { state ->
-                        state.copy(discoveryGreeting = discoveryGreetingFor(daypart, date))
+                        state.copy(
+                            discoveryGreeting = discoveryGreetingFor(daypart, date, mission),
+                            activeDiscoveryMissionId = mission.id,
+                        )
                     }
                 }
         }
+    }
+
+    fun onRecommendationFeedback(
+        episode: Episode,
+        action: cx.aswin.boxlore.feature.home.components.RecommendationFeedbackAction,
+        exposureId: String? = null,
+    ) {
+        viewModelScope.launch {
+            val target =
+                FeedbackTarget(
+                    episodeId = episode.id,
+                    podcastId = episode.podcastId.orEmpty(),
+                    genre = episode.podcastGenre,
+                    source = CandidateSource.SERVER_RECOMMENDATION,
+                    exposureId = exposureId,
+                )
+            when (action) {
+                cx.aswin.boxlore.feature.home.components.RecommendationFeedbackAction.MORE_LIKE_THIS ->
+                    rankingFeedback.moreLikeThis(target)
+                cx.aswin.boxlore.feature.home.components.RecommendationFeedbackAction.NOT_FOR_ME ->
+                    rankingFeedback.notForMe(target)
+                cx.aswin.boxlore.feature.home.components.RecommendationFeedbackAction.HIDE_SHOW ->
+                    rankingFeedback.hideShow(
+                        podcastId = episode.podcastId.orEmpty(),
+                        exposureId = exposureId,
+                        episodeId = episode.id,
+                        genre = episode.podcastGenre,
+                        source = CandidateSource.SERVER_RECOMMENDATION,
+                    )
+            }
+            cx.aswin.boxlore.core.analytics.AnalyticsHelper.trackHomeRecommendationFeedback(
+                episodeId = episode.id,
+                podcastId = episode.podcastId.orEmpty(),
+                action = action.name.lowercase(),
+                personalizationMode = _personalizationMode.value.name,
+                exposureId = exposureId,
+            )
+            reallocateHomeSlateAfterFeedback()
+        }
+    }
+
+    fun onManualAnchorSelected(podcastId: String) {
+        viewModelScope.launch {
+            rankingFeedback.recordManualAnchor(podcastId)
+            setOverriddenRecPodcast(podcastId)
+        }
+    }
+
+    private fun reallocateHomeSlateAfterFeedback() {
+        boxcastPrefs.clearPersonalizationCaches()
+        fetchPersonalizedRecommendations(activeRegion)
     }
 
 

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModel.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
 
-@Suppress("kotlin:S6310", "LongParameterList")
+@Suppress("kotlin:S6310", "LongParameterList", "LargeClass")
 class HomeViewModel(
     application: Application,
     val podcastRepository: PodcastRepository,

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModelBecauseYouLike.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModelBecauseYouLike.kt
@@ -1,14 +1,16 @@
 package cx.aswin.boxlore.feature.home
 
+import cx.aswin.boxlore.core.playback.getHistoryForRecommendations
 import cx.aswin.boxlore.core.playback.getRecentHistoryList
-
 import cx.aswin.boxlore.core.ranking.CandidateSource
 import cx.aswin.boxlore.core.ranking.EpisodeRankingInput
 import cx.aswin.boxlore.core.ranking.RankingObjective
 import cx.aswin.boxlore.core.ranking.RankingSurface
 import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.feature.home.logic.HomeAnchorSelectionLogic
 import cx.aswin.boxlore.feature.home.logic.HomeBecauseYouLikeLogic
+import cx.aswin.boxlore.feature.home.logic.HomePersonalizationModeLogic
 import cx.aswin.boxlore.feature.home.logic.PodcastAffinityLogic
 import cx.aswin.boxlore.feature.home.logic.toRecommendationPodcast
 import androidx.lifecycle.viewModelScope
@@ -23,6 +25,13 @@ internal suspend fun HomeViewModel.resolveFavoritePodcast(
     subscriptions: List<Podcast>,
     historyList: List<HomeListeningHistoryItem>,
 ): Podcast? {
+    if (!HomePersonalizationModeLogic.showBecauseYouLike(_personalizationMode.value) &&
+        overriddenId == null
+    ) {
+        // Cold-start / regional: BYL stays hidden unless the user already forced an anchor.
+        return null
+    }
+
     val historySignals = historyList.map { HomeBecauseYouLikeLogic.toAffinitySignal(it) }
     if (overriddenId != null) {
         val sub = subscriptions.find { it.id == overriddenId }
@@ -38,35 +47,43 @@ internal suspend fun HomeViewModel.resolveFavoritePodcast(
         return null
     }
 
-    if (subscriptions.isEmpty() && historyList.isEmpty()) return null
+    val hidden = adaptiveRankingRepository.hardExcludedPodcastIds()
+    val showBeliefs = adaptiveRankingRepository.showFacetBeliefs()
+    val lastPlayedMap =
+        historySignals
+            .groupBy { it.podcastId }
+            .mapValues { (_, items) -> items.maxOfOrNull { it.lastPlayedAt } ?: 0L }
+    val selection =
+        HomeAnchorSelectionLogic.selectAutomatic(
+            candidates =
+                showBeliefs.map { (podcastId, belief) ->
+                    HomeAnchorSelectionLogic.ShowCandidate(
+                        podcastId = podcastId,
+                        affinity = belief.affinity,
+                        confidence = belief.confidence,
+                        evidence = belief.evidence,
+                        lastPlayedAt = lastPlayedMap[podcastId] ?: 0L,
+                        isHidden = podcastId in hidden,
+                    )
+                },
+            currentAnchorId = _seemsToLikePodcast.value?.id,
+            manualOverrideId = null,
+        ) ?: return null
 
-    val lastPlayedMap = mutableMapOf<String, Long>()
-    val podcastNameMap = mutableMapOf<String, String>()
-    val podcastImageMap = mutableMapOf<String, String>()
-
-    val scores =
-        PodcastAffinityLogic.calculatePodcastAffinityScores(
-            subscriptions = subscriptions,
-            historyList = historySignals,
-            lastPlayedMap = lastPlayedMap,
-            podcastNameMap = podcastNameMap,
-            podcastImageMap = podcastImageMap,
-        )
-
-    val topPodId =
-        PodcastAffinityLogic.topAffinityPodcastId(scores, lastPlayedMap)
-            ?: return null
-
-    val sub = subscriptions.find { it.id == topPodId }
-    if (sub != null) return sub
-
+    val topPodId = selection.podcastId
+    subscriptions.find { it.id == topPodId }?.let { return it }
     localCatalog.getLocalPodcast(topPodId)?.let { return it }
+
+    val hist = historySignals.find { it.podcastId == topPodId }
+    if (hist != null) {
+        return PodcastAffinityLogic.podcastFromHistorySignal(hist)
+    }
 
     return Podcast(
         id = topPodId,
-        title = podcastNameMap[topPodId] ?: "Podcast",
+        title = "Podcast",
         artist = "",
-        imageUrl = podcastImageMap[topPodId] ?: "",
+        imageUrl = "",
         fallbackImageUrl = "",
         description = "",
     )
@@ -80,11 +97,59 @@ internal fun HomeViewModel.fetchBecauseYouLikeRecommendations(
     viewModelScope.launch {
         _isBecauseYouLikeLoading.value = true
         try {
+            if (!HomePersonalizationModeLogic.showBecauseYouLike(_personalizationMode.value)) {
+                _becauseYouLikePodcasts.value = emptyList()
+                _becauseYouLikeRecommendations.value = emptyList()
+                return@launch
+            }
             val title = podcast.title
             val desc = podcast.description ?: ""
             val id = podcast.id
+            val history = playbackRepository.getHistoryForRecommendations(15)
+            val retainedTasteIds = _recommendations.value.mapNotNull { it.podcastId }
+            val slate =
+                homePersonalizationCoordinator.loadSlate(
+                    cx.aswin.boxlore.core.catalog.home.HomePersonalizationCoordinator.SlateRequest(
+                        modules = listOf("because_you_like"),
+                        country = region,
+                        languages =
+                            cx.aswin.boxlore.core.catalog.recommendationLanguagesForCountry(region),
+                        history = history,
+                        anchorPodcastId = id,
+                        missionId = _uiState.value.activeDiscoveryMissionId,
+                        excludedPodcastIds = retainedTasteIds + listOf(id),
+                        excludedEpisodeIds = _recommendations.value.map { it.id },
+                        noveltyPreference = null,
+                        daypart = clockContextFlow.value.daypart.name.lowercase(),
+                        revision = "home-v1-byl|$id",
+                        becauseYouLikeOnly = true,
+                    ),
+                )
+            if (slate.becauseYouLikeEpisodes.isNotEmpty() || slate.becauseYouLikePodcasts.isNotEmpty()) {
+                val ranked =
+                    rankBecauseYouLike(
+                        slate.becauseYouLikePodcasts,
+                        slate.becauseYouLikeEpisodes,
+                    )
+                _becauseYouLikePodcasts.value = ranked.first
+                _becauseYouLikeRecommendations.value = ranked.second
+                try {
+                    val json = Json { ignoreUnknownKeys = true }
+                    boxcastPrefs.saveBylCache(
+                        episodesJson = json.encodeToString(ranked.second),
+                        podcastsJson = json.encodeToString(ranked.first),
+                        podcastId = id,
+                    )
+                } catch (ce: Exception) {
+                    android.util.Log.e("HomeViewModel", "Failed to cache because-you-like", ce)
+                }
+                return@launch
+            }
 
-            android.util.Log.d("HomeViewModel", "Fetching because-you-like recommendations for: $title (ID: $id), region: $region")
+            android.util.Log.d(
+                "HomeViewModel",
+                "Fetching because-you-like recommendations for: $title (ID: $id), region: $region",
+            )
             val data =
                 podcastRepository.getBecauseYouLikeRecommendations(
                     podcastTitle = title,
@@ -106,11 +171,6 @@ internal fun HomeViewModel.fetchBecauseYouLikeRecommendations(
                     title = { it.title },
                 )
             val ranked = rankBecauseYouLike(distinctPodcasts, distinctEpisodes)
-
-            android.util.Log.d(
-                "HomeViewModel",
-                "Fetched because-you-like: podcasts count = ${distinctPodcasts.size}, episodes count = ${distinctEpisodes.size}",
-            )
 
             _becauseYouLikePodcasts.value = ranked.first
             _becauseYouLikeRecommendations.value = ranked.second

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModelLoadData.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModelLoadData.kt
@@ -1,6 +1,6 @@
 package cx.aswin.boxlore.feature.home
 
-import androidx.lifecycle.viewModelScope
+import cx.aswin.boxlore.core.catalog.home.HomePersonalizationCoordinator
 import cx.aswin.boxlore.core.playback.MixtapeEngine
 import cx.aswin.boxlore.core.playback.getHistoryForRecommendations
 import cx.aswin.boxlore.core.playback.resumeSessions
@@ -13,10 +13,14 @@ import cx.aswin.boxlore.core.ranking.RankingObjective
 import cx.aswin.boxlore.core.ranking.RankingSurface
 import cx.aswin.boxlore.core.database.toScorable
 import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.feature.home.logic.HomeAnchorSelectionLogic
+import cx.aswin.boxlore.feature.home.logic.HomeMeaningfulPlayLogic
 import cx.aswin.boxlore.feature.home.logic.HomeMixtapeCache
+import cx.aswin.boxlore.feature.home.logic.HomePersonalizationModeLogic
 import cx.aswin.boxlore.feature.home.logic.HomeUiAssemblyLogic
 import cx.aswin.boxlore.feature.home.logic.discoverPodcastsExcluding
 import cx.aswin.boxlore.feature.home.logic.toRecommendationPodcast
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,21 +38,122 @@ import kotlinx.serialization.json.Json
 internal fun HomeViewModel.fetchPersonalizedRecommendations(region: String) {
     viewModelScope.launch {
         _isRecommendationsLoaded.value = false
+        _personalizedRequestFailed.value = false
         try {
             val interests = boxcastPrefs.getUserGenres().toList()
             val history = playbackRepository.getHistoryForRecommendations(15)
-
+            val meaningfulCount = HomeMeaningfulPlayLogic.countMeaningfulPlays(history)
             val subscribedIds = subscriptionRepository.subscribedPodcastIds.first().toList()
             val subscribedGenres =
                 subscriptionRepository.subscribedPodcasts
                     .first()
                     .mapNotNull { it.genre }
                     .distinct()
+            val hiddenShows = adaptiveRankingRepository.hardExcludedPodcastIds()
+            val showBeliefs = adaptiveRankingRepository.showFacetBeliefs()
+            val hasEligiblePositiveShow =
+                showBeliefs.any { (podcastId, belief) ->
+                    podcastId !in hiddenShows &&
+                        belief.affinity >= HomeAnchorSelectionLogic.MIN_AFFINITY &&
+                        belief.confidence >= HomeAnchorSelectionLogic.MIN_CONFIDENCE &&
+                        belief.evidence >= HomeAnchorSelectionLogic.MIN_EVIDENCE
+                }
+            val attemptPersonalized =
+                meaningfulCount >= HomePersonalizationModeLogic.MEANINGFUL_PLAYS_TO_ATTEMPT &&
+                    (
+                        meaningfulCount < HomePersonalizationModeLogic.MEANINGFUL_PLAYS_TO_REQUIRE_ANCHOR ||
+                            hasEligiblePositiveShow
+                        )
+            _personalizationMode.value =
+                HomePersonalizationModeLogic.derive(
+                    meaningfulPlayCount = meaningfulCount,
+                    hasEligiblePositiveShow = hasEligiblePositiveShow,
+                    personalizedCandidatesLoaded = false,
+                    personalizedRequestFailed = false,
+                )
 
-            android.util.Log.d(
-                "HomeViewModel",
-                "Fetching recommendations with history size: ${history.size}, interests: $interests, region: $region, subscribedCount: ${subscribedIds.size}",
-            )
+            if (attemptPersonalized) {
+                val missionId = _uiState.value.activeDiscoveryMissionId
+                val manualAnchor = userPrefs.overriddenRecPodcastIdStream.first()
+                val autoAnchor =
+                    HomeAnchorSelectionLogic.selectAutomatic(
+                        candidates =
+                            showBeliefs.map { (podcastId, belief) ->
+                                HomeAnchorSelectionLogic.ShowCandidate(
+                                    podcastId = podcastId,
+                                    affinity = belief.affinity,
+                                    confidence = belief.confidence,
+                                    evidence = belief.evidence,
+                                    isHidden = podcastId in hiddenShows,
+                                )
+                            },
+                        currentAnchorId = _seemsToLikePodcast.value?.id,
+                        manualOverrideId = manualAnchor,
+                    )?.podcastId
+                val slate =
+                    homePersonalizationCoordinator.loadSlate(
+                        HomePersonalizationCoordinator.SlateRequest(
+                            modules = listOf("taste", "because_you_like", "mission", "regional"),
+                            country = region,
+                            languages =
+                                cx.aswin.boxlore.core.catalog.recommendationLanguagesForCountry(region),
+                            history = history,
+                            anchorPodcastId = autoAnchor,
+                            missionId = missionId,
+                            excludedPodcastIds = (subscribedIds + hiddenShows).distinct(),
+                            excludedEpisodeIds = history.mapNotNull { it.episodeId },
+                            noveltyPreference = null,
+                            daypart = clockContextFlow.value.daypart.name.lowercase(),
+                            revision = "home-v1",
+                        ),
+                    )
+                if (slate.taste.isNotEmpty() || slate.regional.isNotEmpty()) {
+                    val tasteItems = slate.taste.ifEmpty { slate.regional }
+                    val distinctRecs =
+                        tasteItems
+                            .distinctBy { it.id }
+                            .distinctBy { it.title.lowercase().trim() }
+                    _recommendations.value = distinctRecs
+                    _isRecommendationsFallback.value = slate.isFallback
+                    _personalizedCandidatesLoaded.value = !slate.isFallback && slate.taste.isNotEmpty()
+                    _personalizedRequestFailed.value = false
+                    if (slate.becauseYouLikeEpisodes.isNotEmpty() || slate.becauseYouLikePodcasts.isNotEmpty()) {
+                        _becauseYouLikeRecommendations.value = slate.becauseYouLikeEpisodes
+                        _becauseYouLikePodcasts.value = slate.becauseYouLikePodcasts
+                        if (autoAnchor != null) {
+                            localCatalog.getLocalPodcast(autoAnchor)?.let {
+                                _seemsToLikePodcast.value = it
+                            }
+                        }
+                    }
+                    try {
+                        val json = Json { ignoreUnknownKeys = true }
+                        boxcastPrefs.saveRecommendationsCache(
+                            json.encodeToString(distinctRecs),
+                            slate.isFallback,
+                        )
+                    } catch (ce: Exception) {
+                        android.util.Log.e("HomeViewModel", "Failed to cache recommendations", ce)
+                    }
+                    _personalizationMode.value =
+                        HomePersonalizationModeLogic.derive(
+                            meaningfulPlayCount = meaningfulCount,
+                            hasEligiblePositiveShow = hasEligiblePositiveShow,
+                            personalizedCandidatesLoaded = _personalizedCandidatesLoaded.value,
+                            personalizedRequestFailed = false,
+                        )
+                    cx.aswin.boxlore.core.analytics.AnalyticsHelper.trackHomePersonalizationMode(
+                        mode = _personalizationMode.value.name,
+                        meaningfulPlayCount = meaningfulCount,
+                        isFallback = slate.isFallback,
+                        candidateRequestOk = true,
+                    )
+                    return@launch
+                }
+                _personalizedRequestFailed.value = true
+            }
+
+            // Regional / legacy path (cold start or candidate failure).
             val recs =
                 podcastRepository.getPersonalizedRecommendations(
                     history = history,
@@ -57,21 +162,32 @@ internal fun HomeViewModel.fetchPersonalizedRecommendations(region: String) {
                     subscribedPodcastIds = subscribedIds,
                     subscribedGenres = subscribedGenres,
                 )
-            android.util.Log.d("HomeViewModel", "Fetched recommendations size: ${recs.size}")
             val distinctRecs =
                 recs
                     .distinctBy { it.id }
                     .distinctBy { it.title.lowercase().trim() }
             _recommendations.value = distinctRecs
+            _isRecommendationsFallback.value = true
+            _personalizedCandidatesLoaded.value = false
             try {
                 val json = Json { ignoreUnknownKeys = true }
-                val serialized = json.encodeToString(distinctRecs)
-                boxcastPrefs.setCachedRecommendationsJson(serialized)
+                boxcastPrefs.saveRecommendationsCache(
+                    json.encodeToString(distinctRecs),
+                    isFallback = true,
+                )
             } catch (ce: Exception) {
                 android.util.Log.e("HomeViewModel", "Failed to cache recommendations", ce)
             }
+            _personalizationMode.value =
+                HomePersonalizationModeLogic.derive(
+                    meaningfulPlayCount = meaningfulCount,
+                    hasEligiblePositiveShow = hasEligiblePositiveShow,
+                    personalizedCandidatesLoaded = false,
+                    personalizedRequestFailed = _personalizedRequestFailed.value,
+                )
         } catch (e: Exception) {
             android.util.Log.e("HomeViewModel", "Failed to fetch personalized recommendations", e)
+            _personalizedRequestFailed.value = true
         } finally {
             _isRecommendationsLoaded.value = true
         }
@@ -452,6 +568,12 @@ internal fun HomeViewModel.loadData() {
                                     discoveryGreetingFor(
                                         daypart = daypart,
                                         date = clockContextFlow.value.date,
+                                        mission =
+                                            _uiState.value.discoveryGreeting.mission
+                                                ?: _uiState.value.activeDiscoveryMissionId?.let { id ->
+                                                    cx.aswin.boxlore.feature.home.logic.HomeDiscoveryMission.entries
+                                                        .firstOrNull { it.id == id }
+                                                },
                                     ),
                                 discoverPodcasts = assembled.discoverPodcasts,
                                 recommendations = assembled.recommendations,
@@ -472,6 +594,8 @@ internal fun HomeViewModel.loadData() {
                                 becauseYouLikePodcasts = wrapper.becauseYouLikePodcasts,
                                 isBecauseYouLikeLoading = wrapper.isBecauseYouLikeLoading,
                                 isRecommendationsFallback = wrapper.isRecommendationsFallback,
+                                personalizationMode = _personalizationMode.value,
+                                activeDiscoveryMissionId = _uiState.value.activeDiscoveryMissionId,
                                 adaptiveSections = wrapper.adaptiveSections,
                                 isAdaptiveSectionsLoading = _isAdaptiveSectionsLoading.value,
                             )

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModelLoadData.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModelLoadData.kt
@@ -35,6 +35,14 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
+private data class PersonalizationGate(
+    val meaningfulCount: Int,
+    val hasEligiblePositiveShow: Boolean,
+    val attemptPersonalized: Boolean,
+    val hiddenShows: Set<String>,
+    val showBeliefs: List<Pair<String, cx.aswin.boxlore.core.ranking.FacetBelief>>,
+)
+
 internal fun HomeViewModel.fetchPersonalizedRecommendations(region: String) {
     viewModelScope.launch {
         _isRecommendationsLoaded.value = false
@@ -42,155 +50,197 @@ internal fun HomeViewModel.fetchPersonalizedRecommendations(region: String) {
         try {
             val interests = boxcastPrefs.getUserGenres().toList()
             val history = playbackRepository.getHistoryForRecommendations(15)
-            val meaningfulCount = HomeMeaningfulPlayLogic.countMeaningfulPlays(history)
             val subscribedIds = subscriptionRepository.subscribedPodcastIds.first().toList()
             val subscribedGenres =
                 subscriptionRepository.subscribedPodcasts
                     .first()
                     .mapNotNull { it.genre }
                     .distinct()
-            val hiddenShows = adaptiveRankingRepository.hardExcludedPodcastIds()
-            val showBeliefs = adaptiveRankingRepository.showFacetBeliefs()
-            val hasEligiblePositiveShow =
-                showBeliefs.any { (podcastId, belief) ->
-                    podcastId !in hiddenShows &&
-                        belief.affinity >= HomeAnchorSelectionLogic.MIN_AFFINITY &&
-                        belief.confidence >= HomeAnchorSelectionLogic.MIN_CONFIDENCE &&
-                        belief.evidence >= HomeAnchorSelectionLogic.MIN_EVIDENCE
-                }
-            val attemptPersonalized =
-                meaningfulCount >= HomePersonalizationModeLogic.MEANINGFUL_PLAYS_TO_ATTEMPT &&
-                    (
-                        meaningfulCount < HomePersonalizationModeLogic.MEANINGFUL_PLAYS_TO_REQUIRE_ANCHOR ||
-                            hasEligiblePositiveShow
-                        )
+            val gate = resolvePersonalizationGate(history)
             _personalizationMode.value =
                 HomePersonalizationModeLogic.derive(
-                    meaningfulPlayCount = meaningfulCount,
-                    hasEligiblePositiveShow = hasEligiblePositiveShow,
+                    meaningfulPlayCount = gate.meaningfulCount,
+                    hasEligiblePositiveShow = gate.hasEligiblePositiveShow,
                     personalizedCandidatesLoaded = false,
                     personalizedRequestFailed = false,
                 )
 
-            if (attemptPersonalized) {
-                val missionId = _uiState.value.activeDiscoveryMissionId
-                val manualAnchor = userPrefs.overriddenRecPodcastIdStream.first()
-                val autoAnchor =
-                    HomeAnchorSelectionLogic.selectAutomatic(
-                        candidates =
-                            showBeliefs.map { (podcastId, belief) ->
-                                HomeAnchorSelectionLogic.ShowCandidate(
-                                    podcastId = podcastId,
-                                    affinity = belief.affinity,
-                                    confidence = belief.confidence,
-                                    evidence = belief.evidence,
-                                    isHidden = podcastId in hiddenShows,
-                                )
-                            },
-                        currentAnchorId = _seemsToLikePodcast.value?.id,
-                        manualOverrideId = manualAnchor,
-                    )?.podcastId
-                val slate =
-                    homePersonalizationCoordinator.loadSlate(
-                        HomePersonalizationCoordinator.SlateRequest(
-                            modules = listOf("taste", "because_you_like", "mission", "regional"),
-                            country = region,
-                            languages =
-                                cx.aswin.boxlore.core.catalog.recommendationLanguagesForCountry(region),
-                            history = history,
-                            anchorPodcastId = autoAnchor,
-                            missionId = missionId,
-                            excludedPodcastIds = (subscribedIds + hiddenShows).distinct(),
-                            excludedEpisodeIds = history.mapNotNull { it.episodeId },
-                            noveltyPreference = null,
-                            daypart = clockContextFlow.value.daypart.name.lowercase(),
-                            revision = "home-v1",
-                        ),
+            if (gate.attemptPersonalized) {
+                val applied =
+                    tryApplyCandidateSlate(
+                        region = region,
+                        history = history,
+                        subscribedIds = subscribedIds,
+                        gate = gate,
                     )
-                if (slate.taste.isNotEmpty() || slate.regional.isNotEmpty()) {
-                    val tasteItems = slate.taste.ifEmpty { slate.regional }
-                    val distinctRecs =
-                        tasteItems
-                            .distinctBy { it.id }
-                            .distinctBy { it.title.lowercase().trim() }
-                    _recommendations.value = distinctRecs
-                    _isRecommendationsFallback.value = slate.isFallback
-                    _personalizedCandidatesLoaded.value = !slate.isFallback && slate.taste.isNotEmpty()
-                    _personalizedRequestFailed.value = false
-                    if (slate.becauseYouLikeEpisodes.isNotEmpty() || slate.becauseYouLikePodcasts.isNotEmpty()) {
-                        _becauseYouLikeRecommendations.value = slate.becauseYouLikeEpisodes
-                        _becauseYouLikePodcasts.value = slate.becauseYouLikePodcasts
-                        if (autoAnchor != null) {
-                            localCatalog.getLocalPodcast(autoAnchor)?.let {
-                                _seemsToLikePodcast.value = it
-                            }
-                        }
-                    }
-                    try {
-                        val json = Json { ignoreUnknownKeys = true }
-                        boxcastPrefs.saveRecommendationsCache(
-                            json.encodeToString(distinctRecs),
-                            slate.isFallback,
-                        )
-                    } catch (ce: Exception) {
-                        android.util.Log.e("HomeViewModel", "Failed to cache recommendations", ce)
-                    }
-                    _personalizationMode.value =
-                        HomePersonalizationModeLogic.derive(
-                            meaningfulPlayCount = meaningfulCount,
-                            hasEligiblePositiveShow = hasEligiblePositiveShow,
-                            personalizedCandidatesLoaded = _personalizedCandidatesLoaded.value,
-                            personalizedRequestFailed = false,
-                        )
-                    cx.aswin.boxlore.core.analytics.AnalyticsHelper.trackHomePersonalizationMode(
-                        mode = _personalizationMode.value.name,
-                        meaningfulPlayCount = meaningfulCount,
-                        isFallback = slate.isFallback,
-                        candidateRequestOk = true,
-                    )
-                    return@launch
-                }
+                if (applied) return@launch
                 _personalizedRequestFailed.value = true
             }
 
-            // Regional / legacy path (cold start or candidate failure).
-            val recs =
-                podcastRepository.getPersonalizedRecommendations(
-                    history = history,
-                    interests = interests,
-                    country = region,
-                    subscribedPodcastIds = subscribedIds,
-                    subscribedGenres = subscribedGenres,
-                )
-            val distinctRecs =
-                recs
-                    .distinctBy { it.id }
-                    .distinctBy { it.title.lowercase().trim() }
-            _recommendations.value = distinctRecs
-            _isRecommendationsFallback.value = true
-            _personalizedCandidatesLoaded.value = false
-            try {
-                val json = Json { ignoreUnknownKeys = true }
-                boxcastPrefs.saveRecommendationsCache(
-                    json.encodeToString(distinctRecs),
-                    isFallback = true,
-                )
-            } catch (ce: Exception) {
-                android.util.Log.e("HomeViewModel", "Failed to cache recommendations", ce)
-            }
-            _personalizationMode.value =
-                HomePersonalizationModeLogic.derive(
-                    meaningfulPlayCount = meaningfulCount,
-                    hasEligiblePositiveShow = hasEligiblePositiveShow,
-                    personalizedCandidatesLoaded = false,
-                    personalizedRequestFailed = _personalizedRequestFailed.value,
-                )
+            applyRegionalRecommendations(
+                region = region,
+                history = history,
+                interests = interests,
+                subscribedIds = subscribedIds,
+                subscribedGenres = subscribedGenres,
+                gate = gate,
+            )
         } catch (e: Exception) {
             android.util.Log.e("HomeViewModel", "Failed to fetch personalized recommendations", e)
             _personalizedRequestFailed.value = true
         } finally {
             _isRecommendationsLoaded.value = true
         }
+    }
+}
+
+private suspend fun HomeViewModel.resolvePersonalizationGate(
+    history: List<cx.aswin.boxlore.core.network.model.HistoryItem>,
+): PersonalizationGate {
+    val meaningfulCount = HomeMeaningfulPlayLogic.countMeaningfulPlays(history)
+    val hiddenShows = adaptiveRankingRepository.hardExcludedPodcastIds()
+    val showBeliefs = adaptiveRankingRepository.showFacetBeliefs()
+    val hasEligiblePositiveShow =
+        showBeliefs.any { (podcastId, belief) ->
+            podcastId !in hiddenShows &&
+                belief.affinity >= HomeAnchorSelectionLogic.MIN_AFFINITY &&
+                belief.confidence >= HomeAnchorSelectionLogic.MIN_CONFIDENCE &&
+                belief.evidence >= HomeAnchorSelectionLogic.MIN_EVIDENCE
+        }
+    val attemptPersonalized =
+        meaningfulCount >= HomePersonalizationModeLogic.MEANINGFUL_PLAYS_TO_ATTEMPT &&
+            (
+                meaningfulCount < HomePersonalizationModeLogic.MEANINGFUL_PLAYS_TO_REQUIRE_ANCHOR ||
+                    hasEligiblePositiveShow
+                )
+    return PersonalizationGate(
+        meaningfulCount = meaningfulCount,
+        hasEligiblePositiveShow = hasEligiblePositiveShow,
+        attemptPersonalized = attemptPersonalized,
+        hiddenShows = hiddenShows,
+        showBeliefs = showBeliefs,
+    )
+}
+
+private suspend fun HomeViewModel.tryApplyCandidateSlate(
+    region: String,
+    history: List<cx.aswin.boxlore.core.network.model.HistoryItem>,
+    subscribedIds: List<String>,
+    gate: PersonalizationGate,
+): Boolean {
+    val missionId = _uiState.value.activeDiscoveryMissionId
+    val manualAnchor = userPrefs.overriddenRecPodcastIdStream.first()
+    val autoAnchor =
+        HomeAnchorSelectionLogic.selectAutomatic(
+            candidates =
+                gate.showBeliefs.map { (podcastId, belief) ->
+                    HomeAnchorSelectionLogic.ShowCandidate(
+                        podcastId = podcastId,
+                        affinity = belief.affinity,
+                        confidence = belief.confidence,
+                        evidence = belief.evidence,
+                        isHidden = podcastId in gate.hiddenShows,
+                    )
+                },
+            currentAnchorId = _seemsToLikePodcast.value?.id,
+            manualOverrideId = manualAnchor,
+        )?.podcastId
+    val slate =
+        homePersonalizationCoordinator.loadSlate(
+            HomePersonalizationCoordinator.SlateRequest(
+                modules = listOf("taste", "because_you_like", "mission", "regional"),
+                country = region,
+                languages = cx.aswin.boxlore.core.catalog.recommendationLanguagesForCountry(region),
+                history = history,
+                anchorPodcastId = autoAnchor,
+                missionId = missionId,
+                excludedPodcastIds = (subscribedIds + gate.hiddenShows).distinct(),
+                excludedEpisodeIds = history.mapNotNull { it.episodeId },
+                noveltyPreference = null,
+                daypart = clockContextFlow.value.daypart.name.lowercase(),
+                revision = "home-v1",
+            ),
+        )
+    if (slate.taste.isEmpty() && slate.regional.isEmpty()) return false
+
+    val tasteItems = slate.taste.ifEmpty { slate.regional }
+    val distinctRecs =
+        tasteItems
+            .distinctBy { it.id }
+            .distinctBy { it.title.lowercase().trim() }
+    _recommendations.value = distinctRecs
+    _isRecommendationsFallback.value = slate.isFallback
+    _personalizedCandidatesLoaded.value = !slate.isFallback && slate.taste.isNotEmpty()
+    _personalizedRequestFailed.value = false
+    if (slate.becauseYouLikeEpisodes.isNotEmpty() || slate.becauseYouLikePodcasts.isNotEmpty()) {
+        _becauseYouLikeRecommendations.value = slate.becauseYouLikeEpisodes
+        _becauseYouLikePodcasts.value = slate.becauseYouLikePodcasts
+        if (autoAnchor != null) {
+            localCatalog.getLocalPodcast(autoAnchor)?.let { _seemsToLikePodcast.value = it }
+        }
+    }
+    cacheRecommendations(distinctRecs, slate.isFallback)
+    _personalizationMode.value =
+        HomePersonalizationModeLogic.derive(
+            meaningfulPlayCount = gate.meaningfulCount,
+            hasEligiblePositiveShow = gate.hasEligiblePositiveShow,
+            personalizedCandidatesLoaded = _personalizedCandidatesLoaded.value,
+            personalizedRequestFailed = false,
+        )
+    cx.aswin.boxlore.core.analytics.AnalyticsHelper.trackHomePersonalizationMode(
+        mode = _personalizationMode.value.name,
+        meaningfulPlayCount = gate.meaningfulCount,
+        isFallback = slate.isFallback,
+        candidateRequestOk = true,
+    )
+    return true
+}
+
+private suspend fun HomeViewModel.applyRegionalRecommendations(
+    region: String,
+    history: List<cx.aswin.boxlore.core.network.model.HistoryItem>,
+    interests: List<String>,
+    subscribedIds: List<String>,
+    subscribedGenres: List<String>,
+    gate: PersonalizationGate,
+) {
+    val recs =
+        podcastRepository.getPersonalizedRecommendations(
+            history = history,
+            interests = interests,
+            country = region,
+            subscribedPodcastIds = subscribedIds,
+            subscribedGenres = subscribedGenres,
+        )
+    val distinctRecs =
+        recs
+            .distinctBy { it.id }
+            .distinctBy { it.title.lowercase().trim() }
+    _recommendations.value = distinctRecs
+    _isRecommendationsFallback.value = true
+    _personalizedCandidatesLoaded.value = false
+    cacheRecommendations(distinctRecs, isFallback = true)
+    _personalizationMode.value =
+        HomePersonalizationModeLogic.derive(
+            meaningfulPlayCount = gate.meaningfulCount,
+            hasEligiblePositiveShow = gate.hasEligiblePositiveShow,
+            personalizedCandidatesLoaded = false,
+            personalizedRequestFailed = _personalizedRequestFailed.value,
+        )
+}
+
+private fun HomeViewModel.cacheRecommendations(
+    distinctRecs: List<cx.aswin.boxlore.core.model.Episode>,
+    isFallback: Boolean,
+) {
+    try {
+        val json = Json { ignoreUnknownKeys = true }
+        boxcastPrefs.saveRecommendationsCache(
+            json.encodeToString(distinctRecs),
+            isFallback,
+        )
+    } catch (ce: Exception) {
+        android.util.Log.e("HomeViewModel", "Failed to cache recommendations", ce)
     }
 }
 

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/CuratedEpisodeCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/CuratedEpisodeCard.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,62 +26,80 @@ fun CuratedEpisodeCard(
     episode: Episode,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onFeedback: ((RecommendationFeedbackAction) -> Unit)? = null,
 ) {
     val isNew =
         episode.publishedDate > 0L &&
             (System.currentTimeMillis() / 1000L - episode.publishedDate) < 2 * 24 * 60 * 60L
+    var menuExpanded by remember { mutableStateOf(false) }
 
-    FeedMediaCard(
-        imageUrl = (episode.imageUrl ?: "").ifEmpty { podcast.imageUrl },
-        title = episode.title,
-        subtitle = podcast.title,
-        onClick = onClick,
-        modifier = modifier,
-        imageBadge = {
-            if (isNew) {
-                Box(
-                    modifier =
-                        Modifier
-                            .padding(6.dp)
-                            .clip(MaterialTheme.shapes.extraSmall)
-                            .background(MaterialTheme.colorScheme.primary)
-                            .align(Alignment.TopStart),
-                ) {
-                    Text(
-                        text = "NEW",
-                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp, lineHeight = 8.sp),
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
-                    )
+    Box(modifier = modifier) {
+        FeedMediaCard(
+            imageUrl = (episode.imageUrl ?: "").ifEmpty { podcast.imageUrl },
+            title = episode.title,
+            subtitle = podcast.title,
+            onClick = onClick,
+            onLongClick =
+                if (onFeedback != null) {
+                    { menuExpanded = true }
+                } else {
+                    null
+                },
+            imageBadge = {
+                if (isNew) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .padding(6.dp)
+                                .clip(MaterialTheme.shapes.extraSmall)
+                                .background(MaterialTheme.colorScheme.primary)
+                                .align(Alignment.TopStart),
+                    ) {
+                        Text(
+                            text = "NEW",
+                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp, lineHeight = 8.sp),
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onPrimary,
+                            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+                        )
+                    }
                 }
-            }
-        },
-        imageOverlay = {
-            if (episode.duration > 0) {
-                Box(
-                    modifier =
-                        Modifier
-                            .padding(6.dp)
-                            .clip(MaterialTheme.shapes.small)
-                            .background(Color.Black.copy(alpha = 0.6f))
-                            .align(Alignment.BottomEnd),
-                ) {
-                    Text(
-                        text = formatDuration(episode.duration),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.Medium,
-                        color = Color.White,
-                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                    )
+            },
+            imageOverlay = {
+                if (episode.duration > 0) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .padding(6.dp)
+                                .clip(MaterialTheme.shapes.small)
+                                .background(Color.Black.copy(alpha = 0.6f))
+                                .align(Alignment.BottomEnd),
+                    ) {
+                        Text(
+                            text = formatDuration(episode.duration),
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Medium,
+                            color = Color.White,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                        )
+                    }
                 }
-            }
-        },
-    )
+            },
+        )
+        if (onFeedback != null) {
+            RecommendationFeedbackMenu(
+                expanded = menuExpanded,
+                onDismiss = { menuExpanded = false },
+                onMoreLikeThis = { onFeedback(RecommendationFeedbackAction.MORE_LIKE_THIS) },
+                onNotForMe = { onFeedback(RecommendationFeedbackAction.NOT_FOR_ME) },
+                onHideShow = { onFeedback(RecommendationFeedbackAction.HIDE_SHOW) },
+            )
+        }
+    }
 }
 
 private fun formatDuration(seconds: Int): String {
     if (seconds <= 0) return ""
-    val m = seconds / 60
-    return "${m}m"
+    val minutes = seconds / 60
+    return "${minutes}m"
 }

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/ForYouSection.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/ForYouSection.kt
@@ -1,6 +1,8 @@
 package cx.aswin.boxlore.feature.home.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
@@ -13,6 +15,10 @@ import androidx.compose.material.icons.rounded.Videocam
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -30,6 +36,8 @@ import cx.aswin.boxlore.core.designsystem.theme.m3Shimmer
 import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.feature.home.StableEpisodeList
+import cx.aswin.boxlore.feature.home.logic.HomePersonalizationMode
+import cx.aswin.boxlore.feature.home.logic.HomePersonalizationModeLogic
 
 /**
  * Emits the "For You" section directly into a [LazyStaggeredGridScope] instead of composing
@@ -43,19 +51,23 @@ fun LazyStaggeredGridScope.forYouItems(
     discoveryContextTitle: String,
     showTasteHeader: Boolean = true,
     isFallback: Boolean = true,
+    personalizationMode: HomePersonalizationMode = if (isFallback) {
+        HomePersonalizationMode.REGIONAL
+    } else {
+        HomePersonalizationMode.PERSONALIZED
+    },
+    onRecommendationFeedback: ((Episode, RecommendationFeedbackAction) -> Unit)? = null,
 ) {
     val items = recommendations.list.take(9)
+    val title = HomePersonalizationModeLogic.tasteSectionTitle(personalizationMode)
+    val subtitle = HomePersonalizationModeLogic.tasteSectionSubtitle(personalizationMode)
+    val regionalLabel = personalizationMode != HomePersonalizationMode.PERSONALIZED
 
     if (showTasteHeader) {
         item(span = StaggeredGridItemSpan.FullLine, key = "for_you_header", contentType = "for_you_header") {
             HomeChildSectionHeader(
-                title = if (isFallback) "Popular in your Region" else "Based on Your Taste",
-                subtitle =
-                    if (isFallback) {
-                        "Popular picks from listeners near you"
-                    } else {
-                        "Picked from your listening patterns"
-                    },
+                title = title,
+                subtitle = subtitle,
                 icon = Icons.Rounded.AutoAwesome,
             )
         }
@@ -96,7 +108,7 @@ fun LazyStaggeredGridScope.forYouItems(
         ForYouHeroCard(
             episode = ep,
             parentPodcast = parentPodcast,
-            isFallback = isFallback,
+            isFallback = regionalLabel,
             onClick = {
                 AnalyticsHelper.trackHomeRecommendationCardTapped(
                     episodeId = ep.id,
@@ -107,6 +119,9 @@ fun LazyStaggeredGridScope.forYouItems(
                     timeBlockTitle = discoveryContextTitle,
                 )
                 onEpisodeClick(ep, parentPodcast)
+            },
+            onFeedback = onRecommendationFeedback?.let { cb ->
+                { action -> cb(ep, action) }
             },
         )
     }
@@ -142,26 +157,41 @@ fun LazyStaggeredGridScope.forYouItems(
                 )
                 onEpisodeClick(ep, parentPodcast)
             },
+            onFeedback = onRecommendationFeedback?.let { cb ->
+                { action -> cb(ep, action) }
+            },
             modifier = Modifier.fillMaxWidth(),
         )
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ForYouHeroCard(
     episode: Episode,
     parentPodcast: Podcast,
     isFallback: Boolean = true,
     onClick: () -> Unit,
+    onFeedback: ((RecommendationFeedbackAction) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
     Box(
         modifier =
             modifier
                 .fillMaxWidth()
                 .height(200.dp)
                 .clip(RoundedCornerShape(20.dp))
-                .expressiveClickable(shape = RoundedCornerShape(20.dp), onClick = onClick),
+                .then(
+                    if (onFeedback != null) {
+                        Modifier.combinedClickable(
+                            onClick = onClick,
+                            onLongClick = { menuExpanded = true },
+                        )
+                    } else {
+                        Modifier.expressiveClickable(shape = RoundedCornerShape(20.dp), onClick = onClick)
+                    },
+                ),
     ) {
         // Full-bleed artwork background
         OptimizedImage(
@@ -299,6 +329,16 @@ private fun ForYouHeroCard(
                     )
                 }
             }
+        }
+
+        if (onFeedback != null) {
+            RecommendationFeedbackMenu(
+                expanded = menuExpanded,
+                onDismiss = { menuExpanded = false },
+                onMoreLikeThis = { onFeedback(RecommendationFeedbackAction.MORE_LIKE_THIS) },
+                onNotForMe = { onFeedback(RecommendationFeedbackAction.NOT_FOR_ME) },
+                onHideShow = { onFeedback(RecommendationFeedbackAction.HIDE_SHOW) },
+            )
         }
     }
 }

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/ForYouSection.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/ForYouSection.kt
@@ -74,19 +74,45 @@ fun LazyStaggeredGridScope.forYouItems(
     }
 
     if (items.isEmpty()) {
-        // Skeleton: hero + a handful of grid skeletons, each an individual staggered item.
-        item(span = StaggeredGridItemSpan.FullLine, key = "for_you_hero_skeleton", contentType = "for_you_hero_skeleton") {
-            val baseColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)
-            val highlightColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
-            ForYouHeroSkeleton(baseColor = baseColor, highlightColor = highlightColor)
-        }
-        items(8, key = { "for_you_skel_$it" }, contentType = { "for_you_skel" }) {
-            GridSkeletonItem()
-        }
+        emitForYouSkeletons()
         return
     }
 
-    // Hero card (index 0) — full width. Also hosts the impression analytics effect.
+    emitForYouHero(
+        recommendations = recommendations,
+        hero = items[0],
+        discoveryContextTitle = discoveryContextTitle,
+        regionalLabel = regionalLabel,
+        onEpisodeClick = onEpisodeClick,
+        onRecommendationFeedback = onRecommendationFeedback,
+    )
+    emitForYouGrid(
+        remaining = items.drop(1),
+        discoveryContextTitle = discoveryContextTitle,
+        onEpisodeClick = onEpisodeClick,
+        onRecommendationFeedback = onRecommendationFeedback,
+    )
+}
+
+private fun LazyStaggeredGridScope.emitForYouSkeletons() {
+    item(span = StaggeredGridItemSpan.FullLine, key = "for_you_hero_skeleton", contentType = "for_you_hero_skeleton") {
+        val baseColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)
+        val highlightColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+        ForYouHeroSkeleton(baseColor = baseColor, highlightColor = highlightColor)
+    }
+    items(8, key = { "for_you_skel_$it" }, contentType = { "for_you_skel" }) {
+        GridSkeletonItem()
+    }
+}
+
+private fun LazyStaggeredGridScope.emitForYouHero(
+    recommendations: StableEpisodeList,
+    hero: Episode,
+    discoveryContextTitle: String,
+    regionalLabel: Boolean,
+    onEpisodeClick: (Episode, Podcast) -> Unit,
+    onRecommendationFeedback: ((Episode, RecommendationFeedbackAction) -> Unit)?,
+) {
     item(span = StaggeredGridItemSpan.FullLine, key = "for_you_hero", contentType = "for_you_hero") {
         LaunchedEffect(recommendations.list, discoveryContextTitle) {
             AnalyticsHelper.trackHomeRecommendationsImpression(
@@ -95,66 +121,39 @@ fun LazyStaggeredGridScope.forYouItems(
                 timeBlockTitle = discoveryContextTitle,
             )
         }
-        val ep = items[0]
-        val parentPodcast =
-            Podcast(
-                id = ep.podcastId ?: "",
-                title = ep.podcastTitle ?: "Podcast",
-                artist = "",
-                imageUrl = ep.podcastImageUrl?.takeIf { it.isNotBlank() } ?: ep.imageUrl?.takeIf { it.isNotBlank() } ?: "",
-                description = "",
-                genre = ep.podcastGenre ?: "Podcast",
-            )
+        val parentPodcast = parentPodcastFromEpisode(hero)
         ForYouHeroCard(
-            episode = ep,
+            episode = hero,
             parentPodcast = parentPodcast,
             isFallback = regionalLabel,
             onClick = {
-                AnalyticsHelper.trackHomeRecommendationCardTapped(
-                    episodeId = ep.id,
-                    episodeTitle = ep.title,
-                    podcastId = parentPodcast.id,
-                    podcastName = parentPodcast.title,
-                    positionIndex = 0,
-                    timeBlockTitle = discoveryContextTitle,
-                )
-                onEpisodeClick(ep, parentPodcast)
+                trackRecommendationTap(hero, parentPodcast, 0, discoveryContextTitle)
+                onEpisodeClick(hero, parentPodcast)
             },
             onFeedback = onRecommendationFeedback?.let { cb ->
-                { action -> cb(ep, action) }
+                { action -> cb(hero, action) }
             },
         )
     }
+}
 
-    // Remaining items become individual staggered (masonry) cards.
-    val remaining = items.drop(1)
+private fun LazyStaggeredGridScope.emitForYouGrid(
+    remaining: List<Episode>,
+    discoveryContextTitle: String,
+    onEpisodeClick: (Episode, Podcast) -> Unit,
+    onRecommendationFeedback: ((Episode, RecommendationFeedbackAction) -> Unit)?,
+) {
     itemsIndexed(
         remaining,
         key = { _, ep -> "for_you_${ep.id}" },
         contentType = { _, _ -> "for_you_card" },
     ) { index, ep ->
-        val originalIndex = index + 1
-        val parentPodcast =
-            Podcast(
-                id = ep.podcastId ?: "",
-                title = ep.podcastTitle ?: "Podcast",
-                artist = "",
-                imageUrl = ep.podcastImageUrl?.takeIf { it.isNotBlank() } ?: ep.imageUrl?.takeIf { it.isNotBlank() } ?: "",
-                description = "",
-                genre = ep.podcastGenre ?: "Podcast",
-            )
+        val parentPodcast = parentPodcastFromEpisode(ep)
         CuratedEpisodeCard(
             podcast = parentPodcast,
             episode = ep,
             onClick = {
-                AnalyticsHelper.trackHomeRecommendationCardTapped(
-                    episodeId = ep.id,
-                    episodeTitle = ep.title,
-                    podcastId = parentPodcast.id,
-                    podcastName = parentPodcast.title,
-                    positionIndex = originalIndex,
-                    timeBlockTitle = discoveryContextTitle,
-                )
+                trackRecommendationTap(ep, parentPodcast, index + 1, discoveryContextTitle)
                 onEpisodeClick(ep, parentPodcast)
             },
             onFeedback = onRecommendationFeedback?.let { cb ->
@@ -163,6 +162,32 @@ fun LazyStaggeredGridScope.forYouItems(
             modifier = Modifier.fillMaxWidth(),
         )
     }
+}
+
+private fun parentPodcastFromEpisode(ep: Episode): Podcast =
+    Podcast(
+        id = ep.podcastId ?: "",
+        title = ep.podcastTitle ?: "Podcast",
+        artist = "",
+        imageUrl = ep.podcastImageUrl?.takeIf { it.isNotBlank() } ?: ep.imageUrl?.takeIf { it.isNotBlank() } ?: "",
+        description = "",
+        genre = ep.podcastGenre ?: "Podcast",
+    )
+
+private fun trackRecommendationTap(
+    episode: Episode,
+    parentPodcast: Podcast,
+    positionIndex: Int,
+    discoveryContextTitle: String,
+) {
+    AnalyticsHelper.trackHomeRecommendationCardTapped(
+        episodeId = episode.id,
+        episodeTitle = episode.title,
+        podcastId = parentPodcast.id,
+        podcastName = parentPodcast.title,
+        positionIndex = positionIndex,
+        timeBlockTitle = discoveryContextTitle,
+    )
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -182,18 +207,8 @@ private fun ForYouHeroCard(
                 .fillMaxWidth()
                 .height(200.dp)
                 .clip(RoundedCornerShape(20.dp))
-                .then(
-                    if (onFeedback != null) {
-                        Modifier.combinedClickable(
-                            onClick = onClick,
-                            onLongClick = { menuExpanded = true },
-                        )
-                    } else {
-                        Modifier.expressiveClickable(shape = RoundedCornerShape(20.dp), onClick = onClick)
-                    },
-                ),
+                .then(forYouHeroClickModifier(onClick, onFeedback) { menuExpanded = true }),
     ) {
-        // Full-bleed artwork background
         OptimizedImage(
             url = episode.imageUrl?.takeIf { it.isNotBlank() } ?: episode.podcastImageUrl?.takeIf { it.isNotBlank() },
             proxyWidth = 600,
@@ -201,136 +216,9 @@ private fun ForYouHeroCard(
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
         )
-
-        // Dark gradient scrim — heavier at bottom for text legibility (Option A)
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(
-                            colorStops =
-                                arrayOf(
-                                    0.0f to Color.Transparent,
-                                    0.3f to Color.Black.copy(alpha = 0.15f),
-                                    0.6f to Color.Black.copy(alpha = 0.65f),
-                                    1.0f to Color.Black,
-                                ),
-                        ),
-                    ),
-        )
-
-        // Premium tag for the Hero card
-        Box(
-            modifier =
-                Modifier
-                    .padding(14.dp)
-                    .align(Alignment.TopStart)
-                    .background(
-                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
-                        shape = RoundedCornerShape(12.dp),
-                    ).padding(horizontal = 8.dp, vertical = 4.dp),
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                Icon(
-                    imageVector = Icons.Rounded.AutoAwesome,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onPrimary,
-                    modifier = Modifier.size(12.dp),
-                )
-                Text(
-                    text = if (isFallback) "POPULAR IN YOUR REGION" else "FEATURED RECOMMENDATION",
-                    style =
-                        MaterialTheme.typography.labelSmall.copy(
-                            color = MaterialTheme.colorScheme.onPrimary,
-                            fontSize = 9.sp,
-                            fontWeight = FontWeight.Bold,
-                            letterSpacing = 0.5.sp,
-                        ),
-                )
-            }
-        }
-
-        // Metadata anchored to bottom
-        Column(
-            modifier =
-                Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            // Podcast name
-            Text(
-                text = episode.podcastTitle ?: "",
-                style =
-                    MaterialTheme.typography.labelMedium.copy(
-                        color = Color.White.copy(alpha = 0.8f),
-                        fontSize = 11.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        letterSpacing = 0.4.sp,
-                    ),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-
-            // Episode title (larger font since it's the hero card)
-            Text(
-                text = episode.title,
-                style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        color = Color.White,
-                        fontWeight = FontWeight.ExtraBold,
-                        fontSize = 16.sp,
-                        lineHeight = 20.sp,
-                    ),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-
-            // Duration & additional context
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                if (episode.duration > 0) {
-                    val minutes = episode.duration / 60
-                    Text(
-                        text = "$minutes min read/listen",
-                        style =
-                            MaterialTheme.typography.bodySmall.copy(
-                                color = Color.White.copy(alpha = 0.6f),
-                                fontSize = 10.sp,
-                                fontWeight = FontWeight.Medium,
-                            ),
-                    )
-                }
-
-                val genre = episode.podcastGenre ?: parentPodcast.genre
-                if (!genre.isNullOrBlank()) {
-                    Text(
-                        text = "•",
-                        color = Color.White.copy(alpha = 0.4f),
-                        fontSize = 10.sp,
-                    )
-                    Text(
-                        text = genre,
-                        style =
-                            MaterialTheme.typography.bodySmall.copy(
-                                color = Color.White.copy(alpha = 0.6f),
-                                fontSize = 10.sp,
-                                fontWeight = FontWeight.Medium,
-                            ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
-        }
-
+        ForYouHeroScrim()
+        ForYouHeroTag(isFallback = isFallback)
+        ForYouHeroMetadata(episode = episode, parentPodcast = parentPodcast)
         if (onFeedback != null) {
             RecommendationFeedbackMenu(
                 expanded = menuExpanded,
@@ -339,6 +227,145 @@ private fun ForYouHeroCard(
                 onNotForMe = { onFeedback(RecommendationFeedbackAction.NOT_FOR_ME) },
                 onHideShow = { onFeedback(RecommendationFeedbackAction.HIDE_SHOW) },
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+private fun forYouHeroClickModifier(
+    onClick: () -> Unit,
+    onFeedback: ((RecommendationFeedbackAction) -> Unit)?,
+    onLongClick: () -> Unit,
+): Modifier =
+    if (onFeedback != null) {
+        Modifier.combinedClickable(onClick = onClick, onLongClick = onLongClick)
+    } else {
+        Modifier.expressiveClickable(shape = RoundedCornerShape(20.dp), onClick = onClick)
+    }
+
+@Composable
+private fun ForYouHeroScrim() {
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colorStops =
+                            arrayOf(
+                                0.0f to Color.Transparent,
+                                0.3f to Color.Black.copy(alpha = 0.15f),
+                                0.6f to Color.Black.copy(alpha = 0.65f),
+                                1.0f to Color.Black,
+                            ),
+                    ),
+                ),
+    )
+}
+
+@Composable
+private fun BoxScope.ForYouHeroTag(isFallback: Boolean) {
+    Box(
+        modifier =
+            Modifier
+                .padding(14.dp)
+                .align(Alignment.TopStart)
+                .background(
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f),
+                    shape = RoundedCornerShape(12.dp),
+                ).padding(horizontal = 8.dp, vertical = 4.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.AutoAwesome,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(12.dp),
+            )
+            Text(
+                text = if (isFallback) "POPULAR IN YOUR REGION" else "FEATURED RECOMMENDATION",
+                style =
+                    MaterialTheme.typography.labelSmall.copy(
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        fontSize = 9.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 0.5.sp,
+                    ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.ForYouHeroMetadata(
+    episode: Episode,
+    parentPodcast: Podcast,
+) {
+    Column(
+        modifier =
+            Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = episode.podcastTitle ?: "",
+            style =
+                MaterialTheme.typography.labelMedium.copy(
+                    color = Color.White.copy(alpha = 0.8f),
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    letterSpacing = 0.4.sp,
+                ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = episode.title,
+            style =
+                MaterialTheme.typography.titleMedium.copy(
+                    color = Color.White,
+                    fontWeight = FontWeight.ExtraBold,
+                    fontSize = 16.sp,
+                    lineHeight = 20.sp,
+                ),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (episode.duration > 0) {
+                Text(
+                    text = "${episode.duration / 60} min read/listen",
+                    style =
+                        MaterialTheme.typography.bodySmall.copy(
+                            color = Color.White.copy(alpha = 0.6f),
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Medium,
+                        ),
+                )
+            }
+            val genre = episode.podcastGenre ?: parentPodcast.genre
+            if (!genre.isNullOrBlank()) {
+                Text(text = "•", color = Color.White.copy(alpha = 0.4f), fontSize = 10.sp)
+                Text(
+                    text = genre,
+                    style =
+                        MaterialTheme.typography.bodySmall.copy(
+                            color = Color.White.copy(alpha = 0.6f),
+                            fontSize = 10.sp,
+                            fontWeight = FontWeight.Medium,
+                        ),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }
@@ -372,7 +399,6 @@ private fun ForYouHorizontalBentoCard(
                 .clip(RoundedCornerShape(20.dp))
                 .expressiveClickable(onClick = onClick),
     ) {
-        // Full-bleed artwork background
         OptimizedImage(
             url = episode.imageUrl?.takeIf { it.isNotBlank() } ?: episode.podcastImageUrl?.takeIf { it.isNotBlank() },
             proxyWidth = 600,
@@ -380,8 +406,6 @@ private fun ForYouHorizontalBentoCard(
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
         )
-
-        // Heavy dark gradient scrim for pristine text contrast
         Box(
             modifier =
                 Modifier
@@ -397,8 +421,6 @@ private fun ForYouHorizontalBentoCard(
                         ),
                     ),
         )
-
-        // Duration chip — top left
         if (episode.duration > 0) {
             val minutes = episode.duration / 60
             Surface(
@@ -421,8 +443,6 @@ private fun ForYouHorizontalBentoCard(
                 )
             }
         }
-
-        // Genre chip — top right (or video badge if video)
         val genre = episode.podcastGenre
         if (episode.enclosureType?.startsWith("video/") == true) {
             Surface(
@@ -468,8 +488,6 @@ private fun ForYouHorizontalBentoCard(
                 )
             }
         }
-
-        // Episode title — bottom aligned
         Column(
             modifier =
                 Modifier

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/PodcastCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/PodcastCard.kt
@@ -100,6 +100,7 @@ fun PodcastCard(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
+@Suppress("LongParameterList") // Card content + optional long-press feedback affordance.
 fun FeedMediaCard(
     imageUrl: String,
     title: String,

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/PodcastCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/PodcastCard.kt
@@ -1,6 +1,8 @@
 package cx.aswin.boxlore.feature.home.components
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
@@ -96,6 +98,7 @@ fun PodcastCard(
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun FeedMediaCard(
     imageUrl: String,
@@ -103,6 +106,7 @@ fun FeedMediaCard(
     subtitle: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
     imageBadge: @Composable (BoxScope.() -> Unit)? = null,
     imageOverlay: @Composable (BoxScope.() -> Unit)? = null,
 ) {
@@ -110,7 +114,15 @@ fun FeedMediaCard(
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
         border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-        modifier = modifier.expressiveClickable(onClick = onClick),
+        modifier =
+            if (onLongClick != null) {
+                modifier.combinedClickable(
+                    onClick = onClick,
+                    onLongClick = onLongClick,
+                )
+            } else {
+                modifier.expressiveClickable(onClick = onClick)
+            },
     ) {
         Column {
             Box(

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/RecommendationFeedbackAction.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/RecommendationFeedbackAction.kt
@@ -1,0 +1,7 @@
+package cx.aswin.boxlore.feature.home.components
+
+enum class RecommendationFeedbackAction {
+    MORE_LIKE_THIS,
+    NOT_FOR_ME,
+    HIDE_SHOW,
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/RecommendationFeedbackMenu.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/RecommendationFeedbackMenu.kt
@@ -1,0 +1,48 @@
+package cx.aswin.boxlore.feature.home.components
+
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Accessible recommendation feedback actions (long-press / overflow menu).
+ */
+@Composable
+fun RecommendationFeedbackMenu(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    onMoreLikeThis: () -> Unit,
+    onNotForMe: () -> Unit,
+    onHideShow: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        modifier = modifier,
+    ) {
+        DropdownMenuItem(
+            text = { Text("More like this") },
+            onClick = {
+                onDismiss()
+                onMoreLikeThis()
+            },
+        )
+        DropdownMenuItem(
+            text = { Text("Not for me") },
+            onClick = {
+                onDismiss()
+                onNotForMe()
+            },
+        )
+        DropdownMenuItem(
+            text = { Text("Hide this show") },
+            onClick = {
+                onDismiss()
+                onHideShow()
+            },
+        )
+    }
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeAnchorSelectionLogic.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeAnchorSelectionLogic.kt
@@ -1,0 +1,75 @@
+package cx.aswin.boxlore.feature.home.logic
+
+/**
+ * Because You Like automatic anchor selection using learner SHOW affinity + evidence.
+ * Replaces the legacy subscription +100 heuristic.
+ */
+object HomeAnchorSelectionLogic {
+    data class ShowCandidate(
+        val podcastId: String,
+        val affinity: Double,
+        val confidence: Double,
+        val evidence: Double,
+        val lastPlayedAt: Long = 0L,
+        val isHidden: Boolean = false,
+    )
+
+    data class Selection(
+        val podcastId: String,
+        val reason: String,
+    )
+
+    /** Minimum evidence mass before a show can become an automatic anchor. */
+    const val MIN_EVIDENCE = 0.75
+
+    /** Minimum confidence (0–1) for automatic anchor. */
+    const val MIN_CONFIDENCE = 0.35
+
+    /** Minimum affinity in [-1, 1]. */
+    const val MIN_AFFINITY = 0.15
+
+    /**
+     * Hysteresis: keep [currentAnchorId] unless another candidate exceeds it by this margin.
+     */
+    const val SWITCH_MARGIN = 0.12
+
+    fun selectAutomatic(
+        candidates: List<ShowCandidate>,
+        currentAnchorId: String?,
+        manualOverrideId: String?,
+    ): Selection? {
+        if (manualOverrideId != null) {
+            val stillPresent = candidates.any { it.podcastId == manualOverrideId && !it.isHidden }
+            if (stillPresent || candidates.isEmpty()) {
+                return Selection(manualOverrideId, "manual_override")
+            }
+        }
+        val eligible =
+            candidates
+                .filterNot(ShowCandidate::isHidden)
+                .filter {
+                    it.affinity >= MIN_AFFINITY &&
+                        it.confidence >= MIN_CONFIDENCE &&
+                        it.evidence >= MIN_EVIDENCE
+                }
+        if (eligible.isEmpty()) return null
+
+        val ranked =
+            eligible.sortedWith(
+                compareByDescending<ShowCandidate> { it.affinity * it.confidence }
+                    .thenByDescending { it.lastPlayedAt },
+            )
+        val top = ranked.first()
+        if (currentAnchorId != null) {
+            val current = eligible.firstOrNull { it.podcastId == currentAnchorId }
+            if (current != null) {
+                val topScore = top.affinity * top.confidence
+                val currentScore = current.affinity * current.confidence
+                if (topScore < currentScore + SWITCH_MARGIN) {
+                    return Selection(current.podcastId, "hysteresis")
+                }
+            }
+        }
+        return Selection(top.podcastId, "learner_show_affinity")
+    }
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeDiscoveryMission.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeDiscoveryMission.kt
@@ -1,0 +1,103 @@
+package cx.aswin.boxlore.feature.home.logic
+
+/**
+ * Fixed greeting discovery mission catalog. Exactly one mission is active at a time.
+ * Rotate only when daypart / exposure / novelty warrant — not on every recomposition.
+ */
+enum class HomeDiscoveryMission(
+    val id: String,
+    val title: String,
+    val subtitle: String,
+    val maxDurationSeconds: Int? = null,
+    val preferFresh: Boolean = false,
+    val stretchBeyondTaste: Boolean = false,
+) {
+    FRESH_DROPS(
+        id = "fresh_drops",
+        title = "Fresh drops",
+        subtitle = "Recently published picks adjacent to your taste",
+        preferFresh = true,
+    ),
+    SHORT_LISTENS(
+        id = "short_listens",
+        title = "Short listens",
+        subtitle = "High-confidence episodes under about 25 minutes",
+        maxDurationSeconds = 25 * 60,
+    ),
+    DEEP_DIVES(
+        id = "deep_dives",
+        title = "Deep dives",
+        subtitle = "Longer episodes for a focused listening window",
+    ),
+    ADJACENT_STRETCH(
+        id = "adjacent_stretch",
+        title = "Something adjacent",
+        subtitle = "One step outside your closest taste neighborhood",
+        stretchBeyondTaste = true,
+    ),
+}
+
+object HomeDiscoveryMissionLogic {
+    data class MissionContext(
+        val daypart: String,
+        val recentMissionIds: List<String> = emptyList(),
+        val noveltyPreference: Double = 0.5,
+        val preferShort: Boolean = false,
+    )
+
+    fun select(
+        context: MissionContext,
+        nowSlotKey: String,
+        stickyMissionId: String?,
+        stickySlotKey: String?,
+    ): HomeDiscoveryMission {
+        // Keep sticky mission within the same daypart slot.
+        if (stickyMissionId != null && stickySlotKey == nowSlotKey) {
+            HomeDiscoveryMission.entries
+                .firstOrNull { it.id == stickyMissionId }
+                ?.let { return it }
+        }
+        val recent = context.recentMissionIds.toSet()
+        val ranked = rankedCandidates(context)
+            .filterNot { it.id in recent }
+            .ifEmpty { rankedCandidates(context) }
+        return ranked.first()
+    }
+
+    fun slotKey(daypart: String, localDate: String): String = "$localDate:$daypart"
+
+    private fun rankedCandidates(context: MissionContext): List<HomeDiscoveryMission> {
+        val base =
+            when {
+                context.preferShort ||
+                    context.daypart.equals("morning", ignoreCase = true) ->
+                    listOf(
+                        HomeDiscoveryMission.SHORT_LISTENS,
+                        HomeDiscoveryMission.FRESH_DROPS,
+                        HomeDiscoveryMission.DEEP_DIVES,
+                        HomeDiscoveryMission.ADJACENT_STRETCH,
+                    )
+                context.daypart.equals("evening", ignoreCase = true) ||
+                    context.daypart.equals("night", ignoreCase = true) ->
+                    listOf(
+                        HomeDiscoveryMission.DEEP_DIVES,
+                        HomeDiscoveryMission.FRESH_DROPS,
+                        HomeDiscoveryMission.SHORT_LISTENS,
+                        HomeDiscoveryMission.ADJACENT_STRETCH,
+                    )
+                else ->
+                    listOf(
+                        HomeDiscoveryMission.FRESH_DROPS,
+                        HomeDiscoveryMission.SHORT_LISTENS,
+                        HomeDiscoveryMission.DEEP_DIVES,
+                        HomeDiscoveryMission.ADJACENT_STRETCH,
+                    )
+            }
+        return if (context.noveltyPreference >= 0.65) {
+            listOf(HomeDiscoveryMission.ADJACENT_STRETCH) +
+                base.filterNot { it == HomeDiscoveryMission.ADJACENT_STRETCH }
+        } else {
+            base
+        }
+    }
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeMeaningfulPlayLogic.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeMeaningfulPlayLogic.kt
@@ -1,0 +1,21 @@
+package cx.aswin.boxlore.feature.home.logic
+
+import cx.aswin.boxlore.core.network.model.HistoryItem
+
+/** Counts meaningful listens used by [HomePersonalizationModeLogic]. */
+object HomeMeaningfulPlayLogic {
+    const val MIN_PROGRESS_MS = 60_000L
+    const val MIN_PROGRESS_RATIO = 0.20
+
+    fun countMeaningfulPlays(history: List<HistoryItem>): Int =
+        history.count(::isMeaningful)
+
+    fun isMeaningful(item: HistoryItem): Boolean {
+        if (item.isCompleted == true || item.isLiked == true) return true
+        val duration = item.durationMs ?: 0L
+        val progress = item.progressMs ?: 0L
+        if (progress >= MIN_PROGRESS_MS) return true
+        if (duration <= 0L) return false
+        return progress.toDouble() / duration >= MIN_PROGRESS_RATIO
+    }
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomePersonalizationMode.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomePersonalizationMode.kt
@@ -1,0 +1,75 @@
+package cx.aswin.boxlore.feature.home.logic
+
+/**
+ * Durable Home personalization mode derived from meaningful-listen evidence and
+ * learner eligibility. Recomputed from persisted signals — not one-shot UI flags.
+ */
+enum class HomePersonalizationMode {
+    /** Honest regional charts; Because You Like hidden. */
+    REGIONAL,
+
+    /** Second+ meaningful play landed; personalized retrieval in flight. */
+    PERSONALIZING,
+
+    /** Taste and Because You Like eligible after successful candidate load. */
+    PERSONALIZED,
+}
+
+/**
+ * Pure mode derivation for Home cold-start → personalized transition.
+ *
+ * Thresholds (plan):
+ * - 0–1 meaningful plays → [HomePersonalizationMode.REGIONAL]
+ * - ≥2 meaningful plays → attempt personalization ([PERSONALIZING] until loaded)
+ * - By the third meaningful play, transition to [PERSONALIZED] when an eligible
+ *   positively evidenced show exists and candidates loaded successfully.
+ */
+object HomePersonalizationModeLogic {
+    const val MEANINGFUL_PLAYS_TO_ATTEMPT = 2
+    const val MEANINGFUL_PLAYS_TO_REQUIRE_ANCHOR = 3
+
+    fun derive(
+        meaningfulPlayCount: Int,
+        hasEligiblePositiveShow: Boolean,
+        personalizedCandidatesLoaded: Boolean,
+        personalizedRequestFailed: Boolean,
+    ): HomePersonalizationMode {
+        if (meaningfulPlayCount < MEANINGFUL_PLAYS_TO_ATTEMPT) {
+            return HomePersonalizationMode.REGIONAL
+        }
+        val anchorReady =
+            meaningfulPlayCount < MEANINGFUL_PLAYS_TO_REQUIRE_ANCHOR ||
+                hasEligiblePositiveShow
+        if (!anchorReady) {
+            return HomePersonalizationMode.REGIONAL
+        }
+        if (personalizedCandidatesLoaded) {
+            return HomePersonalizationMode.PERSONALIZED
+        }
+        // Transient failure keeps last regional slate visible but stays PERSONALIZING
+        // so retries continue (plan: do not get stuck).
+        if (personalizedRequestFailed) {
+            return HomePersonalizationMode.PERSONALIZING
+        }
+        return HomePersonalizationMode.PERSONALIZING
+    }
+
+    fun showBecauseYouLike(mode: HomePersonalizationMode): Boolean =
+        mode == HomePersonalizationMode.PERSONALIZED
+
+    fun tasteSectionTitle(mode: HomePersonalizationMode): String =
+        when (mode) {
+            HomePersonalizationMode.REGIONAL,
+            HomePersonalizationMode.PERSONALIZING,
+            -> "Popular in your Region"
+            HomePersonalizationMode.PERSONALIZED -> "Based on Your Taste"
+        }
+
+    fun tasteSectionSubtitle(mode: HomePersonalizationMode): String =
+        when (mode) {
+            HomePersonalizationMode.REGIONAL,
+            HomePersonalizationMode.PERSONALIZING,
+            -> "Popular picks from listeners near you"
+            HomePersonalizationMode.PERSONALIZED -> "Picked from your listening patterns"
+        }
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeSlateAllocationLogic.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeSlateAllocationLogic.kt
@@ -1,0 +1,97 @@
+package cx.aswin.boxlore.feature.home.logic
+
+/**
+ * Allocates retrieved candidates across Taste / Because You Like / Mission with
+ * global show+episode de-duplication. Pure JVM logic for unit tests.
+ */
+object HomeSlateAllocationLogic {
+    enum class Module {
+        TASTE,
+        BECAUSE_YOU_LIKE,
+        MISSION,
+    }
+
+    data class Candidate(
+        val episodeId: String,
+        val podcastId: String,
+        val score: Double,
+        val reason: String,
+        val moduleHint: Module?,
+        val isNovel: Boolean = false,
+        val isSubscription: Boolean = false,
+        val alreadyConsumedShow: Boolean = false,
+    )
+
+    data class AllocatedSlate(
+        val taste: List<Candidate>,
+        val becauseYouLike: List<Candidate>,
+        val mission: List<Candidate>,
+    )
+
+    fun allocate(
+        candidates: List<Candidate>,
+        tasteLimit: Int,
+        bylLimit: Int,
+        missionLimit: Int,
+        excludeSubscriptionsFromTaste: Boolean = true,
+    ): AllocatedSlate {
+        val usedEpisodes = mutableSetOf<String>()
+        val usedShows = mutableSetOf<String>()
+
+        fun take(
+            limit: Int,
+            predicate: (Candidate) -> Boolean,
+        ): List<Candidate> {
+            if (limit <= 0) return emptyList()
+            val out = mutableListOf<Candidate>()
+            for (candidate in candidates.sortedByDescending(Candidate::score)) {
+                if (out.size >= limit) break
+                if (!predicate(candidate)) continue
+                if (candidate.episodeId in usedEpisodes) continue
+                if (candidate.podcastId in usedShows) continue
+                out += candidate
+                usedEpisodes += candidate.episodeId
+                usedShows += candidate.podcastId
+            }
+            return out
+        }
+
+        val taste =
+            take(tasteLimit) { candidate ->
+                val hintOk =
+                    candidate.moduleHint == null ||
+                        candidate.moduleHint == Module.TASTE
+                val subOk = !excludeSubscriptionsFromTaste || !candidate.isSubscription
+                val consumedOk = !candidate.alreadyConsumedShow
+                hintOk && subOk && consumedOk &&
+                    !candidate.reason.contains("anchor", ignoreCase = true)
+            }
+
+        val byl =
+            take(bylLimit) { candidate ->
+                val hintOk =
+                    candidate.moduleHint == null ||
+                        candidate.moduleHint == Module.BECAUSE_YOU_LIKE
+                hintOk &&
+                    (
+                        candidate.moduleHint == Module.BECAUSE_YOU_LIKE ||
+                            candidate.reason.contains("anchor", ignoreCase = true) ||
+                            candidate.reason.contains("because", ignoreCase = true)
+                        )
+            }
+
+        val mission =
+            take(missionLimit) { candidate ->
+                val hintOk =
+                    candidate.moduleHint == null ||
+                        candidate.moduleHint == Module.MISSION
+                hintOk
+            }
+
+        return AllocatedSlate(
+            taste = taste,
+            becauseYouLike = byl,
+            mission = mission,
+        )
+    }
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeSlateAllocationLogic.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeSlateAllocationLogic.kt
@@ -35,6 +35,7 @@ object HomeSlateAllocationLogic {
         missionLimit: Int,
         excludeSubscriptionsFromTaste: Boolean = true,
     ): AllocatedSlate {
+        val ranked = candidates.sortedByDescending(Candidate::score)
         val usedEpisodes = mutableSetOf<String>()
         val usedShows = mutableSetOf<String>()
 
@@ -44,49 +45,27 @@ object HomeSlateAllocationLogic {
         ): List<Candidate> {
             if (limit <= 0) return emptyList()
             val out = mutableListOf<Candidate>()
-            for (candidate in candidates.sortedByDescending(Candidate::score)) {
+            for (candidate in ranked) {
                 if (out.size >= limit) break
-                if (!predicate(candidate)) continue
-                if (candidate.episodeId in usedEpisodes) continue
-                if (candidate.podcastId in usedShows) continue
-                out += candidate
-                usedEpisodes += candidate.episodeId
-                usedShows += candidate.podcastId
+                val available =
+                    candidate.episodeId !in usedEpisodes &&
+                        candidate.podcastId !in usedShows &&
+                        predicate(candidate)
+                if (available) {
+                    out += candidate
+                    usedEpisodes += candidate.episodeId
+                    usedShows += candidate.podcastId
+                }
             }
             return out
         }
 
         val taste =
             take(tasteLimit) { candidate ->
-                val hintOk =
-                    candidate.moduleHint == null ||
-                        candidate.moduleHint == Module.TASTE
-                val subOk = !excludeSubscriptionsFromTaste || !candidate.isSubscription
-                val consumedOk = !candidate.alreadyConsumedShow
-                hintOk && subOk && consumedOk &&
-                    !candidate.reason.contains("anchor", ignoreCase = true)
+                isTasteEligible(candidate, excludeSubscriptionsFromTaste)
             }
-
-        val byl =
-            take(bylLimit) { candidate ->
-                val hintOk =
-                    candidate.moduleHint == null ||
-                        candidate.moduleHint == Module.BECAUSE_YOU_LIKE
-                hintOk &&
-                    (
-                        candidate.moduleHint == Module.BECAUSE_YOU_LIKE ||
-                            candidate.reason.contains("anchor", ignoreCase = true) ||
-                            candidate.reason.contains("because", ignoreCase = true)
-                        )
-            }
-
-        val mission =
-            take(missionLimit) { candidate ->
-                val hintOk =
-                    candidate.moduleHint == null ||
-                        candidate.moduleHint == Module.MISSION
-                hintOk
-            }
+        val byl = take(bylLimit, ::isBecauseYouLikeEligible)
+        val mission = take(missionLimit, ::isMissionEligible)
 
         return AllocatedSlate(
             taste = taste,
@@ -94,4 +73,33 @@ object HomeSlateAllocationLogic {
             mission = mission,
         )
     }
+
+    private fun isTasteEligible(
+        candidate: Candidate,
+        excludeSubscriptionsFromTaste: Boolean,
+    ): Boolean {
+        val hintOk =
+            candidate.moduleHint == null ||
+                candidate.moduleHint == Module.TASTE
+        val subOk = !excludeSubscriptionsFromTaste || !candidate.isSubscription
+        val consumedOk = !candidate.alreadyConsumedShow
+        return hintOk &&
+            subOk &&
+            consumedOk &&
+            !candidate.reason.contains("anchor", ignoreCase = true)
+    }
+
+    private fun isBecauseYouLikeEligible(candidate: Candidate): Boolean {
+        val hintOk =
+            candidate.moduleHint == null ||
+                candidate.moduleHint == Module.BECAUSE_YOU_LIKE
+        val reasonOk =
+            candidate.moduleHint == Module.BECAUSE_YOU_LIKE ||
+                candidate.reason.contains("anchor", ignoreCase = true) ||
+                candidate.reason.contains("because", ignoreCase = true)
+        return hintOk && reasonOk
+    }
+
+    private fun isMissionEligible(candidate: Candidate): Boolean =
+        candidate.moduleHint == null || candidate.moduleHint == Module.MISSION
 }

--- a/feature/home/src/test/java/cx/aswin/boxlore/feature/home/logic/HomePersonalizationLogicTest.kt
+++ b/feature/home/src/test/java/cx/aswin/boxlore/feature/home/logic/HomePersonalizationLogicTest.kt
@@ -1,0 +1,310 @@
+package cx.aswin.boxlore.feature.home.logic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomePersonalizationModeLogicTest {
+    @Test
+    fun zeroOrOnePlayStaysRegional() {
+        assertEquals(
+            HomePersonalizationMode.REGIONAL,
+            HomePersonalizationModeLogic.derive(
+                meaningfulPlayCount = 0,
+                hasEligiblePositiveShow = false,
+                personalizedCandidatesLoaded = false,
+                personalizedRequestFailed = false,
+            ),
+        )
+        assertEquals(
+            HomePersonalizationMode.REGIONAL,
+            HomePersonalizationModeLogic.derive(
+                meaningfulPlayCount = 1,
+                hasEligiblePositiveShow = true,
+                personalizedCandidatesLoaded = true,
+                personalizedRequestFailed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun secondPlayAttemptsPersonalizing() {
+        assertEquals(
+            HomePersonalizationMode.PERSONALIZING,
+            HomePersonalizationModeLogic.derive(
+                meaningfulPlayCount = 2,
+                hasEligiblePositiveShow = true,
+                personalizedCandidatesLoaded = false,
+                personalizedRequestFailed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun thirdPlayWithoutEligibleShowStaysRegional() {
+        assertEquals(
+            HomePersonalizationMode.REGIONAL,
+            HomePersonalizationModeLogic.derive(
+                meaningfulPlayCount = 3,
+                hasEligiblePositiveShow = false,
+                personalizedCandidatesLoaded = false,
+                personalizedRequestFailed = false,
+            ),
+        )
+    }
+
+    @Test
+    fun loadedCandidatesBecomePersonalized() {
+        assertEquals(
+            HomePersonalizationMode.PERSONALIZED,
+            HomePersonalizationModeLogic.derive(
+                meaningfulPlayCount = 3,
+                hasEligiblePositiveShow = true,
+                personalizedCandidatesLoaded = true,
+                personalizedRequestFailed = false,
+            ),
+        )
+        assertTrue(
+            HomePersonalizationModeLogic.showBecauseYouLike(
+                HomePersonalizationMode.PERSONALIZED,
+            ),
+        )
+        assertFalse(
+            HomePersonalizationModeLogic.showBecauseYouLike(
+                HomePersonalizationMode.REGIONAL,
+            ),
+        )
+    }
+
+    @Test
+    fun titlesStayHonestInRegional() {
+        assertEquals(
+            "Popular in your Region",
+            HomePersonalizationModeLogic.tasteSectionTitle(HomePersonalizationMode.REGIONAL),
+        )
+        assertEquals(
+            "Based on Your Taste",
+            HomePersonalizationModeLogic.tasteSectionTitle(HomePersonalizationMode.PERSONALIZED),
+        )
+    }
+}
+
+class HomeDiscoveryMissionLogicTest {
+    @Test
+    fun stickyMissionPersistsWithinSlot() {
+        val selected =
+            HomeDiscoveryMissionLogic.select(
+                context =
+                    HomeDiscoveryMissionLogic.MissionContext(
+                        daypart = "morning",
+                        preferShort = true,
+                    ),
+                nowSlotKey = "2026-07-21:morning",
+                stickyMissionId = HomeDiscoveryMission.DEEP_DIVES.id,
+                stickySlotKey = "2026-07-21:morning",
+            )
+        assertEquals(HomeDiscoveryMission.DEEP_DIVES, selected)
+    }
+
+    @Test
+    fun morningPrefersShortListensWhenNoSticky() {
+        val selected =
+            HomeDiscoveryMissionLogic.select(
+                context =
+                    HomeDiscoveryMissionLogic.MissionContext(
+                        daypart = "morning",
+                        preferShort = true,
+                    ),
+                nowSlotKey = "2026-07-21:morning",
+                stickyMissionId = null,
+                stickySlotKey = null,
+            )
+        assertEquals(HomeDiscoveryMission.SHORT_LISTENS, selected)
+    }
+
+    @Test
+    fun highNoveltyPrefersAdjacentStretch() {
+        val selected =
+            HomeDiscoveryMissionLogic.select(
+                context =
+                    HomeDiscoveryMissionLogic.MissionContext(
+                        daypart = "afternoon",
+                        noveltyPreference = 0.8,
+                    ),
+                nowSlotKey = "2026-07-21:afternoon",
+                stickyMissionId = null,
+                stickySlotKey = null,
+            )
+        assertEquals(HomeDiscoveryMission.ADJACENT_STRETCH, selected)
+    }
+}
+
+class HomeAnchorSelectionLogicTest {
+    @Test
+    fun manualOverrideWins() {
+        val selection =
+            HomeAnchorSelectionLogic.selectAutomatic(
+                candidates =
+                    listOf(
+                        show("a", affinity = 0.9, confidence = 0.9, evidence = 2.0),
+                        show("b", affinity = 0.2, confidence = 0.4, evidence = 1.0),
+                    ),
+                currentAnchorId = "a",
+                manualOverrideId = "b",
+            )
+        assertEquals("b", selection?.podcastId)
+        assertEquals("manual_override", selection?.reason)
+    }
+
+    @Test
+    fun weakEvidenceIsIneligible() {
+        assertNull(
+            HomeAnchorSelectionLogic.selectAutomatic(
+                candidates =
+                    listOf(
+                        show("a", affinity = 0.9, confidence = 0.1, evidence = 0.1),
+                    ),
+                currentAnchorId = null,
+                manualOverrideId = null,
+            ),
+        )
+    }
+
+    @Test
+    fun hysteresisKeepsCurrentUnlessMarginExceeded() {
+        val kept =
+            HomeAnchorSelectionLogic.selectAutomatic(
+                candidates =
+                    listOf(
+                        show("current", affinity = 0.5, confidence = 0.8, evidence = 2.0),
+                        show("challenger", affinity = 0.55, confidence = 0.8, evidence = 2.0),
+                    ),
+                currentAnchorId = "current",
+                manualOverrideId = null,
+            )
+        assertEquals("current", kept?.podcastId)
+
+        val switched =
+            HomeAnchorSelectionLogic.selectAutomatic(
+                candidates =
+                    listOf(
+                        show("current", affinity = 0.4, confidence = 0.8, evidence = 2.0),
+                        show("challenger", affinity = 0.8, confidence = 0.9, evidence = 2.0),
+                    ),
+                currentAnchorId = "current",
+                manualOverrideId = null,
+            )
+        assertEquals("challenger", switched?.podcastId)
+    }
+
+    private fun show(
+        id: String,
+        affinity: Double,
+        confidence: Double,
+        evidence: Double,
+    ) = HomeAnchorSelectionLogic.ShowCandidate(
+        podcastId = id,
+        affinity = affinity,
+        confidence = confidence,
+        evidence = evidence,
+    )
+}
+
+class HomeSlateAllocationLogicTest {
+    @Test
+    fun deduplicatesShowsAcrossModules() {
+        val slate =
+            HomeSlateAllocationLogic.allocate(
+                candidates =
+                    listOf(
+                        candidate("e1", "p1", 1.0, "taste", HomeSlateAllocationLogic.Module.TASTE),
+                        candidate("e2", "p1", 0.9, "anchor", HomeSlateAllocationLogic.Module.BECAUSE_YOU_LIKE),
+                        candidate("e3", "p2", 0.8, "mission", HomeSlateAllocationLogic.Module.MISSION),
+                        candidate("e4", "p3", 0.7, "anchor", HomeSlateAllocationLogic.Module.BECAUSE_YOU_LIKE),
+                    ),
+                tasteLimit = 2,
+                bylLimit = 2,
+                missionLimit = 2,
+            )
+        assertEquals(listOf("e1"), slate.taste.map { it.episodeId })
+        assertEquals(listOf("e4"), slate.becauseYouLike.map { it.episodeId })
+        assertEquals(listOf("e3"), slate.mission.map { it.episodeId })
+    }
+
+    @Test
+    fun tasteExcludesSubscriptions() {
+        val slate =
+            HomeSlateAllocationLogic.allocate(
+                candidates =
+                    listOf(
+                        candidate(
+                            "e1",
+                            "p1",
+                            1.0,
+                            "taste",
+                            HomeSlateAllocationLogic.Module.TASTE,
+                            isSubscription = true,
+                        ),
+                        candidate("e2", "p2", 0.5, "taste", HomeSlateAllocationLogic.Module.TASTE),
+                    ),
+                tasteLimit = 2,
+                bylLimit = 0,
+                missionLimit = 0,
+            )
+        assertEquals(listOf("e2"), slate.taste.map { it.episodeId })
+    }
+
+    private fun candidate(
+        episodeId: String,
+        podcastId: String,
+        score: Double,
+        reason: String,
+        hint: HomeSlateAllocationLogic.Module,
+        isSubscription: Boolean = false,
+    ) = HomeSlateAllocationLogic.Candidate(
+        episodeId = episodeId,
+        podcastId = podcastId,
+        score = score,
+        reason = reason,
+        moduleHint = hint,
+        isSubscription = isSubscription,
+    )
+}
+
+class HomeMeaningfulPlayLogicTest {
+    @Test
+    fun countsCompletedLikedAndProgress() {
+        val history =
+            listOf(
+                cx.aswin.boxlore.core.network.model.HistoryItem(
+                    podcastTitle = "a",
+                    episodeTitle = "e1",
+                    podcastId = "1",
+                    progressMs = 10_000L,
+                    durationMs = 100_000L,
+                ),
+                cx.aswin.boxlore.core.network.model.HistoryItem(
+                    podcastTitle = "b",
+                    episodeTitle = "e2",
+                    podcastId = "2",
+                    isCompleted = true,
+                ),
+                cx.aswin.boxlore.core.network.model.HistoryItem(
+                    podcastTitle = "c",
+                    episodeTitle = "e3",
+                    podcastId = "3",
+                    isLiked = true,
+                ),
+                cx.aswin.boxlore.core.network.model.HistoryItem(
+                    podcastTitle = "d",
+                    episodeTitle = "e4",
+                    podcastId = "4",
+                    progressMs = 70_000L,
+                    durationMs = 100_000L,
+                ),
+            )
+        assertEquals(3, HomeMeaningfulPlayLogic.countMeaningfulPlays(history))
+    }
+}

--- a/scripts/sync/03-sync-episodes.js
+++ b/scripts/sync/03-sync-episodes.js
@@ -106,6 +106,26 @@ async function main() {
     log.info(`- never checked:    ${log.fmt(neverChecked)}`);
     log.info(`- stale news (8h):  ${log.fmt(staleNews)}`);
     log.info(`- stale other (24h):${log.fmt(staleRegular)}`);
+    if (deferred >= cfg.BACKLOG_WARN_THRESHOLD) {
+        log.warn(`Episode sync backlog high: ${log.fmt(deferred)} deferred (threshold ${log.fmt(cfg.BACKLOG_WARN_THRESHOLD)})`);
+        console.log(`::warning title=Episode sync backlog::${deferred} shows deferred beyond this run's cap`);
+    }
+    const oldestCheckAge = allDue.reduce((maxAge, id) => {
+        const checkedAt = st.shows[id]?.c || 0;
+        if (!checkedAt) return Math.max(maxAge, cfg.MAX_CHECK_AGE_WARN_MS + 1);
+        return Math.max(maxAge, now - checkedAt);
+    }, 0);
+    if (oldestCheckAge > cfg.MAX_CHECK_AGE_WARN_MS) {
+        const hours = Math.round(oldestCheckAge / 3600000);
+        log.warn(`Oldest due show check age ${hours}h exceeds ${Math.round(cfg.MAX_CHECK_AGE_WARN_MS / 3600000)}h`);
+        console.log(`::warning title=Episode sync freshness::Oldest due show is ${hours}h overdue`);
+    }
+    const chartsAge = now - (st.chartsRefreshedAt || 0);
+    if (st.chartsRefreshedAt && chartsAge > cfg.CHART_REFRESH_STALE_WARN_MS) {
+        const hours = Math.round(chartsAge / 3600000);
+        log.warn(`Charts last refreshed ${hours}h ago`);
+        console.log(`::warning title=Chart refresh stale::Charts last refreshed ${hours}h ago`);
+    }
     log.endGroup();
 
     // --- Process ---

--- a/scripts/sync/lib/config.js
+++ b/scripts/sync/lib/config.js
@@ -71,6 +71,13 @@ module.exports = {
     // Deterministic per-show jitter (+/-10%) on staleness thresholds so
     // check times spread instead of re-synchronizing into waves.
     STALENESS_JITTER: 0.10,
+    // Health thresholds: emit ::warning annotations when backlog/age exceed these.
+    BACKLOG_WARN_THRESHOLD: parseInt(process.env.BACKLOG_WARN_THRESHOLD || '1500', 10),
+    MAX_CHECK_AGE_WARN_MS: parseInt(process.env.MAX_CHECK_AGE_WARN_MS || String(48 * 60 * 60 * 1000), 10),
+    CHART_REFRESH_STALE_WARN_MS: parseInt(
+        process.env.CHART_REFRESH_STALE_WARN_MS || String(36 * 60 * 60 * 1000),
+        10,
+    ),
 
     // --- Import ---
     // If more than this many chart shows are missing from Turso, use the PI


### PR DESCRIPTION
## Summary

- Rebuild Home personalization around exact exposure-token attribution, hard show exclusions, and a durable `REGIONAL → PERSONALIZING → PERSONALIZED` mode machine.
- Add Android support for `POST /home/candidates/v1` with a shared coordinator, ≥4h module cache, learner-selected Because You Like anchors, and BYL-only refresh on manual anchor change.
- Rebuild Taste / Because You Like / greeting mission UX with honest regional labeling, rotating discovery missions, and long-press recommendation feedback.

## Motivation

Home recommendations were three disconnected paths with weak attribution, subscription-biased Because You Like, and regional charts sometimes labeled as personalized taste. This rebuild makes learning measurable and labels honest before expanding adaptive ranking elsewhere.

## What changed

- Ranking: exact `exposureId` resolve/delta, outcome ledger, `hideShow` / `moreLikeThis` / `notForMe` / `recordManualAnchor`, destructive personalization pipeline wipe (v2) while preserving history/subs/queue/downloads.
- Catalog/network: `HomeCandidatesModels`, `getHomeCandidatesV1`, `HomePersonalizationCoordinator`, locale-aware recommendation languages.
- Home UI/state: personalization mode titles, mission under greeting, long-press feedback menu, learner-based BYL anchor selection.
- Sync: backlog/age and chart-stale health warnings.
- Docs: recommendation-system + analytics glossary updates for the new path.

## Behavior & compatibility

- Older API routes remain; new Android builds prefer `/home/candidates/v1` and fall back to legacy recommendations when unavailable.
- Cold start (0–1 meaningful plays) shows **Popular in your Region** and hides Because You Like; personalization activates after meaningful listening evidence.
- First launch of the new learner pipeline clears personalization Room/caches once; listening library identity is preserved.

## Impact (required)

### User impact — pick **exactly one**

- [x] `user-impact-high`
- [ ] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

Also labeled: `backend-change`

### Listener impact

**What changes in the user’s life:**

Home recommendations become more honest and more personal over time. Early on, popular regional picks are clearly labeled as such. After a bit of real listening, Taste and Because You Like switch on with recommendations that better match what you actually finish and like, and you can long-press a card to ask for more like it, mark it not for you, or hide that show. Changing the Because You Like anchor is treated as intentional preference, not a dislike of the previous show.

## Test plan

- [ ] Cold start (≤1 meaningful play): Taste labeled Popular in your Region; Because You Like hidden
- [ ] After 2–3 meaningful plays: mode transitions toward personalized Taste; BYL appears when an eligible show exists
- [ ] Long-press Taste card: More like this / Not for me / Hide this show reallocates without restart
- [ ] Manual BYL anchor change refreshes Because You Like without wiping Taste cache
- [ ] Offline / candidate failure: regional slate retained; no “Based on Your Taste” relabel of charts
- [ ] `./gradlew :core:ranking:testDebugUnitTest :core:catalog:testDebugUnitTest :feature:home:testDebugUnitTest --tests '*HomePersonalization*'`
- [ ] `./gradlew installDebug` and smoke Home loading/cached/empty states