### PR TITLE
fix(explore): share Home bootstrap recommendations on For You

### DIFF
--- a/feature/explore/README.md
+++ b/feature/explore/README.md
@@ -31,7 +31,7 @@ src/main/java/cx/aswin/boxlore/feature/explore/
 ## Dependencies
 
 - Project dependencies: `:core:designsystem`, `:core:catalog`, `:core:playback`, `:core:model`, `:core:network`, `:core:analytics`, `:core:ranking`, and `:core:prefs`.
-- Libraries: Compose, Navigation, Coil, lifecycle runtime/ViewModel Compose, Palette, Turbine and coroutines-test for tests.
+- Libraries: Compose, Navigation, Coil, lifecycle runtime/ViewModel Compose, Palette, kotlinx.serialization.json, Turbine and coroutines-test for tests.
 - Reverse-edge rule: feature modules must not depend on other feature modules.
 
 ## Threading / lifecycle
@@ -45,12 +45,13 @@ src/main/java/cx/aswin/boxlore/feature/explore/
 
 - This module owns no raw storage files.
 - Learn history and recommendation caches are accessed through `BoxcastPrefs` in `:core:prefs`.
+- Explore For You uses the **same** Home bootstrap recommendations payload: hydrate from `BoxcastPrefs` shared cache, refresh via `PodcastRepository.getHomeBootstrapData`, and write that cache back (taste or popular-in-region fallback). It does not call the standalone empty-seed `getPersonalizedRecommendations` path.
 - Network DTOs map to feature UI models before entering UI state.
 
 ## Testing notes
 
 - Unit tests live under `feature/explore/src/test`.
-- Existing coverage includes Learn pagination, Learn deck logic, and Explore browse logic.
+- Existing coverage includes Learn pagination, Learn deck logic, Explore browse logic, and shared recommendation cache helpers (`ExploreSharedRecommendationsLogicTest`).
 - Prefer fakes for repository and prefs dependencies when expanding ViewModel coverage.
 
 ```bash

--- a/feature/explore/build.gradle.kts
+++ b/feature/explore/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.kotlinCompose)
     alias(libs.plugins.kover)
 }
@@ -62,6 +63,8 @@ dependencies {
     implementation(projects.core.network)
     implementation(projects.core.analytics)
     implementation(projects.core.ranking)
+    implementation(projects.core.prefs)
+    implementation(libs.kotlinx.serialization.json)
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/feature/explore/src/main/java/cx/aswin/boxlore/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxlore/feature/explore/ExploreScreen.kt
@@ -221,10 +221,7 @@ fun ExploreContent(
     }
     val displayList = if (state.isSearching) state.searchResults else state.trending
 
-    val context = androidx.compose.ui.platform.LocalContext.current
-    val isRecommendationsFallback = remember {
-        cx.aswin.boxlore.core.prefs.BoxcastPrefs(context).isRecommendationsFallback()
-    }
+    val isRecommendationsFallback = state.isRecommendationsFallback
 
     if (state.selectedTab == 1 && state.recommendations.isNotEmpty()) {
         LaunchedEffect(state.recommendations) {

--- a/feature/explore/src/main/java/cx/aswin/boxlore/feature/explore/ExploreViewModel.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxlore/feature/explore/ExploreViewModel.kt
@@ -36,6 +36,7 @@ import cx.aswin.boxlore.core.playback.PlaybackRepository
 import cx.aswin.boxlore.core.playback.getHistoryForRecommendations
 import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.feature.explore.logic.ExploreBrowseLogic
+import cx.aswin.boxlore.feature.explore.logic.ExploreSharedRecommendationsLogic
 
 enum class SearchTab { SHOWS, EPISODES }
 
@@ -56,6 +57,7 @@ sealed interface ExploreUiState {
         val hasMore: Boolean = true,
         val selectedTab: Int = 1, // 0 for Trending, 1 for For You (default)
         val isRecommendationsLoading: Boolean = false,
+        val isRecommendationsFallback: Boolean = true,
         val searchTab: SearchTab = SearchTab.SHOWS,
         val semanticSearchResults: List<Episode> = emptyList(),
         val isSemanticLoading: Boolean = false,
@@ -84,6 +86,7 @@ private data class ExploreRecsSlice(
     val selectedTab: Int,
     val recommendations: List<Episode>,
     val isRecommendationsLoading: Boolean,
+    val isRecommendationsFallback: Boolean,
 )
 
 private data class ExploreSearchSlice(
@@ -119,6 +122,7 @@ class ExploreViewModel(
             isLoadingMore = false,
             selectedTab = if (initialCategory != null || initialTab == "trending") 0 else 1,
             isRecommendationsLoading = false,
+            isRecommendationsFallback = true,
             searchTab = SearchTab.SHOWS,
             semanticSearchResults = emptyList(),
             isSemanticLoading = false,
@@ -136,6 +140,7 @@ class ExploreViewModel(
     private val _selectedTab = MutableStateFlow(if (initialCategory != null || initialTab == "trending") 0 else 1)
     private val _recommendations = MutableStateFlow<List<Episode>>(emptyList())
     private val _isRecommendationsLoading = MutableStateFlow(false)
+    private val _isRecommendationsFallback = MutableStateFlow(true)
     private val _searchTab = MutableStateFlow(SearchTab.SHOWS)
     private val _semanticSearchResults = MutableStateFlow<List<Episode>>(emptyList())
     private val _isSemanticLoading = MutableStateFlow(false)
@@ -228,7 +233,16 @@ class ExploreViewModel(
                     _recommendations,
                     _isRecommendationsLoading,
                 ) { vibe, vibes, selectedTab, recommendations, isRecommendationsLoading ->
-                    ExploreRecsSlice(vibe, vibes, selectedTab, recommendations, isRecommendationsLoading)
+                    ExploreRecsSlice(
+                        vibe,
+                        vibes,
+                        selectedTab,
+                        recommendations,
+                        isRecommendationsLoading,
+                        isRecommendationsFallback = true,
+                    )
+                }.combine(_isRecommendationsFallback) { slice, isFallback ->
+                    slice.copy(isRecommendationsFallback = isFallback)
                 },
                 combine(
                     _searchTab,
@@ -257,6 +271,7 @@ class ExploreViewModel(
                     hasMore = loading.hasMore,
                     selectedTab = recs.selectedTab,
                     isRecommendationsLoading = recs.isRecommendationsLoading,
+                    isRecommendationsFallback = recs.isRecommendationsFallback,
                     searchTab = search.searchTab,
                     semanticSearchResults = search.semanticSearchResults,
                     isSemanticLoading = search.isSemanticLoading,
@@ -278,6 +293,22 @@ class ExploreViewModel(
                 category to region
             }.collectLatest { (category, region) ->
                 loadTrending(category, region)
+            }
+        }
+
+        // Hydrate For You from the shared Home/Explore BoxcastPrefs cache (same payload Home writes).
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            try {
+                val prefs = BoxcastPrefs(getApplication())
+                val cached = ExploreSharedRecommendationsLogic.decodeCachedRecommendationsJson(
+                    prefs.getCachedRecommendationsJson(),
+                )
+                if (cached.isNotEmpty()) {
+                    _recommendations.value = cached
+                }
+                _isRecommendationsFallback.value = prefs.isRecommendationsFallback()
+            } catch (e: Exception) {
+                android.util.Log.e("ExploreViewModel", "Failed to load shared recommendations cache", e)
             }
         }
 
@@ -665,32 +696,61 @@ class ExploreViewModel(
     fun fetchPersonalizedRecommendations() {
         viewModelScope.launch {
             _isRecommendationsLoading.value = true
+            val prefs = BoxcastPrefs(getApplication())
             try {
-                val interests = BoxcastPrefs(getApplication()).getUserGenres().toList()
+                // Prefer shared cache if we already have rows (Home often populated it).
+                if (_recommendations.value.isEmpty()) {
+                    val cached = ExploreSharedRecommendationsLogic.decodeCachedRecommendationsJson(
+                        prefs.getCachedRecommendationsJson(),
+                    )
+                    if (cached.isNotEmpty()) {
+                        _recommendations.value = cached
+                        _isRecommendationsFallback.value = prefs.isRecommendationsFallback()
+                    }
+                }
+
+                val interests = prefs.getUserGenres().toList()
                 val history = playbackRepository.getHistoryForRecommendations(15)
-                
+
                 val subscribedIds = subscriptionRepository.subscribedPodcastIds.first().toList()
                 val subscribedGenres = subscriptionRepository.subscribedPodcasts.first()
                     .mapNotNull { it.genre }
                     .distinct()
-                
+
                 val region = userPrefs.regionStream.first()
-                
-                android.util.Log.d("ExploreViewModel", "Fetching recommendations with history size: ${history.size}, interests: $interests, region: $region, subscribedCount: ${subscribedIds.size}")
-                val recs = podcastRepository.getPersonalizedRecommendations(
+
+                android.util.Log.d(
+                    "ExploreViewModel",
+                    "Refreshing shared bootstrap recommendations; history=${history.size}, interests=$interests, region=$region, subscribed=${subscribedIds.size}",
+                )
+                // Same catalog path as Home For You — includes popular-in-region when taste seeds are empty.
+                val bootstrapData = podcastRepository.getHomeBootstrapData(
+                    country = region,
+                    vibeIds = emptyList(),
                     history = history,
                     interests = interests,
-                    country = region,
                     subscribedPodcastIds = subscribedIds,
-                    subscribedGenres = subscribedGenres
+                    subscribedGenres = subscribedGenres,
                 )
-                android.util.Log.d("ExploreViewModel", "Fetched recommendations size: ${recs.size}")
-                val distinctRecs = recs
-                    .distinctBy { it.id }
-                    .distinctBy { it.title.lowercase().trim() }
+                val distinctRecs = ExploreSharedRecommendationsLogic.distinctRecommendations(
+                    bootstrapData.recommendations,
+                )
+                android.util.Log.d(
+                    "ExploreViewModel",
+                    "Shared recommendations size=${distinctRecs.size}, fallback=${bootstrapData.isRecommendationsFallback}",
+                )
                 _recommendations.value = distinctRecs
+                _isRecommendationsFallback.value = bootstrapData.isRecommendationsFallback
+                try {
+                    prefs.saveRecommendationsCache(
+                        ExploreSharedRecommendationsLogic.encodeRecommendationsJson(distinctRecs),
+                        bootstrapData.isRecommendationsFallback,
+                    )
+                } catch (ce: Exception) {
+                    android.util.Log.e("ExploreViewModel", "Failed to write shared recommendations cache", ce)
+                }
             } catch (e: Exception) {
-                android.util.Log.e("ExploreViewModel", "Failed to fetch personalized recommendations", e)
+                android.util.Log.e("ExploreViewModel", "Failed to fetch shared recommendations", e)
             } finally {
                 _isRecommendationsLoading.value = false
             }

--- a/feature/explore/src/main/java/cx/aswin/boxlore/feature/explore/logic/ExploreSharedRecommendationsLogic.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxlore/feature/explore/logic/ExploreSharedRecommendationsLogic.kt
@@ -1,0 +1,30 @@
+package cx.aswin.boxlore.feature.explore.logic
+
+import cx.aswin.boxlore.core.model.Episode
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Shared Home ↔ Explore recommendation list helpers.
+ *
+ * Both surfaces read/write [cx.aswin.boxlore.core.prefs.BoxcastPrefs] recommendation
+ * cache and should present the same bootstrap payload (taste or region fallback).
+ */
+object ExploreSharedRecommendationsLogic {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun distinctRecommendations(episodes: List<Episode>): List<Episode> =
+        episodes
+            .distinctBy { it.id }
+            .distinctBy { it.title.lowercase().trim() }
+
+    fun decodeCachedRecommendationsJson(serialized: String?): List<Episode> {
+        if (serialized.isNullOrBlank()) return emptyList()
+        return runCatching {
+            distinctRecommendations(json.decodeFromString<List<Episode>>(serialized))
+        }.getOrDefault(emptyList())
+    }
+
+    fun encodeRecommendationsJson(episodes: List<Episode>): String =
+        json.encodeToString(distinctRecommendations(episodes))
+}

--- a/feature/explore/src/test/java/cx/aswin/boxlore/feature/explore/logic/ExploreSharedRecommendationsLogicTest.kt
+++ b/feature/explore/src/test/java/cx/aswin/boxlore/feature/explore/logic/ExploreSharedRecommendationsLogicTest.kt
@@ -1,0 +1,50 @@
+package cx.aswin.boxlore.feature.explore.logic
+
+import cx.aswin.boxlore.core.model.Episode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ExploreSharedRecommendationsLogicTest {
+    @Test
+    fun `distinctRecommendations drops duplicate ids and titles`() {
+        val a = episode(id = "1", title = "Hello")
+        val b = episode(id = "1", title = "Hello again")
+        val c = episode(id = "2", title = "Hello")
+        val d = episode(id = "3", title = "Other")
+
+        val result = ExploreSharedRecommendationsLogic.distinctRecommendations(listOf(a, b, c, d))
+
+        assertEquals(listOf(a, d), result)
+    }
+
+    @Test
+    fun `decodeCachedRecommendationsJson round trips via encode`() {
+        val episodes = listOf(episode(id = "10", title = "Alpha"), episode(id = "11", title = "Beta"))
+        val encoded = ExploreSharedRecommendationsLogic.encodeRecommendationsJson(episodes)
+        val decoded = ExploreSharedRecommendationsLogic.decodeCachedRecommendationsJson(encoded)
+        assertEquals(episodes.map { it.id }, decoded.map { it.id })
+    }
+
+    @Test
+    fun `decodeCachedRecommendationsJson returns empty on null or garbage`() {
+        assertTrue(ExploreSharedRecommendationsLogic.decodeCachedRecommendationsJson(null).isEmpty())
+        assertTrue(ExploreSharedRecommendationsLogic.decodeCachedRecommendationsJson("").isEmpty())
+        assertTrue(ExploreSharedRecommendationsLogic.decodeCachedRecommendationsJson("{not-json}").isEmpty())
+    }
+
+    private fun episode(
+        id: String,
+        title: String,
+    ): Episode =
+        Episode(
+            id = id,
+            title = title,
+            description = "",
+            audioUrl = "https://example.com/$id.mp3",
+            duration = 60,
+            publishedDate = 0L,
+            podcastId = "pod",
+            podcastTitle = "Show",
+        )
+}


### PR DESCRIPTION
## Summary
- Explore For You now hydrates from the shared `BoxcastPrefs` recommendations cache and refreshes via the same `getHomeBootstrapData` path Home uses (including popular-in-region when taste seeds are empty).
- Removes the empty-seed `getPersonalizedRecommendations` early-return path that left For You blank on fresh installs.
- Adds hermetic cache encode/decode helpers + unit tests; documents the shared payload in the Explore README.

## Listener impact
### What changes in the user’s life
On a new install (or before you’ve built listening history), Explore → For You shows the same regional picks as Home instead of “Your Taste Profile is Growing.”

## Test plan
- [ ] Fresh install / clear app data: open Home (For You / Popular in your Region appears), then Explore → For You — same style of content, no growing-profile empty state
- [ ] Open Explore For You before Home finishes: still loads via bootstrap (not stuck empty)
- [ ] After listening/subscribing: For You can leave fallback labeling when taste-based recs return
- [ ] `./gradlew :feature:explore:testDebugUnitTest --tests '*ExploreSharedRecommendationsLogicTest'`