### PR TITLE
fix(sync): stop CSV newlines from breaking podcast dump import

### DIFF
--- a/.github/workflows/sync-pi-data.yml
+++ b/.github/workflows/sync-pi-data.yml
@@ -96,20 +96,23 @@ jobs:
           sqlite3 -csv podcastindex_feeds.db ".import missing_itunes_ids.txt chart_ids"
           echo "Imported $(sqlite3 podcastindex_feeds.db 'SELECT COUNT(*) FROM chart_ids;') missing iTunes IDs"
           # Column list must match PODCAST_IMPORT_COLUMNS in scripts/sync/lib/config.js
+          # Flatten CR/LF in every text column. Unquoted fields with raw
+          # newlines otherwise split mid-row and the importer sends the wrong
+          # number of bind args to Turso (expected 12, got 4).
           sqlite3 -header -csv podcastindex_feeds.db "
             SELECT
               p.id,
               p.itunesId AS itunes_id,
-              p.title,
-              p.itunesAuthor AS author,
+              REPLACE(REPLACE(p.title, char(10), ' '), char(13), ' ') AS title,
+              REPLACE(REPLACE(p.itunesAuthor, char(10), ' '), char(13), ' ') AS author,
               REPLACE(REPLACE(p.description, char(10), ' '), char(13), ' ') AS description,
-              p.imageUrl AS image_url,
-              p.url AS feed_url,
-              p.link AS website_url,
-              p.category1 || ',' || p.category2 AS categories,
-              p.language,
+              REPLACE(REPLACE(p.imageUrl, char(10), ' '), char(13), ' ') AS image_url,
+              REPLACE(REPLACE(p.url, char(10), ' '), char(13), ' ') AS feed_url,
+              REPLACE(REPLACE(p.link, char(10), ' '), char(13), ' ') AS website_url,
+              REPLACE(REPLACE(COALESCE(p.category1, '') || ',' || COALESCE(p.category2, ''), char(10), ' '), char(13), ' ') AS categories,
+              REPLACE(REPLACE(p.language, char(10), ' '), char(13), ' ') AS language,
               p.explicit,
-              p.itunesType AS type
+              REPLACE(REPLACE(p.itunesType, char(10), ' '), char(13), ' ') AS type
             FROM podcasts p
             WHERE p.itunesId IN (SELECT itunes_id FROM chart_ids);
           " > podcasts_export.csv

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -9,6 +9,7 @@
     "uuid": "11.1.1"
   },
   "scripts": {
-    "reset-sync": "node scratch/run-reset-now.js"
+    "reset-sync": "node scratch/run-reset-now.js",
+    "test:sync-csv": "node --test sync/lib/csv.test.js"
   }
 }

--- a/scripts/sync/02-import-podcasts.js
+++ b/scripts/sync/02-import-podcasts.js
@@ -19,6 +19,7 @@ const turso = require('./lib/turso');
 const pi = require('./lib/podcast-index');
 const state = require('./lib/state');
 const cfg = require('./lib/config');
+const { parseCSVLine, parseCSVRecords } = require('./lib/csv');
 
 const MISSING_IDS_FILE = 'missing_itunes_ids.txt';
 const CSV_FILE = 'podcasts_export.csv';
@@ -43,26 +44,6 @@ function sortCategories(rawCats) {
             return a.localeCompare(b);
         })
         .join(', ');
-}
-
-function parseCSVLine(line) {
-    const result = [];
-    let current = '';
-    let inQuotes = false;
-    for (let i = 0; i < line.length; i++) {
-        const ch = line[i];
-        if (ch === '"') {
-            if (inQuotes && line[i + 1] === '"') { current += '"'; i++; }
-            else inQuotes = !inQuotes;
-        } else if (ch === ',' && !inQuotes) {
-            result.push(current);
-            current = '';
-        } else {
-            current += ch;
-        }
-    }
-    result.push(current);
-    return result;
 }
 
 /** Missing chart itunes ids (string-normalized set difference). */
@@ -98,13 +79,15 @@ async function precheck() {
 
 async function importFromCSV() {
     const content = fs.readFileSync(CSV_FILE, 'utf-8');
-    const lines = content.split('\n').filter(l => l.trim());
-    if (lines.length < 2) {
+    // Quote-aware record split: unquoted mid-field newlines (legacy dumps)
+    // must not create short rows that bind the wrong number of Turso args.
+    const records = parseCSVRecords(content);
+    if (records.length < 2) {
         log.info('CSV contains no data rows - nothing to import');
         return { count: 0, ids: [] };
     }
 
-    const headers = parseCSVLine(lines[0]);
+    const headers = parseCSVLine(records[0]);
     // Enforce the fixed whitelist: every CSV header must be a known column.
     const unknown = headers.filter(h => !cfg.PODCAST_IMPORT_COLUMNS.includes(h));
     if (unknown.length > 0) {
@@ -113,32 +96,46 @@ async function importFromCSV() {
 
     const idIdx = headers.indexOf('id');
     const catIdx = headers.indexOf('categories');
-    const dataLines = lines.slice(1);
-    log.info(`Importing ${log.fmt(dataLines.length)} rows from ${CSV_FILE}`);
+    const dataRecords = records.slice(1);
+    log.info(`Importing ${log.fmt(dataRecords.length)} rows from ${CSV_FILE}`);
 
     const BATCH = 50;
     let imported = 0;
+    let skipped = 0;
     const ids = [];
-    const prog = log.progress(dataLines.length, 'csv-import');
+    const placeholders = headers.map(() => '?').join(',');
+    const insertSql = `INSERT OR IGNORE INTO podcasts (${headers.join(',')}, qdrant_vectorized, qdrant_podcast_vectorized)
+                      VALUES (${placeholders}, 0, 0)`;
+    const prog = log.progress(dataRecords.length, 'csv-import');
 
-    for (let i = 0; i < dataLines.length; i += BATCH) {
-        const batchLines = dataLines.slice(i, i + BATCH);
-        const statements = batchLines.map(line => {
-            const values = parseCSVLine(line);
+    for (let i = 0; i < dataRecords.length; i += BATCH) {
+        const batchRecords = dataRecords.slice(i, i + BATCH);
+        const statements = [];
+        for (const record of batchRecords) {
+            const values = parseCSVLine(record);
+            if (values.length !== headers.length) {
+                skipped++;
+                log.warn(
+                    `Skipping CSV row with ${values.length} fields (expected ${headers.length}): `
+                    + `${record.slice(0, 80)}${record.length > 80 ? '…' : ''}`
+                );
+                prog.tick();
+                continue;
+            }
             if (idIdx !== -1 && values[idIdx]) ids.push(String(values[idIdx]));
             if (catIdx !== -1 && values[catIdx]) {
                 values[catIdx] = sortCategories(values[catIdx]);
             }
-            const placeholders = headers.map(() => '?').join(',');
-            return {
-                sql: `INSERT OR IGNORE INTO podcasts (${headers.join(',')}, qdrant_vectorized, qdrant_podcast_vectorized)
-                      VALUES (${placeholders}, 0, 0)`,
-                args: values,
-            };
-        });
-        await turso.batch(statements);
-        imported += statements.length;
-        for (let k = 0; k < statements.length; k++) prog.tick();
+            statements.push({ sql: insertSql, args: values });
+            prog.tick();
+        }
+        if (statements.length > 0) {
+            await turso.batch(statements);
+            imported += statements.length;
+        }
+    }
+    if (skipped > 0) {
+        log.warn(`Skipped ${log.fmt(skipped)} malformed CSV row(s); imported ${log.fmt(imported)}`);
     }
     return { count: imported, ids };
 }

--- a/scripts/sync/lib/csv.js
+++ b/scripts/sync/lib/csv.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/**
+ * Minimal CSV helpers for the PI dump import path.
+ * Records may contain commas and newlines inside quoted fields.
+ */
+
+/** Parse one physical CSV line (or record) into field values. */
+function parseCSVLine(line) {
+    const result = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (ch === '"') {
+            if (inQuotes && line[i + 1] === '"') {
+                current += '"';
+                i++;
+            } else {
+                inQuotes = !inQuotes;
+            }
+        } else if (ch === ',' && !inQuotes) {
+            result.push(current);
+            current = '';
+        } else {
+            current += ch;
+        }
+    }
+    result.push(current);
+    return result;
+}
+
+/**
+ * Split a full CSV document into records, keeping newlines that sit inside
+ * quoted fields attached to the same record. Trailing empty lines are dropped.
+ */
+function parseCSVRecords(content) {
+    const records = [];
+    let current = '';
+    let inQuotes = false;
+    for (let i = 0; i < content.length; i++) {
+        const ch = content[i];
+        if (ch === '"') {
+            if (inQuotes && content[i + 1] === '"') {
+                current += '""';
+                i++;
+            } else {
+                inQuotes = !inQuotes;
+                current += ch;
+            }
+        } else if ((ch === '\n' || ch === '\r') && !inQuotes) {
+            if (ch === '\r' && content[i + 1] === '\n') i++;
+            if (current.trim()) records.push(current);
+            current = '';
+        } else {
+            current += ch;
+        }
+    }
+    if (current.trim()) records.push(current);
+    return records;
+}
+
+module.exports = { parseCSVLine, parseCSVRecords };

--- a/scripts/sync/lib/csv.test.js
+++ b/scripts/sync/lib/csv.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseCSVLine, parseCSVRecords } = require('./csv');
+
+describe('parseCSVLine', () => {
+    it('splits plain fields', () => {
+        assert.deepEqual(parseCSVLine('a,b,c'), ['a', 'b', 'c']);
+    });
+
+    it('keeps commas inside quotes', () => {
+        assert.deepEqual(parseCSVLine('1,"hello, world",3'), ['1', 'hello, world', '3']);
+    });
+
+    it('unescapes doubled quotes', () => {
+        assert.deepEqual(parseCSVLine('"say ""hi"""'), ['say "hi"']);
+    });
+});
+
+describe('parseCSVRecords', () => {
+    it('splits on newlines outside quotes', () => {
+        assert.deepEqual(
+            parseCSVRecords('h1,h2\nr1,r2\nr3,r4\n'),
+            ['h1,h2', 'r1,r2', 'r3,r4']
+        );
+    });
+
+    it('keeps quoted newlines inside one record', () => {
+        const records = parseCSVRecords('id,author\n1,"Line one\nLine two",ok\n');
+        assert.equal(records.length, 2);
+        assert.deepEqual(parseCSVLine(records[1]), ['1', 'Line one\nLine two', 'ok']);
+    });
+
+    it('handles CRLF record separators', () => {
+        assert.deepEqual(
+            parseCSVRecords('a,b\r\nc,d\r\n'),
+            ['a,b', 'c,d']
+        );
+    });
+
+    it('surfaces short rows from unquoted mid-field newlines (export must flatten)', () => {
+        // PI dump can emit unquoted author with a raw LF; record split then
+        // yields a 4-field fragment — importer must skip those, not bind them.
+        const records = parseCSVRecords('id,itunes_id,title,author,description\n1,2,Show,Auth\nor Name,Desc\n');
+        assert.equal(records.length, 3);
+        assert.equal(parseCSVLine(records[1]).length, 4);
+        assert.equal(parseCSVLine(records[2]).length, 2);
+    });
+});


### PR DESCRIPTION
## Summary
- Flatten CR/LF in every Podcast Index dump export text column so unquoted mid-field newlines cannot split CSV rows.
- Make Stage 2d CSV import quote-aware and skip rows whose field count does not match the header (instead of failing Turso with `expected 12, got 4`).
- Add `node --test` coverage for the CSV helpers (`npm run test:sync-csv` under `scripts/`).

## Test plan
- [x] `node --test scripts/sync/lib/csv.test.js` (7 passing)
- [ ] After merge, confirm next scheduled `sync-pi-data` run completes Stage 2d without the args-mismatch error
- [ ] Spot-check logs for any skipped malformed CSV warnings (should be rare after export flatten)