### PR TITLE
feat(playback,home): soft-expire forgotten resumes and equal-height discovery

### DIFF
--- a/app/src/main/java/cx/aswin/boxlore/navigation/NavGraphLibrarySettingsDestinations.kt
+++ b/app/src/main/java/cx/aswin/boxlore/navigation/NavGraphLibrarySettingsDestinations.kt
@@ -109,6 +109,7 @@ internal fun androidx.navigation.NavGraphBuilder.addSettingsDestination(w: NavGr
                             hideCompletedInHome = settingsState.hideCompletedInHome,
                             hideCompletedInSubs = settingsState.hideCompletedInSubs,
                             hideCompletedInShowDetails = settingsState.hideCompletedInShowDetails,
+                            restartForgottenEpisodes = settingsState.restartForgottenEpisodes,
                         ),
                     actions =
                         cx.aswin.boxlore.feature.home.settings.pages.PlaybackActions(
@@ -128,6 +129,9 @@ internal fun androidx.navigation.NavGraphBuilder.addSettingsDestination(w: NavGr
                             onSetHideCompletedInHome = { hide -> scope.launch { userPrefs.setHideCompletedInHome(hide) } },
                             onSetHideCompletedInSubs = { hide -> scope.launch { userPrefs.setHideCompletedInSubs(hide) } },
                             onSetHideCompletedInShowDetails = { hide -> scope.launch { userPrefs.setHideCompletedInShowDetails(hide) } },
+                            onSetRestartForgottenEpisodes = { enabled ->
+                                scope.launch { userPrefs.setRestartForgottenEpisodes(enabled) }
+                            },
                         ),
                 ),
             libraryBackupWriters =

--- a/app/src/main/java/cx/aswin/boxlore/navigation/NavGraphWiring.kt
+++ b/app/src/main/java/cx/aswin/boxlore/navigation/NavGraphWiring.kt
@@ -119,6 +119,7 @@ data class NavSettingsState(
     val hideCompletedInHome: Boolean,
     val hideCompletedInSubs: Boolean,
     val hideCompletedInShowDetails: Boolean,
+    val restartForgottenEpisodes: Boolean,
 )
 
 /** Callbacks for OPML import state owned by MainActivity. */

--- a/app/src/main/java/cx/aswin/boxlore/ui/BoxLoreAppRoot.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/BoxLoreAppRoot.kt
@@ -290,6 +290,7 @@ fun BoxLoreAppRoot(
     val hideCompletedInHome by userPrefs.hideCompletedInHomeStream.collectAsState(initial = true)
     val hideCompletedInSubs by userPrefs.hideCompletedInSubsStream.collectAsState(initial = true)
     val hideCompletedInShowDetails by userPrefs.hideCompletedInShowDetailsStream.collectAsState(initial = false)
+    val restartForgottenEpisodes by userPrefs.restartForgottenEpisodesStream.collectAsState(initial = true)
     val useDynamicColor by userPrefs.useDynamicColorStream.collectAsState(
         initial = remember { userPrefs.cachedUseDynamicColor },
     )
@@ -539,6 +540,7 @@ fun BoxLoreAppRoot(
                                     hideCompletedInHome = hideCompletedInHome,
                                     hideCompletedInSubs = hideCompletedInSubs,
                                     hideCompletedInShowDetails = hideCompletedInShowDetails,
+                                    restartForgottenEpisodes = restartForgottenEpisodes,
                                 ),
                         )
                     }

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManager.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManager.kt
@@ -35,6 +35,7 @@ data class GlobalPreferencesBackup(
     val hideCompletedInShowDetails: Boolean? = null,
     val hideCompletedInHome: Boolean? = null,
     val hideCompletedInSubs: Boolean? = null,
+    val restartForgottenEpisodes: Boolean? = null,
     val smartDownloadsEnabled: Boolean? = null,
     val smartDownloadsMaxEpisodes: Int? = null,
     val smartDownloadsStorageBudget: Long? = null,
@@ -97,6 +98,7 @@ class LibraryBackupManager(
                 hideCompletedInShowDetails = userPrefs.hideCompletedInShowDetailsStream.first(),
                 hideCompletedInHome = userPrefs.hideCompletedInHomeStream.first(),
                 hideCompletedInSubs = userPrefs.hideCompletedInSubsStream.first(),
+                restartForgottenEpisodes = userPrefs.restartForgottenEpisodesStream.first(),
                 smartDownloadsEnabled = userPrefs.smartDownloadsEnabledStream.first(),
                 smartDownloadsMaxEpisodes = userPrefs.smartDownloadsMaxEpisodesStream.first(),
                 smartDownloadsStorageBudget = userPrefs.smartDownloadsStorageBudgetStream.first(),
@@ -175,6 +177,7 @@ class LibraryBackupManager(
                     prefs.hideCompletedInShowDetails?.let { up.setHideCompletedInShowDetails(it) }
                     prefs.hideCompletedInHome?.let { up.setHideCompletedInHome(it) }
                     prefs.hideCompletedInSubs?.let { up.setHideCompletedInSubs(it) }
+                    prefs.restartForgottenEpisodes?.let { up.setRestartForgottenEpisodes(it) }
                     prefs.smartDownloadsEnabled?.let { enabled ->
                         up.setSmartDownloadsEnabled(enabled)
                         if (enabled) {

--- a/core/playback/README.md
+++ b/core/playback/README.md
@@ -13,6 +13,7 @@ Owns playback session control, queue orchestration, smart queue logic, Media3 pl
 - `PlaybackQueueCoordinator` emits `queue_modified` remove on remove; `undoQueueRemoval` emits a compensating `add` (`source=undo`) so undone removals do not permanently skew analytics.
 - `QueueMath`, `QueueSkipMemory`, `SmartQueueEngine`, `SmartQueueSources`, and `MixtapeEngine` implement queue and mixtape logic.
 - `PlaybackMediaIdPolicy`, `PlaybackArtworkResolver`, and `PlaybackSkipPolicy` define session IDs, artwork, and skip behavior.
+- `PlaybackSkipPolicy` also owns intent-aware stale resume: when Settings → Playback → **Restart forgotten episodes** is on (default), implicit plays (queue / mixtape / Smart Queue / casual) soft-expire mid-episode seek after 7 days without `lastPlayedAt`; Jump Back In (`home_hero_resume*`) and History (`library_history`) always seek. Progress is never wiped — seek policy only. Mixtape/SQ still *select* unfinished episodes within the 30-day suggestion band; chrome follows soft-expire (mixtape hides progress / “Xm left”; Smart Queue stamps `resume_stale` → queue label “Starting over”).
 - `PlaybackControlSync` keeps UI playback speed / seek sizes aligned with Media3 when a session is cleared or a new queue starts, and sanitizes user-requested speeds before apply/persist.
 - `HistoryRecommendationLogic`, `AutoVoiceSearchLogic`, `SmartQueueRefillPolicy`, `MixtapeResumePolicy`, `NightWindowLogic`, and `ListeningHistoryUpsertLogic` are JVM-testable playback helpers.
 - `AutoArtworkFetchLogic` and `AutoCollageFreshnessLogic` encode Android Auto artwork fetch / collage cache policy for hermetic tests.
@@ -87,7 +88,7 @@ Files under `core/data/service` are compatibility stubs for old service class na
 ## Testing notes
 
 - Unit tests live under `core/playback/src/test`.
-- Existing coverage includes skip policy, media ID policy, artwork resolution, control sync (speed/seek preserve on clear), history recommendation filtering, voice search, smart-queue refill policy, mixtape resume policy, night-window logic, listening-history upsert logic, queue math, skip memory, smart queue, playback session mapping, Auto artwork fetch/content-type policy, collage freshness signatures, and Auto artwork source-store durability.
+- Existing coverage includes skip policy (including stale-resume intent × flag × freshness), media ID policy, artwork resolution, control sync (speed/seek preserve on clear), history recommendation filtering, voice search, smart-queue refill policy, mixtape resume policy, night-window logic, listening-history upsert logic, queue math, skip memory, smart queue, playback session mapping, Auto artwork fetch/content-type policy, collage freshness signatures, and Auto artwork source-store durability.
 - Service-level tests must install shared dependency holders before exercising service code.
 
 ```bash

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/MixtapeEngine.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/MixtapeEngine.kt
@@ -38,8 +38,10 @@ object MixtapeEngine {
         val source: CandidateSource,
         val progressMs: Long = 0L,
         val durationMs: Long = 0L,
+        val lastPlayedAtMs: Long? = null,
     )
 
+    @Suppress("LongParameterList", "CyclomaticComplexMethod")
     suspend fun build(
         subscriptions: List<Podcast>,
         history: List<ListeningHistoryEntity>,
@@ -51,6 +53,7 @@ object MixtapeEngine {
         ),
         adaptiveRanking: AdaptiveRanking? = null,
         nowMs: Long = System.currentTimeMillis(),
+        staleRestartEnabled: Boolean = true,
     ): Result {
         val historyByEpisode = history.associateBy(ListeningHistoryEntity::episodeId)
         val subscriptionsById = subscriptions.associateBy(Podcast::id)
@@ -104,8 +107,12 @@ object MixtapeEngine {
             ordered = ordered.take(MAX_ITEMS).toMutableList()
         }
         val podcasts = ordered.map { candidate ->
+            val softExpireProgress =
+                candidate.isProgress &&
+                    staleRestartEnabled &&
+                    PlaybackSkipPolicy.isStaleLastPlayed(candidate.lastPlayedAtMs, nowMs)
             val status = when {
-                candidate.isProgress -> EpisodeStatus.IN_PROGRESS
+                candidate.isProgress && !softExpireProgress -> EpisodeStatus.IN_PROGRESS
                 historyByEpisode[candidate.episode.id]?.isCompleted == true ->
                     EpisodeStatus.COMPLETED
                 else -> EpisodeStatus.UNPLAYED
@@ -177,6 +184,7 @@ object MixtapeEngine {
                 source = CandidateSource.LOCAL_HISTORY,
                 progressMs = item.progressMs,
                 durationMs = item.durationMs,
+                lastPlayedAtMs = item.lastPlayedAt,
             )
         }
 

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackIntroOutroController.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackIntroOutroController.kt
@@ -18,11 +18,13 @@ private const val OUTRO_REARM_HYSTERESIS_MS = 1_000L
 private const val EFFECTIVE_END_WATCHDOG_MS = 1_250L
 private const val TRUE_END_SEEK_MARGIN_MS = 250L
 
+@Suppress("LongParameterList")
 internal class PlaybackIntroOutroController(
     private val scope: CoroutineScope,
     private val database: BoxLoreDatabase,
     private val globalSkipBeginningMs: () -> Long,
     private val globalSkipEndingMs: () -> Long,
+    private val staleRestartEnabled: () -> Boolean,
     private val lifecycleEpisodeId: (MediaItem?) -> String?,
     private val findPodcastIdForEpisode: suspend (String) -> String?,
     private val onActiveDurationResolved: (episodeId: String, durationMs: Long) -> Unit,
@@ -310,12 +312,17 @@ internal class PlaybackIntroOutroController(
 
     private fun resolveActiveIntroTarget(history: ListeningHistoryEntity?) {
         val explicitStartMs = activationInitialPositionMs.takeIf { it > 0L }
+        val entryPointKey =
+            PlaybackMediaIdPolicy.parseEntryPointString(activeLifecycleMediaItem?.mediaMetadata?.extras)
         val initialPosition =
             PlaybackSkipPolicy.resolveInitialPosition(
                 explicitPositionMs = explicitStartMs,
                 savedProgressMs = history?.progressMs ?: 0L,
                 isCompleted = history?.isCompleted == true,
                 skipBeginningMs = effectiveSkipBeginningMs,
+                resumeIntent = PlaybackSkipPolicy.resumeIntentFromEntryPoint(entryPointKey),
+                lastPlayedAtMs = history?.lastPlayedAt,
+                staleRestartEnabled = staleRestartEnabled(),
             )
         pendingIntroTargetMs =
             when (initialPosition.reason) {

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackQueueCoordinator.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackQueueCoordinator.kt
@@ -35,6 +35,7 @@ data class RemovedQueueItem(
 /**
  * Queue play / mutate / reconcile APIs for [cx.aswin.boxlore.core.playback.PlaybackRepository].
  */
+@Suppress("LongParameterList")
 internal class PlaybackQueueCoordinator(
     private val scope: CoroutineScope,
     private val playerStateFlow: MutableStateFlow<PlayerState>,
@@ -45,7 +46,7 @@ internal class PlaybackQueueCoordinator(
     private val prefs: SharedPreferences,
     private val playerDismissedKey: String,
     private val queueMaxSize: Int,
-    private val checkSavedProgress: suspend (String?, Long?, PlaybackEntryPoint) -> Pair<Long, Boolean>,
+    private val checkSavedProgress: suspend (String?, Long?, PlaybackEntryPoint, android.os.Bundle?) -> Pair<Long, Boolean>,
     private val onPlaybackStarted: () -> Unit,
     private val storePendingEntryPoint: (android.os.Bundle?) -> Unit,
     private val saveCurrentState: suspend (updateLastPlayedAt: Boolean) -> Unit,
@@ -253,7 +254,7 @@ internal class PlaybackQueueCoordinator(
             val mediaItems = buildMediaItems(uniqueEpisodes, podcast, entryPointContext)
 
             val startEpisodeId = uniqueEpisodes.getOrNull(uniqueStartIndex)?.id
-            val (startPosMs, initialLikeState) = checkSavedProgress(startEpisodeId, initialPositionMs, entryPoint)
+            val (startPosMs, initialLikeState) = checkSavedProgress(startEpisodeId, initialPositionMs, entryPoint, entryPointContext)
 
             val currentEp = uniqueEpisodes.getOrNull(uniqueStartIndex)
             if (currentEp != null) {

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackRepository.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackRepository.kt
@@ -217,8 +217,8 @@ class PlaybackRepository internal constructor(
             prefs = prefs,
             playerDismissedKey = KEY_PLAYER_DISMISSED,
             queueMaxSize = QUEUE_MAX_SIZE,
-            checkSavedProgress = { startEpisodeId, initialPositionMs, entryPoint ->
-                checkSavedProgress(startEpisodeId, initialPositionMs, entryPoint)
+            checkSavedProgress = { startEpisodeId, initialPositionMs, entryPoint, sourceContext ->
+                checkSavedProgress(startEpisodeId, initialPositionMs, entryPoint, sourceContext)
             },
             onPlaybackStarted = { sleepController.onPlaybackStarted() },
             storePendingEntryPoint = ::storePendingEntryPoint,
@@ -231,8 +231,18 @@ class PlaybackRepository internal constructor(
             scope = repositoryScope,
             playerStateFlow = playerStateFlow,
             mediaHandle = mediaHandle,
-            listeningHistoryDao = listeningHistoryDao,
             storePendingEntryPoint = ::storePendingEntryPoint,
+            resolveInitialSeekMs = { episodeId, entryPointKey ->
+                checkSavedProgress(
+                    startEpisodeId = episodeId,
+                    initialPositionMs = null,
+                    entryPoint = PlaybackEntryPoint.GENERIC,
+                    sourceContext =
+                        entryPointKey?.let { key ->
+                            android.os.Bundle().apply { putString("entry_point", key) }
+                        },
+                ).first
+            },
             playQueue = { episodes, podcast, startIndex, entryPoint, initialPositionMs, sourceContext ->
                 queueCoordinator.playQueue(
                     episodes,
@@ -509,16 +519,19 @@ class PlaybackRepository internal constructor(
         startEpisodeId: String?,
         initialPositionMs: Long?,
         entryPoint: PlaybackEntryPoint = PlaybackEntryPoint.GENERIC,
+        sourceContext: android.os.Bundle? = null,
     ): Pair<Long, Boolean> {
         var initialLikeState = false
         var savedProgressMs = 0L
         var isCompleted = false
+        var lastPlayedAtMs: Long? = null
         var resetRequested = false
         if (startEpisodeId != null) {
             val saved = listeningHistoryDao.getHistoryItem(startEpisodeId)
             if (saved != null) {
                 savedProgressMs = saved.progressMs
                 isCompleted = saved.isCompleted
+                lastPlayedAtMs = saved.lastPlayedAt
                 resetRequested =
                     shouldResetPlaybackForMixtape(
                         saved.progressMs,
@@ -528,6 +541,10 @@ class PlaybackRepository internal constructor(
                 initialLikeState = saved.isLiked
             }
         }
+        val entryPointKey =
+            PlaybackMediaIdPolicy.parseEntryPointString(sourceContext)
+                ?: entryPoint.takeIf { it != PlaybackEntryPoint.GENERIC }?.name?.lowercase()
+        val staleRestartEnabled = userPreferencesRepository.restartForgottenEpisodesStream.first()
         val initialPosition =
             PlaybackSkipPolicy.resolveInitialPosition(
                 explicitPositionMs = initialPositionMs,
@@ -535,6 +552,9 @@ class PlaybackRepository internal constructor(
                 isCompleted = isCompleted,
                 skipBeginningMs = PlaybackSkipPolicy.DEFAULT_SKIP_BEGINNING_MS,
                 resetRequested = resetRequested,
+                resumeIntent = PlaybackSkipPolicy.resumeIntentFromEntryPoint(entryPointKey),
+                lastPlayedAtMs = lastPlayedAtMs,
+                staleRestartEnabled = staleRestartEnabled,
             )
         return Pair(initialPosition.positionMs, initialLikeState)
     }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackSkipPolicy.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackSkipPolicy.kt
@@ -14,10 +14,22 @@ object PlaybackSkipPolicy {
     const val MEANINGFUL_RESUME_MS = 2_000L
     const val MIN_PLAYABLE_CONTENT_MS = 30_000L
 
+    /** Soft-expire window for implicit mid-episode seek when restart-forgotten is enabled. */
+    const val STALE_RESUME_MS = 7L * 24L * 60L * 60L * 1_000L
+
     data class EffectiveTrim(
         val skipBeginningMs: Long,
         val skipEndingMs: Long,
     )
+
+    /**
+     * Whether the listener chose an unfinished episode (true resume) vs something that just started
+     * playing (queue / mixtape / Smart Queue / casual play).
+     */
+    enum class ResumeIntent {
+        EXPLICIT,
+        IMPLICIT,
+    }
 
     enum class InitialPositionReason {
         EXPLICIT,
@@ -30,6 +42,27 @@ object PlaybackSkipPolicy {
         val positionMs: Long,
         val reason: InitialPositionReason,
     )
+
+    /**
+     * Maps free-form `entry_point` strings to [ResumeIntent].
+     * Jump Back In / listening history → [ResumeIntent.EXPLICIT]; everything else → implicit.
+     */
+    fun resumeIntentFromEntryPoint(raw: String?): ResumeIntent {
+        val key = raw?.trim()?.lowercase().orEmpty()
+        if (key.isEmpty()) return ResumeIntent.IMPLICIT
+        if (key.contains("home_hero_resume")) return ResumeIntent.EXPLICIT
+        if (key == "library_history" || key.contains("listening_history")) return ResumeIntent.EXPLICIT
+        return ResumeIntent.IMPLICIT
+    }
+
+    fun isStaleLastPlayed(
+        lastPlayedAtMs: Long?,
+        nowMs: Long,
+        warmWindowMs: Long = STALE_RESUME_MS,
+    ): Boolean {
+        if (lastPlayedAtMs == null || lastPlayedAtMs <= 0L) return true
+        return nowMs - lastPlayedAtMs > warmWindowMs
+    }
 
     fun sanitizeTrim(valueMs: Long): Long = PlaybackSkipBounds.sanitizeTrim(valueMs)
 
@@ -54,18 +87,31 @@ object PlaybackSkipPolicy {
                 ),
         )
 
+    @Suppress("LongParameterList")
     fun resolveInitialPosition(
         explicitPositionMs: Long?,
         savedProgressMs: Long,
         isCompleted: Boolean,
         skipBeginningMs: Long,
         resetRequested: Boolean = false,
+        resumeIntent: ResumeIntent = ResumeIntent.IMPLICIT,
+        lastPlayedAtMs: Long? = null,
+        staleRestartEnabled: Boolean = false,
+        nowMs: Long = System.currentTimeMillis(),
     ): InitialPosition {
         if (explicitPositionMs != null) {
             return InitialPosition(explicitPositionMs.coerceAtLeast(0L), InitialPositionReason.EXPLICIT)
         }
-        if (!resetRequested && !isCompleted && savedProgressMs > MEANINGFUL_RESUME_MS) {
-            return InitialPosition(savedProgressMs, InitialPositionReason.RESUME)
+        val meaningfulProgress =
+            !resetRequested && !isCompleted && savedProgressMs > MEANINGFUL_RESUME_MS
+        if (meaningfulProgress) {
+            val softExpire =
+                staleRestartEnabled &&
+                    resumeIntent == ResumeIntent.IMPLICIT &&
+                    isStaleLastPlayed(lastPlayedAtMs, nowMs)
+            if (!softExpire) {
+                return InitialPosition(savedProgressMs, InitialPositionReason.RESUME)
+            }
         }
         val sanitizedBeginning = sanitizeTrim(skipBeginningMs)
         return if (sanitizedBeginning > 0L) {

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackTransportHelper.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/PlaybackTransportHelper.kt
@@ -3,7 +3,6 @@ package cx.aswin.boxlore.core.playback
 import android.util.Log
 import androidx.media3.common.MediaItem
 import cx.aswin.boxlore.core.playback.PlayerState
-import cx.aswin.boxlore.core.database.ListeningHistoryDao
 import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.core.model.PlaybackEntryPoint
 import cx.aswin.boxlore.core.model.Podcast
@@ -19,8 +18,8 @@ internal class PlaybackTransportHelper(
     private val scope: CoroutineScope,
     private val playerStateFlow: MutableStateFlow<PlayerState>,
     private val mediaHandle: PlaybackMediaControllerHandle,
-    private val listeningHistoryDao: ListeningHistoryDao,
     private val storePendingEntryPoint: (android.os.Bundle?) -> Unit,
+    private val resolveInitialSeekMs: suspend (episodeId: String, entryPointKey: String?) -> Long,
     private val playQueue: suspend (
         episodes: List<Episode>,
         podcast: Podcast,
@@ -162,16 +161,14 @@ internal class PlaybackTransportHelper(
         controller: androidx.media3.session.MediaController,
         targetEpisodeId: String,
         mediaIndex: Int,
+        entryPointKey: String?,
     ) {
         scope.launch {
-            val saved = listeningHistoryDao.getHistoryItem(targetEpisodeId)
-            val savedPosMs =
-                if (saved != null && !saved.isCompleted && saved.progressMs > 2000) {
-                    android.util.Log.d("PlaybackRepo", "skipToEpisode: Restoring saved position ${saved.progressMs}ms for $targetEpisodeId")
-                    saved.progressMs
-                } else {
-                    0L
-                }
+            val savedPosMs = resolveInitialSeekMs(targetEpisodeId, entryPointKey)
+            android.util.Log.d(
+                "PlaybackRepo",
+                "skipToEpisode: Restoring position ${savedPosMs}ms for $targetEpisodeId (entry=$entryPointKey)",
+            )
             kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
                 controller.seekTo(mediaIndex, savedPosMs)
                 controller.play()
@@ -219,7 +216,12 @@ internal class PlaybackTransportHelper(
 
                     cx.aswin.boxlore.core.analytics.AnalyticsHelper
                         .setSeekSource("transition")
-                    restorePositionAndSeek(controller, targetEpisode.id, i)
+                    restorePositionAndSeek(
+                        controller,
+                        targetEpisode.id,
+                        i,
+                        PlaybackMediaIdPolicy.parseEntryPointString(entryPointContext),
+                    )
                     return
                 }
             }

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/SmartQueueEngine.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/SmartQueueEngine.kt
@@ -38,6 +38,11 @@ interface SmartQueueEngine {
     companion object {
         const val SOURCE_SAME_PODCAST = "same_podcast"
         const val SOURCE_RESUME = "resume"
+        /**
+         * Resume-band pick that will cold-start when Restart forgotten episodes is on
+         * (`lastPlayedAt` older than [PlaybackSkipPolicy.STALE_RESUME_MS]).
+         */
+        const val SOURCE_RESUME_STALE = "resume_stale"
         const val SOURCE_SUBSCRIPTION = "subscription"
         /** Legacy persisted rows; new refills use [SOURCE_PERSONALIZED_REC] or [SOURCE_SIMILAR_EPISODE]. */
         const val SOURCE_SERVER_REC = "server_rec"
@@ -53,6 +58,7 @@ interface SmartQueueEngine {
          */
         val DISCOVERY_REFILL_SOURCES: Set<String> = setOf(
             SOURCE_RESUME,
+            SOURCE_RESUME_STALE,
             SOURCE_SUBSCRIPTION,
             SOURCE_SERVER_REC,
             SOURCE_PERSONALIZED_REC,
@@ -111,6 +117,7 @@ class DefaultSmartQueueEngine(
     private val skipMemory: QueueSkipMemory? = null,
     private val nowMs: () -> Long = { System.currentTimeMillis() },
     private val adaptiveScorer: AdaptiveCandidateScorer? = null,
+    private val staleRestartEnabled: () -> Boolean = { true },
 ) : SmartQueueEngine {
 
     companion object {
@@ -437,7 +444,16 @@ class DefaultSmartQueueEngine(
                     artist = "",
                     imageUrl = entity.podcastImageUrl ?: entity.episodeImageUrl ?: ""
                 )
-                QueueEntry(episodeItem, pod, SmartQueueEngine.SOURCE_RESUME)
+                val softExpire =
+                    staleRestartEnabled() &&
+                        PlaybackSkipPolicy.isStaleLastPlayed(entity.lastPlayedAt, nowMs())
+                val source =
+                    if (softExpire) {
+                        SmartQueueEngine.SOURCE_RESUME_STALE
+                    } else {
+                        SmartQueueEngine.SOURCE_RESUME
+                    }
+                QueueEntry(episodeItem, pod, source)
             }
             .filter { it.episode.id != 0L }
             .toList()
@@ -805,7 +821,9 @@ class DefaultSmartQueueEngine(
     )
 
     private fun String.toCandidateSource(): CandidateSource = when (this) {
-        SmartQueueEngine.SOURCE_RESUME -> CandidateSource.LOCAL_HISTORY
+        SmartQueueEngine.SOURCE_RESUME,
+        SmartQueueEngine.SOURCE_RESUME_STALE,
+        -> CandidateSource.LOCAL_HISTORY
         SmartQueueEngine.SOURCE_SUBSCRIPTION,
         SmartQueueEngine.SOURCE_SAME_PODCAST,
         -> CandidateSource.SUBSCRIPTION

--- a/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/BoxLorePlaybackService.kt
+++ b/core/playback/src/main/java/cx/aswin/boxlore/core/playback/service/BoxLorePlaybackService.kt
@@ -93,6 +93,7 @@ open class BoxLorePlaybackService :
             sources = smartQueueSources,
             skipMemory = queueSkipMemory,
             adaptiveScorer = adaptiveCandidateScorer,
+            staleRestartEnabled = { cachedRestartForgottenEpisodes },
         )
     }
     override val queueRepository by lazy {
@@ -123,6 +124,8 @@ open class BoxLorePlaybackService :
     @Volatile private var cachedSeekBackwardMs = PlaybackSkipPolicy.DEFAULT_SEEK_BACKWARD_MS
 
     @Volatile private var cachedSeekForwardMs = PlaybackSkipPolicy.DEFAULT_SEEK_FORWARD_MS
+
+    @Volatile private var cachedRestartForgottenEpisodes = true
 
     // Breaks circular lazy init between telemetry ↔ intro/outro controllers.
     private var introOutroControllerRef: PlaybackIntroOutroController? = null
@@ -157,6 +160,7 @@ open class BoxLorePlaybackService :
             database = database,
             globalSkipBeginningMs = { cachedSkipBeginningMs },
             globalSkipEndingMs = { cachedSkipEndingMs },
+            staleRestartEnabled = { cachedRestartForgottenEpisodes },
             lifecycleEpisodeId = ::lifecycleEpisodeId,
             findPodcastIdForEpisode = ::findPodcastIdForEpisode,
             onActiveDurationResolved = { episodeId, durationMs ->
@@ -235,6 +239,11 @@ open class BoxLorePlaybackService :
             userPreferencesRepository.seekForwardMsStream.collectLatest { value ->
                 cachedSeekForwardMs = PlaybackSkipPolicy.sanitizeSeekForward(value)
                 updateSeekCommandButtons()
+            }
+        }
+        serviceScope.launch {
+            userPreferencesRepository.restartForgottenEpisodesStream.collectLatest { enabled ->
+                cachedRestartForgottenEpisodes = enabled
             }
         }
 

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/MixtapeEngineTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/MixtapeEngineTest.kt
@@ -81,6 +81,48 @@ class MixtapeEngineTest {
         }
 
     @Test
+    fun softExpiredResumeStillSelectedButPresentedWithoutProgressChrome() =
+        runTest {
+            val result =
+                MixtapeEngine.build(
+                    subscriptions = emptyList(),
+                    history =
+                        listOf(
+                            history(
+                                episodeId = "ep-stale",
+                                lastPlayedAt = nowMs - 8L * 24 * 60 * 60 * 1000L,
+                            ),
+                        ),
+                    nowMs = nowMs,
+                    staleRestartEnabled = true,
+                )
+            assertEquals(listOf("ep-stale"), result.episodes.map { it.id })
+            val podcast = result.podcasts.single()
+            assertEquals(EpisodeStatus.UNPLAYED, podcast.episodeStatus)
+            assertNull(podcast.resumeProgress)
+        }
+
+    @Test
+    fun softExpiredResumeKeepsProgressChromeWhenSettingOff() =
+        runTest {
+            val result =
+                MixtapeEngine.build(
+                    subscriptions = emptyList(),
+                    history =
+                        listOf(
+                            history(
+                                episodeId = "ep-stale",
+                                lastPlayedAt = nowMs - 8L * 24 * 60 * 60 * 1000L,
+                            ),
+                        ),
+                    nowMs = nowMs,
+                    staleRestartEnabled = false,
+                )
+            assertEquals(EpisodeStatus.IN_PROGRESS, result.podcasts.single().episodeStatus)
+            assertNotNull(result.podcasts.single().resumeProgress)
+        }
+
+    @Test
     fun resumeWithoutAudioUrlIsSkipped() =
         runTest {
             val result =

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/PlaybackSkipPolicyTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/PlaybackSkipPolicyTest.kt
@@ -49,6 +49,128 @@ class PlaybackSkipPolicyTest {
     }
 
     @Test
+    fun resumeIntentMapsHeroResumeAndHistoryAsExplicit() {
+        assertEquals(
+            PlaybackSkipPolicy.ResumeIntent.EXPLICIT,
+            PlaybackSkipPolicy.resumeIntentFromEntryPoint("home_hero_resume_grid"),
+        )
+        assertEquals(
+            PlaybackSkipPolicy.ResumeIntent.EXPLICIT,
+            PlaybackSkipPolicy.resumeIntentFromEntryPoint("home_hero_resume"),
+        )
+        assertEquals(
+            PlaybackSkipPolicy.ResumeIntent.EXPLICIT,
+            PlaybackSkipPolicy.resumeIntentFromEntryPoint("library_history"),
+        )
+        assertEquals(
+            PlaybackSkipPolicy.ResumeIntent.IMPLICIT,
+            PlaybackSkipPolicy.resumeIntentFromEntryPoint("home_mixtape"),
+        )
+        assertEquals(
+            PlaybackSkipPolicy.ResumeIntent.IMPLICIT,
+            PlaybackSkipPolicy.resumeIntentFromEntryPoint("smart_queue"),
+        )
+        assertEquals(
+            PlaybackSkipPolicy.ResumeIntent.IMPLICIT,
+            PlaybackSkipPolicy.resumeIntentFromEntryPoint(null),
+        )
+    }
+
+    @Test
+    fun explicitIntentAlwaysResumesEvenWhenStaleAndFlagOn() {
+        val now = 1_000_000_000_000L
+        val result =
+            PlaybackSkipPolicy.resolveInitialPosition(
+                explicitPositionMs = null,
+                savedProgressMs = 45_000L,
+                isCompleted = false,
+                skipBeginningMs = 30_000L,
+                resumeIntent = PlaybackSkipPolicy.ResumeIntent.EXPLICIT,
+                lastPlayedAtMs = now - PlaybackSkipPolicy.STALE_RESUME_MS - 1L,
+                staleRestartEnabled = true,
+                nowMs = now,
+            )
+
+        assertEquals(45_000L, result.positionMs)
+        assertEquals(PlaybackSkipPolicy.InitialPositionReason.RESUME, result.reason)
+    }
+
+    @Test
+    fun implicitWarmResumesWhenFlagOn() {
+        val now = 1_000_000_000_000L
+        val result =
+            PlaybackSkipPolicy.resolveInitialPosition(
+                explicitPositionMs = null,
+                savedProgressMs = 45_000L,
+                isCompleted = false,
+                skipBeginningMs = 30_000L,
+                resumeIntent = PlaybackSkipPolicy.ResumeIntent.IMPLICIT,
+                lastPlayedAtMs = now - 2L * 24L * 60L * 60L * 1_000L,
+                staleRestartEnabled = true,
+                nowMs = now,
+            )
+
+        assertEquals(45_000L, result.positionMs)
+        assertEquals(PlaybackSkipPolicy.InitialPositionReason.RESUME, result.reason)
+    }
+
+    @Test
+    fun implicitStaleRestartsWhenFlagOn() {
+        val now = 1_000_000_000_000L
+        val result =
+            PlaybackSkipPolicy.resolveInitialPosition(
+                explicitPositionMs = null,
+                savedProgressMs = 45_000L,
+                isCompleted = false,
+                skipBeginningMs = 30_000L,
+                resumeIntent = PlaybackSkipPolicy.ResumeIntent.IMPLICIT,
+                lastPlayedAtMs = now - PlaybackSkipPolicy.STALE_RESUME_MS - 1L,
+                staleRestartEnabled = true,
+                nowMs = now,
+            )
+
+        assertEquals(30_000L, result.positionMs)
+        assertEquals(PlaybackSkipPolicy.InitialPositionReason.SKIP_BEGINNING, result.reason)
+    }
+
+    @Test
+    fun implicitStaleStillResumesWhenFlagOff() {
+        val now = 1_000_000_000_000L
+        val result =
+            PlaybackSkipPolicy.resolveInitialPosition(
+                explicitPositionMs = null,
+                savedProgressMs = 45_000L,
+                isCompleted = false,
+                skipBeginningMs = 30_000L,
+                resumeIntent = PlaybackSkipPolicy.ResumeIntent.IMPLICIT,
+                lastPlayedAtMs = now - PlaybackSkipPolicy.STALE_RESUME_MS - 1L,
+                staleRestartEnabled = false,
+                nowMs = now,
+            )
+
+        assertEquals(45_000L, result.positionMs)
+        assertEquals(PlaybackSkipPolicy.InitialPositionReason.RESUME, result.reason)
+    }
+
+    @Test
+    fun missingLastPlayedAtIsStaleForImplicitWhenFlagOn() {
+        val result =
+            PlaybackSkipPolicy.resolveInitialPosition(
+                explicitPositionMs = null,
+                savedProgressMs = 45_000L,
+                isCompleted = false,
+                skipBeginningMs = 0L,
+                resumeIntent = PlaybackSkipPolicy.ResumeIntent.IMPLICIT,
+                lastPlayedAtMs = null,
+                staleRestartEnabled = true,
+                nowMs = 1_000_000_000_000L,
+            )
+
+        assertEquals(0L, result.positionMs)
+        assertEquals(PlaybackSkipPolicy.InitialPositionReason.START, result.reason)
+    }
+
+    @Test
     fun nullablePodcastOverridesFallBackIndependently() {
         val result =
             PlaybackSkipPolicy.resolveEffectiveTrim(

--- a/core/playback/src/test/java/cx/aswin/boxlore/core/playback/SmartQueueEngineTest.kt
+++ b/core/playback/src/test/java/cx/aswin/boxlore/core/playback/SmartQueueEngineTest.kt
@@ -189,7 +189,13 @@ class SmartQueueEngineTest {
     private fun engine(
         sources: FakeSources,
         skipMemory: QueueSkipMemory? = null,
-    ) = DefaultSmartQueueEngine(sources = sources, skipMemory = skipMemory, nowMs = { now })
+        staleRestartEnabled: Boolean = true,
+    ) = DefaultSmartQueueEngine(
+        sources = sources,
+        skipMemory = skipMemory,
+        nowMs = { now },
+        staleRestartEnabled = { staleRestartEnabled },
+    )
 
     private fun skipMemory(): QueueSkipMemory {
         var raw: String? = null
@@ -400,6 +406,59 @@ class SmartQueueEngineTest {
             val batch = engine(sources).getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
 
             assertTrue(batch.none { it.source == SmartQueueEngine.SOURCE_RESUME })
+            assertTrue(batch.none { it.source == SmartQueueEngine.SOURCE_RESUME_STALE })
+        }
+
+    @Test
+    fun `resume pick older than 7 days is stamped resume_stale when soft-expire is on`() =
+        runTest {
+            val sources = FakeSources()
+            sources.episodesByPodcast["pod1"] = listOf(episode(1))
+            sources.resumeCandidates =
+                listOf(
+                    resumeEntry(
+                        "301",
+                        "pod2",
+                        progressMs = 50_000,
+                        lastPlayedAt = now - 8L * 24 * 60 * 60 * 1000,
+                    ),
+                )
+
+            val batch = engine(sources, staleRestartEnabled = true)
+                .getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+            val resumes = batch.filter {
+                it.source == SmartQueueEngine.SOURCE_RESUME ||
+                    it.source == SmartQueueEngine.SOURCE_RESUME_STALE
+            }
+            assertEquals(1, resumes.size)
+            assertEquals(SmartQueueEngine.SOURCE_RESUME_STALE, resumes.first().source)
+        }
+
+    @Test
+    fun `resume pick older than 7 days stays resume when soft-expire is off`() =
+        runTest {
+            val sources = FakeSources()
+            sources.episodesByPodcast["pod1"] = listOf(episode(1))
+            sources.resumeCandidates =
+                listOf(
+                    resumeEntry(
+                        "302",
+                        "pod2",
+                        progressMs = 50_000,
+                        lastPlayedAt = now - 8L * 24 * 60 * 60 * 1000,
+                    ),
+                )
+
+            val batch = engine(sources, staleRestartEnabled = false)
+                .getNextEpisodes(currentItem(1), podcast("pod1", type = "serial"))
+
+            val resumes = batch.filter {
+                it.source == SmartQueueEngine.SOURCE_RESUME ||
+                    it.source == SmartQueueEngine.SOURCE_RESUME_STALE
+            }
+            assertEquals(1, resumes.size)
+            assertEquals(SmartQueueEngine.SOURCE_RESUME, resumes.first().source)
         }
 
     // ── Tier 2: scored subscriptions ────────────────────────────────────────

--- a/core/prefs/README.md
+++ b/core/prefs/README.md
@@ -6,7 +6,7 @@ Owns user preference persistence and migration helpers: DataStore-backed user pr
 
 ## Public API
 
-- `UserPreferencesRepository` exposes DataStore-backed settings such as theme, lettering roundness (`font_roundness`: `crisp` / `soft` / `round`, default `round`), navigation style (`navigation_style`: `floating` / `classic`), region, skip durations, smart downloads, and playback preferences. Theme fast-cache (`boxlore_theme_fast_cache`) mirrors `theme_config`, `surface_style`, `theme_brand`, `use_dynamic_color`, `font_roundness`, and `navigation_style` for cold-start / non-Compose readers.
+- `UserPreferencesRepository` exposes DataStore-backed settings such as theme, lettering roundness (`font_roundness`: `crisp` / `soft` / `round`, default `round`), navigation style (`navigation_style`: `floating` / `classic`), region, skip durations, smart downloads, playback preferences, and `restart_forgotten_episodes` (default on — soft-expires mid-episode seek for implicit plays after 7 days; see `:core:playback` `PlaybackSkipPolicy`). Theme fast-cache (`boxlore_theme_fast_cache`) mirrors `theme_config`, `surface_style`, `theme_brand`, `use_dynamic_color`, `font_roundness`, and `navigation_style` for cold-start / non-Compose readers.
 - `FontRoundnessAxis` centralizes lettering preset keys and ROND axis values for prefs, playback (Android Auto collage badges), and other non-Compose readers.
 - `Context.userPreferencesDataStore` defines the `user_preferences` DataStore delegate.
 - `BoxcastPrefs` is the typed facade for `boxlore_prefs` values such as onboarding, genres, recommendation caches, Learn history, and learner-log gates.

--- a/core/prefs/src/main/java/cx/aswin/boxlore/core/prefs/UserPreferenceKeys.kt
+++ b/core/prefs/src/main/java/cx/aswin/boxlore/core/prefs/UserPreferenceKeys.kt
@@ -25,6 +25,8 @@ internal object Keys {
     val HIDE_COMPLETED_IN_SHOW_DETAILS = androidx.datastore.preferences.core.booleanPreferencesKey("hide_completed_in_show_details")
     val HIDE_COMPLETED_IN_HOME = androidx.datastore.preferences.core.booleanPreferencesKey("hide_completed_in_home")
     val HIDE_COMPLETED_IN_SUBS = androidx.datastore.preferences.core.booleanPreferencesKey("hide_completed_in_subs")
+    val RESTART_FORGOTTEN_EPISODES =
+        androidx.datastore.preferences.core.booleanPreferencesKey("restart_forgotten_episodes")
     val HAS_DISMISSED_HOME_IMPORT_BANNER = androidx.datastore.preferences.core.booleanPreferencesKey("has_dismissed_home_import_banner")
     val BRIEFING_DISMISSED_DATE = stringPreferencesKey("briefing_dismissed_date")
     val BRIEFING_DISMISSED_FOREVER = androidx.datastore.preferences.core.booleanPreferencesKey("briefing_dismissed_forever")

--- a/core/prefs/src/main/java/cx/aswin/boxlore/core/prefs/UserPreferencesRepository.kt
+++ b/core/prefs/src/main/java/cx/aswin/boxlore/core/prefs/UserPreferencesRepository.kt
@@ -870,6 +870,24 @@ class UserPreferencesRepository(
         }
     }
 
+    /**
+     * When true (default), implicit plays (queue / mixtape / Smart Queue / casual play) soft-expire
+     * mid-episode seek after 7 days without playing. Explicit resume surfaces always seek.
+     */
+    val restartForgottenEpisodesStream: Flow<Boolean> =
+        dataStore.data
+            .catch { exception ->
+                if (exception is IOException) emit(emptyPreferences()) else throw exception
+            }.map { preferences ->
+                preferences[Keys.RESTART_FORGOTTEN_EPISODES] ?: true
+            }.distinctUntilChanged()
+
+    suspend fun setRestartForgottenEpisodes(enabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[Keys.RESTART_FORGOTTEN_EPISODES] = enabled
+        }
+    }
+
     val overriddenRecPodcastIdStream: Flow<String?> =
         dataStore.data
             .catch { exception ->

--- a/core/prefs/src/test/java/cx/aswin/boxlore/core/prefs/UserPreferencesRepositoryTest.kt
+++ b/core/prefs/src/test/java/cx/aswin/boxlore/core/prefs/UserPreferencesRepositoryTest.kt
@@ -454,6 +454,16 @@ class UserPreferencesRepositoryTest {
         }
 
     @Test
+    fun restartForgottenEpisodesDefaultsOnAndPersists() =
+        runTest {
+            assertTrue(repository.restartForgottenEpisodesStream.first())
+            repository.setRestartForgottenEpisodes(false)
+            assertFalse(repository.restartForgottenEpisodesStream.first())
+            repository.setRestartForgottenEpisodes(true)
+            assertTrue(repository.restartForgottenEpisodesStream.first())
+        }
+
+    @Test
     fun overriddenRecPodcastIdSetAndClear() =
         runTest {
             assertNull(repository.overriddenRecPodcastIdStream.first())

--- a/feature/home/README.md
+++ b/feature/home/README.md
@@ -7,10 +7,9 @@ Owns Home feed presentation, Settings screens, RSS-add UI, and local debug surfa
 ## Public API
 
 - `HomeRoute`, `HomeScreen`, `HomeFeed`, `HomeViewModel`, and `HomeViewModelAssembler` for the Home route. `HomeRoute` reports after its initial loaded feed has committed two frames so the app shell can begin nonessential launch animation without competing with first-paint work.
-- The discovery area below the daypart greeting presents three editorial rows from the
-  catalog’s existing curated provider endpoint. Provider IDs remain internal; listener copy
-  uses concise editorial titles and never exposes backend terminology.
-- `settings.SettingsScreen`, `SettingsViewModel`, and `SettingsViewModelAssembler` for Settings. Appearance includes Theme (System / Light / Dark connected toggle), Background, **Lettering** (Crisp / Soft / Round connected toggle, same chip language as content region, plus an expandable sample preview), Navigation (Floating / Classic), and Colors.
+- Discovery from **Because You Like** downward uses calmer poster cards: title-only under art (no author on podcast cards, no show name on episode posters), equal-height horizontal rails and 2-col grids (`HomeFeedSpacing` / `EqualHeightPosterGrid`) that reserve two title lines for shows and three for episodes (vertically centering shorter titles). For You shows a featured hero plus up to eight body cards (1+4+4); Home Explore shows up to six. Daypart greeting editorial rows and Based on Your Taste use title-only section headers (no subtitles) and never expose backend terminology.
+- Hero carousel grid cards (**Jump back in** / **New episodes**) use title-only cells with a lighter scrim: resume taps play (progress + now-playing ring), new-episodes taps open episode info (NEW badge when fresh).
+- `settings.SettingsScreen`, `SettingsViewModel`, and `SettingsViewModelAssembler` for Settings. Appearance includes Theme (System / Light / Dark connected toggle), Background, **Lettering** (Crisp / Soft / Round connected toggle, same chip language as content region, plus an expandable sample preview), Navigation (Floating / Classic), and Colors. Playback includes **Restart forgotten episodes** (default on; soft-expires mid-episode seek for queue/mixtape after 7 days — see `:core:playback` `PlaybackSkipPolicy`). Mixtape cards hide progress chrome for soft-expired picks; Smart Queue labels those fills “Starting over”.
 - `DebugScreen` and `DebugViewModel` for local learner and runtime diagnostics.
 - Extracted Home UI pieces such as `LibrarySectionRows`, `LibrarySection`, and section/card components. Their Google Sans Flex emphasis uses shared centralized weight tokens.
 - Pure logic helpers under `logic/` for Home assembly, discovery, hero ordering, selection, playback-state mapping, serial episodes, and affinity behavior.
@@ -78,7 +77,8 @@ Main Kotlin files should remain below 1000 lines; extracted Home feed, ViewModel
 
 - Unit tests live under `feature/home/src/test`.
 - Existing coverage includes Settings ViewModel tests, Home listening-history formatting,
-  discovery greeting, editorial-row selection and de-duplication, and pure Home logic helpers.
+  discovery greeting, editorial-row selection and de-duplication, equal-height poster grid
+  extent math, and pure Home logic helpers.
 - Optional Roborazzi goldens for settings dialogs (local only; not CI-gated).
 
 ```bash

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeDataModels.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeDataModels.kt
@@ -23,6 +23,7 @@ data class HomeDataWrapper(
     val isTrendingLoaded: Boolean = false,
     val isRecommendationsLoaded: Boolean = false,
     val hasDismissedImportBanner: Boolean = false,
+    val staleRestartEnabled: Boolean = true,
     val briefing: Briefing? = null,
     val briefingChapters: List<cx.aswin.boxlore.core.model.Chapter> = emptyList(),
     val briefingDismissedDate: String = "",
@@ -50,6 +51,7 @@ internal data class HomeRecsSlice(
     val isTrendingLoaded: Boolean,
     val isRecommendationsLoaded: Boolean,
     val hasDismissedImportBanner: Boolean,
+    val staleRestartEnabled: Boolean = true,
 )
 
 internal data class HomeBriefingSlice(

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeed.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeed.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import cx.aswin.boxlore.core.model.Briefing
 import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.feature.home.components.HeroCarousel
+import cx.aswin.boxlore.feature.home.components.HomeFeedSpacing
 
 @androidx.compose.runtime.Stable
 internal data class PodcastFeedContent(
@@ -64,6 +65,7 @@ internal data class PodcastFeedLoadingState(
 internal data class PodcastFeedPlayback(
     val player: HomePlaybackUi,
     val episodePlaybackState: StablePlaybackStateMap,
+    val softExpireProgressEpisodeIds: Set<String> = emptySet(),
 )
 
 @androidx.compose.runtime.Stable
@@ -90,8 +92,8 @@ internal fun PodcastFeed(
         state = layout.gridState,
         modifier = layout.modifier.fillMaxSize(),
         contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 160.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalItemSpacing = 12.dp,
+        horizontalArrangement = Arrangement.spacedBy(HomeFeedSpacing.GridGap),
+        verticalItemSpacing = HomeFeedSpacing.GridGap,
     ) {
         smartHeroItem(content, playback, callbacks, derivedState)
         yourShowsItem(content, feedState, loadingState, playback, callbacks, derivedState)
@@ -123,7 +125,7 @@ private fun rememberPodcastFeedDerivedState(
     val viewportReady = !loadingState.isLoading
     val discoverItems =
         remember(content.gridItems.list, feedState.selectedCategory) {
-            content.gridItems.list.distinctBy { it.id }.take(10)
+            content.gridItems.list.distinctBy { it.id }.take(HomeFeedSpacing.ExploreGridCap)
         }
     return PodcastFeedDerivedState(
         viewportReady = viewportReady,
@@ -132,7 +134,7 @@ private fun rememberPodcastFeedDerivedState(
         hasRecommendations = recommendationState.isRecommendationsLoading || content.recommendations.list.isNotEmpty(),
         discoverItems = discoverItems,
         showDiscoverContent = !loadingState.isLoading && !loadingState.isFilterLoading && discoverItems.isNotEmpty(),
-        discoverGenreChip = feedState.selectedCategory == null,
+        discoverGenreChip = false,
     )
 }
 

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeedEditorialRows.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeedEditorialRows.kt
@@ -17,6 +17,7 @@ import cx.aswin.boxlore.core.analytics.AnalyticsHelper
 import cx.aswin.boxlore.feature.home.components.CuratedEpisodeCard
 import cx.aswin.boxlore.feature.home.components.HomeChildHeaderTone
 import cx.aswin.boxlore.feature.home.components.HomeChildSectionHeader
+import cx.aswin.boxlore.feature.home.components.HomeFeedSpacing
 
 internal fun LazyStaggeredGridScope.editorialFeedItems(
     content: PodcastFeedContent,
@@ -75,12 +76,11 @@ private fun EditorialRow(
     ) {
         HomeChildSectionHeader(
             title = row.title,
-            subtitle = row.subtitle,
             icon = row.icon.toHomeEditorialIcon(),
             tone = tone,
         )
         LazyRow(
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(HomeFeedSpacing.RailItemGap),
         ) {
             itemsIndexed(
                 items = row.podcasts,
@@ -110,7 +110,8 @@ private fun EditorialRow(
                             position,
                         )
                     },
-                    modifier = Modifier.width(156.dp),
+                    showSubtitle = false,
+                    modifier = Modifier.width(HomeFeedSpacing.RailCardWidth),
                 )
             }
         }

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeedRecommendations.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeedRecommendations.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
-import androidx.compose.foundation.lazy.staggeredgrid.items
-import androidx.compose.foundation.lazy.staggeredgrid.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.ChevronRight
@@ -25,7 +23,10 @@ import androidx.compose.ui.unit.dp
 import cx.aswin.boxlore.core.catalog.content.ContentDaypart
 import cx.aswin.boxlore.core.model.PlaybackEntryPoint
 import cx.aswin.boxlore.feature.home.components.BecauseYouLikeSection
+import cx.aswin.boxlore.feature.home.components.FeedMediaCardDensity
+import cx.aswin.boxlore.feature.home.components.EqualHeightPosterGrid
 import cx.aswin.boxlore.feature.home.components.GridSkeletonItem
+import cx.aswin.boxlore.feature.home.components.HomeFeedSpacing
 import cx.aswin.boxlore.feature.home.components.HomeTopLevelSectionHeader
 import cx.aswin.boxlore.feature.home.components.PodcastCard
 import cx.aswin.boxlore.feature.home.components.forYouItems
@@ -129,8 +130,12 @@ internal fun LazyStaggeredGridScope.discoverFeedItems(
         discoverPodcastItems(derivedState, feedState, callbacks)
         discoverViewMoreItem(feedState, callbacks)
     } else {
-        items(6, key = { "discover_skel_$it" }, contentType = { "discover_skel" }) {
-            GridSkeletonItem()
+        item(span = StaggeredGridItemSpan.FullLine, key = "discover_skel", contentType = "discover_skel") {
+            EqualHeightPosterGrid {
+                repeat(HomeFeedSpacing.ExploreGridCap) {
+                    GridSkeletonItem()
+                }
+            }
         }
     }
 }
@@ -154,16 +159,25 @@ private fun LazyStaggeredGridScope.discoverPodcastItems(
     feedState: PodcastFeedUiState,
     callbacks: HomeFeedCallbacks,
 ) {
-    itemsIndexed(
-        derivedState.discoverItems,
-        key = { _, podcast -> "discover_${podcast.id}" },
-        contentType = { _, _ -> "discover_card" },
-    ) { index, podcast ->
-        PodcastCard(
-            podcast = podcast,
-            showGenreChip = derivedState.discoverGenreChip,
-            onClick = { callbacks.onPodcastClick(podcast, "home_discover_grid", feedState.selectedCategory, index) },
-        )
+    item(span = StaggeredGridItemSpan.FullLine, key = "discover_grid", contentType = "discover_grid") {
+        EqualHeightPosterGrid {
+            derivedState.discoverItems.forEachIndexed { index, podcast ->
+                PodcastCard(
+                    podcast = podcast,
+                    showGenreChip = false,
+                    showSubtitle = false,
+                    density = FeedMediaCardDensity.Grid,
+                    onClick = {
+                        callbacks.onPodcastClick(
+                            podcast,
+                            "home_discover_grid",
+                            feedState.selectedCategory,
+                            index,
+                        )
+                    },
+                )
+            }
+        }
     }
 }
 

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeedYourShows.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeFeedYourShows.kt
@@ -68,6 +68,7 @@ private fun YourShowsFeedContent(
                 isSelectedPodcastLoading = loadingState.isSelectedPodcastLoading,
                 isSelectedRssRefreshing = loadingState.isSelectedRssRefreshing,
                 episodePlaybackState = playback.episodePlaybackState,
+                softExpireProgressEpisodeIds = playback.softExpireProgressEpisodeIds,
                 currentPlayingEpisodeId = playback.player.currentPlayingEpisodeId,
                 isPlaying = playback.player.isPlaying,
                 onPodcastSelected = callbacks.onPodcastSelected,

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeScreen.kt
@@ -404,6 +404,7 @@ private fun HomeScreenFeedContent(
             PodcastFeedPlayback(
                 player = playback,
                 episodePlaybackState = StablePlaybackStateMap(uiState.episodePlaybackState),
+                softExpireProgressEpisodeIds = uiState.softExpireProgressEpisodeIds,
             ),
         callbacks = callbacks,
         layout = PodcastFeedLayout(gridState = gridState),

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeUiModels.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeUiModels.kt
@@ -65,6 +65,7 @@ data class HomeUiState(
     val isSelectedPodcastLoading: Boolean = false,
     val isSelectedRssRefreshing: Boolean = false,
     val episodePlaybackState: Map<String, Pair<EpisodeStatus, Float>> = emptyMap(),
+    val softExpireProgressEpisodeIds: Set<String> = emptySet(),
     val showImportBanner: Boolean = false,
     val briefing: Briefing? = null,
     val briefingChapters: List<cx.aswin.boxlore.core.model.Chapter> = emptyList(),

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModel.kt
@@ -172,6 +172,7 @@ class HomeViewModel(
     // intentionally NOT rebuilt on history/playback ticks (too churny), only when a show is
     // subscribed/unsubscribed so new shows appear promptly.
     internal var stableMixtapeSubSignature: Set<String>? = null
+    internal var stableMixtapeStaleRestartEnabled: Boolean? = null
 
     // Subscription IDs we've already eagerly warmed episodes for (once per session).
     private val eagerlyLoadedSubIds =

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModelLoadData.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/HomeViewModelLoadData.kt
@@ -14,6 +14,7 @@ import cx.aswin.boxlore.core.ranking.RankingSurface
 import cx.aswin.boxlore.core.database.toScorable
 import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.feature.home.logic.HomeMixtapeCache
+import cx.aswin.boxlore.feature.home.logic.homeMixtapeCacheOrNull
 import cx.aswin.boxlore.feature.home.logic.buildHomeEditorialRows
 import cx.aswin.boxlore.feature.home.logic.editorialRowDefinitionsFor
 import cx.aswin.boxlore.feature.home.logic.HomeUiAssemblyLogic
@@ -224,19 +225,24 @@ internal fun HomeViewModel.loadData() {
                     }
                 val recsSlice =
                     combine(
-                        _recommendations,
-                        playbackRepository.completedEpisodeIds,
-                        _isTrendingLoaded,
-                        _isRecommendationsLoaded,
-                        userPrefs.hasDismissedHomeImportBannerStream,
-                    ) { recommendations, completedEpisodeIds, isTrendingLoaded, isRecommendationsLoaded, hasDismissedImportBanner ->
-                        HomeRecsSlice(
-                            recommendations,
-                            completedEpisodeIds,
-                            isTrendingLoaded,
-                            isRecommendationsLoaded,
-                            hasDismissedImportBanner,
-                        )
+                        combine(
+                            _recommendations,
+                            playbackRepository.completedEpisodeIds,
+                            _isTrendingLoaded,
+                            _isRecommendationsLoaded,
+                            userPrefs.hasDismissedHomeImportBannerStream,
+                        ) { recommendations, completedEpisodeIds, isTrendingLoaded, isRecommendationsLoaded, hasDismissedImportBanner ->
+                            HomeRecsSlice(
+                                recommendations,
+                                completedEpisodeIds,
+                                isTrendingLoaded,
+                                isRecommendationsLoaded,
+                                hasDismissedImportBanner,
+                            )
+                        },
+                        userPrefs.restartForgottenEpisodesStream,
+                    ) { slice, staleRestartEnabled ->
+                        slice.copy(staleRestartEnabled = staleRestartEnabled)
                     }
                 val briefingSlice =
                     combine(
@@ -282,6 +288,7 @@ internal fun HomeViewModel.loadData() {
                             isTrendingLoaded = recs.isTrendingLoaded,
                             isRecommendationsLoaded = recs.isRecommendationsLoaded,
                             hasDismissedImportBanner = recs.hasDismissedImportBanner,
+                            staleRestartEnabled = recs.staleRestartEnabled,
                             briefing = briefing.briefing,
                             briefingChapters = briefing.briefingChapters,
                             briefingDismissedDate = briefing.briefingDismissedDate,
@@ -411,21 +418,15 @@ internal fun HomeViewModel.loadData() {
                             }
 
                         val previousMixtape =
-                            if (stableMixtapePodcasts != null &&
-                                stableMixtapeCount != null &&
-                                stableCurrentUnplayedEpisodes != null &&
-                                stableMixtapeSubSignature != null
-                            ) {
-                                HomeMixtapeCache(
-                                    podcasts = stableMixtapePodcasts!!,
-                                    unplayedCount = stableMixtapeCount!!,
-                                    episodes = stableCurrentUnplayedEpisodes!!,
-                                    subSignature = stableMixtapeSubSignature!!,
-                                )
-                            } else {
-                                null
-                            }
+                            homeMixtapeCacheOrNull(
+                                podcasts = stableMixtapePodcasts,
+                                unplayedCount = stableMixtapeCount,
+                                episodes = stableCurrentUnplayedEpisodes,
+                                subSignature = stableMixtapeSubSignature,
+                                staleRestartEnabled = stableMixtapeStaleRestartEnabled,
+                            )
 
+                        val staleRestartEnabled = wrapper.staleRestartEnabled
                         val assembled =
                             HomeUiAssemblyLogic.assemble(
                                 trendingList = trendingList,
@@ -452,6 +453,7 @@ internal fun HomeViewModel.loadData() {
                                                 scorer = adaptiveScorer,
                                                 surface = RankingSurface.HOME,
                                             ),
+                                        staleRestartEnabled = staleRestartEnabled,
                                     )
                                 },
                                 isTrendingLoaded = wrapper.isTrendingLoaded,
@@ -460,6 +462,7 @@ internal fun HomeViewModel.loadData() {
                                 rawBriefingChapters = wrapper.briefingChapters,
                                 briefingDismissedDate = wrapper.briefingDismissedDate,
                                 briefingDismissedForever = wrapper.briefingDismissedForever,
+                                staleRestartEnabled = staleRestartEnabled,
                             )
 
                         stablePodcastOrder = assembled.stablePodcastOrder
@@ -468,6 +471,7 @@ internal fun HomeViewModel.loadData() {
                             stableMixtapeCount = cache.unplayedCount
                             stableCurrentUnplayedEpisodes = cache.episodes
                             stableMixtapeSubSignature = cache.subSignature
+                            stableMixtapeStaleRestartEnabled = cache.staleRestartEnabled
                             currentUnplayedEpisodes = cache.episodes
                         }
 
@@ -501,6 +505,7 @@ internal fun HomeViewModel.loadData() {
                                 isSelectedPodcastLoading = _isSelectedPodcastLoading.value,
                                 isSelectedRssRefreshing = _isSelectedRssRefreshing.value,
                                 episodePlaybackState = assembled.episodePlaybackState,
+                                softExpireProgressEpisodeIds = assembled.softExpireProgressEpisodeIds,
                                 showImportBanner = assembled.showImportBanner,
                                 briefing = assembled.briefing,
                                 briefingChapters = assembled.briefingChapters,

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/BecauseYouLikeSection.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/BecauseYouLikeSection.kt
@@ -123,13 +123,15 @@ fun BecauseYouLikeSection(
                 LazyRow(
                     modifier = Modifier.fillMaxWidth(),
                     contentPadding = PaddingValues(horizontal = 0.dp),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(HomeFeedSpacing.RailItemGap),
                 ) {
                     items(suggestedPodcasts.list, key = { it.id }) { suggestedPodcast ->
                         PodcastCard(
                             podcast = suggestedPodcast,
                             onClick = { onPodcastClick(suggestedPodcast) },
-                            modifier = Modifier.width(140.dp),
+                            showSubtitle = false,
+                            density = FeedMediaCardDensity.Rail,
+                            modifier = Modifier.width(HomeFeedSpacing.RailCardWidth),
                         )
                     }
                 }
@@ -148,7 +150,7 @@ fun BecauseYouLikeSection(
                 LazyRow(
                     modifier = Modifier.fillMaxWidth(),
                     contentPadding = PaddingValues(horizontal = 0.dp),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(HomeFeedSpacing.RailItemGap),
                 ) {
                     items(recommendations.list, key = { it.id }) { episode ->
                         val parentPodcast =
@@ -166,7 +168,8 @@ fun BecauseYouLikeSection(
                             podcast = parentPodcast,
                             episode = episode,
                             onClick = { onEpisodeClick(episode, parentPodcast) },
-                            modifier = Modifier.width(140.dp),
+                            showSubtitle = false,
+                            modifier = Modifier.width(HomeFeedSpacing.RailCardWidth),
                         )
                     }
                 }

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/CuratedEpisodeCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/CuratedEpisodeCard.kt
@@ -11,8 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import cx.aswin.boxlore.core.model.Episode
@@ -24,6 +22,7 @@ fun CuratedEpisodeCard(
     episode: Episode,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    showSubtitle: Boolean = true,
 ) {
     val isNew =
         episode.publishedDate > 0L &&
@@ -32,9 +31,10 @@ fun CuratedEpisodeCard(
     FeedMediaCard(
         imageUrl = (episode.imageUrl ?: "").ifEmpty { podcast.imageUrl },
         title = episode.title,
-        subtitle = podcast.title,
+        subtitle = if (showSubtitle) podcast.title else null,
         onClick = onClick,
         modifier = modifier,
+        titleMaxLines = 3,
         imageBadge = {
             if (isNew) {
                 Box(
@@ -55,31 +55,5 @@ fun CuratedEpisodeCard(
                 }
             }
         },
-        imageOverlay = {
-            if (episode.duration > 0) {
-                Box(
-                    modifier =
-                        Modifier
-                            .padding(6.dp)
-                            .clip(MaterialTheme.shapes.small)
-                            .background(Color.Black.copy(alpha = 0.6f))
-                            .align(Alignment.BottomEnd),
-                ) {
-                    Text(
-                        text = formatDuration(episode.duration),
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = GoogleSansWeight.medium,
-                        color = Color.White,
-                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                    )
-                }
-            }
-        },
     )
-}
-
-private fun formatDuration(seconds: Int): String {
-    if (seconds <= 0) return ""
-    val m = seconds / 60
-    return "${m}m"
 }

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/EqualHeightPosterGrid.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/EqualHeightPosterGrid.kt
@@ -1,0 +1,106 @@
+package cx.aswin.boxlore.feature.home.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.util.fastForEachIndexed
+import kotlin.math.ceil
+import kotlin.math.max
+
+/**
+ * Two-column poster grid with equal intrinsic card heights (fixed title feet).
+ * Does not stretch cells — pair with [FeedMediaCard] fixed 3-line feet for alignment.
+ */
+@Composable
+internal fun EqualHeightPosterGrid(
+    modifier: Modifier = Modifier,
+    columns: Int = 2,
+    horizontalSpacing: Dp = HomeFeedSpacing.GridGap,
+    verticalSpacing: Dp = HomeFeedSpacing.GridGap,
+    content: @Composable () -> Unit,
+) {
+    val colCount = columns.coerceAtLeast(1)
+    Layout(
+        content = content,
+        modifier = modifier,
+    ) { measurables, constraints ->
+        if (constraints.maxWidth == 0 || measurables.isEmpty()) {
+            return@Layout layout(0, 0) {}
+        }
+
+        val hGap = horizontalSpacing.roundToPx()
+        val vGap = verticalSpacing.roundToPx()
+        val maxWidth = constraints.maxWidth
+        val columnWidth =
+            if (colCount == 1) {
+                maxWidth
+            } else {
+                ((maxWidth - hGap * (colCount - 1)) / colCount).coerceAtLeast(0)
+            }
+        val childConstraints =
+            Constraints(
+                minWidth = columnWidth,
+                maxWidth = columnWidth,
+                minHeight = 0,
+                maxHeight = Constraints.Infinity,
+            )
+        val placeables = measurables.map { it.measure(childConstraints) }
+        val itemHeights = placeables.map { it.height }
+        val totalHeight = equalHeightPosterGridExtent(itemHeights, colCount, vGap)
+
+        val width = maxWidth.coerceIn(constraints.minWidth, constraints.maxWidth)
+        val height =
+            totalHeight.coerceIn(
+                constraints.minHeight,
+                if (constraints.maxHeight == Constraints.Infinity) totalHeight else constraints.maxHeight,
+            )
+
+        layout(width, height) {
+            var y = 0
+            val rowCount = ceil(placeables.size / colCount.toFloat()).toInt()
+            for (row in 0 until rowCount) {
+                var rowHeight = 0
+                for (col in 0 until colCount) {
+                    val index = row * colCount + col
+                    if (index < placeables.size) {
+                        rowHeight = max(rowHeight, placeables[index].height)
+                    }
+                }
+                placeables.fastForEachIndexed { index, placeable ->
+                    if (index / colCount == row) {
+                        val col = index % colCount
+                        val x = col * (columnWidth + hGap)
+                        placeable.placeRelative(x, y)
+                    }
+                }
+                y += rowHeight + vGap
+            }
+        }
+    }
+}
+
+/** Total height of a packed [columns]-wide grid given measured item heights and vertical gap. */
+internal fun equalHeightPosterGridExtent(
+    itemHeights: List<Int>,
+    columns: Int,
+    verticalGap: Int,
+): Int {
+    if (itemHeights.isEmpty()) return 0
+    val colCount = columns.coerceAtLeast(1)
+    val rowCount = ceil(itemHeights.size / colCount.toFloat()).toInt()
+    var total = 0
+    for (row in 0 until rowCount) {
+        var rowHeight = 0
+        for (col in 0 until colCount) {
+            val index = row * colCount + col
+            if (index < itemHeights.size) {
+                rowHeight = max(rowHeight, itemHeights[index])
+            }
+        }
+        if (row > 0) total += verticalGap
+        total += rowHeight
+    }
+    return total
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/ForYouSection.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/ForYouSection.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
-import androidx.compose.foundation.lazy.staggeredgrid.items
-import androidx.compose.foundation.lazy.staggeredgrid.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
@@ -34,10 +32,9 @@ import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.feature.home.StableEpisodeList
 
 /**
- * Emits the "For You" section directly into a [LazyStaggeredGridScope] instead of composing
- * the whole section as one heavy full-line item. The hero card stays full-line, while the
- * remaining masonry cards become individual 1-span items so only the cards actually scrolling
- * into view are composed each frame (removes the atomic ~9-card compose spike).
+ * Emits the "For You" section into a [LazyStaggeredGridScope].
+ * Hero stays full-line; body cards sit in one full-line [EqualHeightPosterGrid]
+ * with fixed 3-line title feet.
  */
 fun LazyStaggeredGridScope.forYouItems(
     recommendations: StableEpisodeList,
@@ -46,37 +43,33 @@ fun LazyStaggeredGridScope.forYouItems(
     showTasteHeader: Boolean = true,
     isFallback: Boolean = true,
 ) {
-    val items = recommendations.list.take(9)
+    val items = recommendations.list.take(HomeFeedSpacing.ForYouTotalCap)
 
     if (showTasteHeader) {
         item(span = StaggeredGridItemSpan.FullLine, key = "for_you_header", contentType = "for_you_header") {
             HomeChildSectionHeader(
                 title = if (isFallback) "Popular in your Region" else "Based on Your Taste",
-                subtitle =
-                    if (isFallback) {
-                        "Popular picks from listeners near you"
-                    } else {
-                        "Picked from your listening patterns"
-                    },
                 icon = Icons.Rounded.AutoAwesome,
             )
         }
     }
 
     if (items.isEmpty()) {
-        // Skeleton: hero + a handful of grid skeletons, each an individual staggered item.
         item(span = StaggeredGridItemSpan.FullLine, key = "for_you_hero_skeleton", contentType = "for_you_hero_skeleton") {
             val baseColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f)
             val highlightColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
             ForYouHeroSkeleton(baseColor = baseColor, highlightColor = highlightColor)
         }
-        items(8, key = { "for_you_skel_$it" }, contentType = { "for_you_skel" }) {
-            GridSkeletonItem()
+        item(span = StaggeredGridItemSpan.FullLine, key = "for_you_body_skeleton", contentType = "for_you_body_skeleton") {
+            EqualHeightPosterGrid {
+                repeat(HomeFeedSpacing.ForYouBodyCount) {
+                    GridSkeletonItem()
+                }
+            }
         }
         return
     }
 
-    // Hero card (index 0) — full width. Also hosts the impression analytics effect.
     item(span = StaggeredGridItemSpan.FullLine, key = "for_you_hero", contentType = "for_you_hero") {
         LaunchedEffect(recommendations.list, discoveryContextTitle) {
             AnalyticsHelper.trackHomeRecommendationsImpression(
@@ -113,39 +106,43 @@ fun LazyStaggeredGridScope.forYouItems(
         )
     }
 
-    // Remaining items become individual staggered (masonry) cards.
     val remaining = items.drop(1)
-    itemsIndexed(
-        remaining,
-        key = { _, ep -> "for_you_${ep.id}" },
-        contentType = { _, _ -> "for_you_card" },
-    ) { index, ep ->
-        val originalIndex = index + 1
-        val parentPodcast =
-            Podcast(
-                id = ep.podcastId ?: "",
-                title = ep.podcastTitle ?: "Podcast",
-                artist = "",
-                imageUrl = ep.podcastImageUrl?.takeIf { it.isNotBlank() } ?: ep.imageUrl?.takeIf { it.isNotBlank() } ?: "",
-                description = "",
-                genre = ep.podcastGenre ?: "Podcast",
-            )
-        CuratedEpisodeCard(
-            podcast = parentPodcast,
-            episode = ep,
-            onClick = {
-                AnalyticsHelper.trackHomeRecommendationCardTapped(
-                    episodeId = ep.id,
-                    episodeTitle = ep.title,
-                    podcastId = parentPodcast.id,
-                    podcastName = parentPodcast.title,
-                    positionIndex = originalIndex,
-                    timeBlockTitle = discoveryContextTitle,
-                )
-                onEpisodeClick(ep, parentPodcast)
-            },
-            modifier = Modifier.fillMaxWidth(),
-        )
+    if (remaining.isNotEmpty()) {
+        item(span = StaggeredGridItemSpan.FullLine, key = "for_you_body", contentType = "for_you_body") {
+            EqualHeightPosterGrid {
+                remaining.forEachIndexed { index, ep ->
+                    val originalIndex = index + 1
+                    val parentPodcast =
+                        Podcast(
+                            id = ep.podcastId ?: "",
+                            title = ep.podcastTitle ?: "Podcast",
+                            artist = "",
+                            imageUrl =
+                                ep.podcastImageUrl?.takeIf { it.isNotBlank() }
+                                    ?: ep.imageUrl?.takeIf { it.isNotBlank() }
+                                    ?: "",
+                            description = "",
+                            genre = ep.podcastGenre ?: "Podcast",
+                        )
+                    CuratedEpisodeCard(
+                        podcast = parentPodcast,
+                        episode = ep,
+                        onClick = {
+                            AnalyticsHelper.trackHomeRecommendationCardTapped(
+                                episodeId = ep.id,
+                                episodeTitle = ep.title,
+                                podcastId = parentPodcast.id,
+                                podcastName = parentPodcast.title,
+                                positionIndex = originalIndex,
+                                timeBlockTitle = discoveryContextTitle,
+                            )
+                            onEpisodeClick(ep, parentPodcast)
+                        },
+                        showSubtitle = false,
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/HeroCarousel.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/HeroCarousel.kt
@@ -67,21 +67,16 @@ fun HeroCarousel(
             HeroGridCard(
                 items = item.gridItems,
                 title = "JUMP BACK IN",
-                onPlayClick = { podcast ->
+                mode = HeroGridMode.Resume,
+                onCellClick = { podcast ->
                     val bundle =
                         android.os.Bundle().apply {
                             putString("entry_point", "home_hero_resume_grid")
                             putInt("ep_carousel_position", i)
                             putString("ep_layout_type", "grid_card")
-                            putBoolean("ep_is_subscribed", true) // Assuming RESUME grid items are subscribed
+                            putBoolean("ep_is_subscribed", true)
                         }
                     onPlayClick(podcast, bundle)
-                },
-                onDetailsClick = { podcast ->
-                    // For grid items, we want Episode Details.
-                    // We need to pass this action up.
-                    // Let's assume onDetailsClick passed to HeroCarousel handles this.
-                    onDetailsClick(podcast)
                 },
                 currentPlayingPodcastId = currentPlayingPodcastId,
                 isPlaying = isPlaying,
@@ -91,20 +86,8 @@ fun HeroCarousel(
             HeroGridCard(
                 items = item.gridItems,
                 title = "NEW EPISODES",
-                onPlayClick = { podcast ->
-                    val bundle =
-                        android.os.Bundle().apply {
-                            putString("entry_point", "home_hero_new_episodes_grid")
-                            putInt("ep_carousel_position", i)
-                            putString("ep_layout_type", "grid_card")
-                            putBoolean("ep_is_subscribed", true)
-                        }
-                    onPlayClick(podcast, bundle)
-                },
-                onDetailsClick = { podcast ->
-                    // Same details logic
-                    onDetailsClick(podcast)
-                },
+                mode = HeroGridMode.NewEpisodes,
+                onCellClick = onDetailsClick,
                 currentPlayingPodcastId = currentPlayingPodcastId,
                 isPlaying = isPlaying,
                 modifier = Modifier.maskClip(MaterialTheme.shapes.extraLarge),

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/HeroGridCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/HeroGridCard.kt
@@ -3,13 +3,29 @@ package cx.aswin.boxlore.feature.home.components
 import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -20,6 +36,8 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import cx.aswin.boxlore.core.designsystem.components.OptimizedImage
@@ -29,6 +47,18 @@ import cx.aswin.boxlore.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxlore.core.model.Podcast
 
 private val sessionSeed = kotlin.random.Random.nextInt()
+
+private val GridCellCorner = RoundedCornerShape(14.dp)
+private val TitleFontSize = 13.sp
+private val TitleLineHeight = 17.sp
+private const val TitleMaxLines = 3
+private const val NewEpisodeWindowSeconds = 2 * 24 * 60 * 60L
+
+/** Resume grid taps play; new-episodes grid opens episode info. */
+enum class HeroGridMode {
+    Resume,
+    NewEpisodes,
+}
 
 /**
  * Hero Grid Card — Progressive Density Layout
@@ -42,8 +72,8 @@ private val sessionSeed = kotlin.random.Random.nextInt()
 fun HeroGridCard(
     items: List<Podcast>,
     title: String,
-    onPlayClick: (Podcast) -> Unit,
-    onDetailsClick: (Podcast) -> Unit,
+    mode: HeroGridMode,
+    onCellClick: (Podcast) -> Unit,
     currentPlayingPodcastId: String? = null,
     isPlaying: Boolean = false,
     modifier: Modifier = Modifier,
@@ -69,7 +99,6 @@ fun HeroGridCard(
                 .clip(MaterialTheme.shapes.extraLarge),
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
-            // Background shapes wrapper
             Box(
                 modifier =
                     Modifier
@@ -83,10 +112,8 @@ fun HeroGridCard(
             )
 
             Column(modifier = Modifier.fillMaxSize()) {
-                // Header
                 RowHeader(title = title)
 
-                // Adaptive Grid Content
                 Box(
                     modifier =
                         Modifier
@@ -95,14 +122,24 @@ fun HeroGridCard(
                             .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
                 ) {
                     val displayItems = items.take(4)
+                    val cellContent: @Composable (Podcast, Modifier) -> Unit = { podcast, cellModifier ->
+                        GridCell(
+                            podcast = podcast,
+                            mode = mode,
+                            onClick = onCellClick,
+                            isNowPlaying = mode == HeroGridMode.Resume &&
+                                podcast.id == currentPlayingPodcastId &&
+                                isPlaying,
+                            modifier = cellModifier,
+                        )
+                    }
                     when (displayItems.size) {
-                        2 -> StackedLayout(displayItems, onPlayClick)
-                        3 -> TwoOneLayout(displayItems, onPlayClick)
-                        4 -> GridLayout2x2(displayItems, onPlayClick)
+                        2 -> StackedLayout(displayItems, cellContent)
+                        3 -> TwoOneLayout(displayItems, cellContent)
+                        4 -> GridLayout2x2(displayItems, cellContent)
                         else ->
                             if (displayItems.isNotEmpty()) {
-                                // Fallback: single item fills the space
-                                GridCell(displayItems[0], onPlayClick, modifier = Modifier.fillMaxSize())
+                                cellContent(displayItems[0], Modifier.fillMaxSize())
                             }
                     }
                 }
@@ -111,34 +148,24 @@ fun HeroGridCard(
     }
 }
 
-// --- Layouts ---
-
-/**
- * 2 items: Stacked top/bottom with horizontal divider.
- * Each item gets ~50% of the card height.
- */
 @Composable
 private fun StackedLayout(
     items: List<Podcast>,
-    onPlayClick: (Podcast) -> Unit,
+    cellContent: @Composable (Podcast, Modifier) -> Unit,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(10.dp),
         modifier = Modifier.fillMaxSize(),
     ) {
-        GridCell(items[0], onPlayClick, modifier = Modifier.weight(1f).fillMaxWidth())
-        GridCell(items[1], onPlayClick, modifier = Modifier.weight(1f).fillMaxWidth())
+        cellContent(items[0], Modifier.weight(1f).fillMaxWidth())
+        cellContent(items[1], Modifier.weight(1f).fillMaxWidth())
     }
 }
 
-/**
- * 3 items: 2 on top row, 1 spanning the full bottom.
- * Top row gets ~50% height, bottom gets ~50%.
- */
 @Composable
 private fun TwoOneLayout(
     items: List<Podcast>,
-    onPlayClick: (Podcast) -> Unit,
+    cellContent: @Composable (Podcast, Modifier) -> Unit,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -148,20 +175,17 @@ private fun TwoOneLayout(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             modifier = Modifier.weight(1f),
         ) {
-            GridCell(items[0], onPlayClick, modifier = Modifier.weight(1f).fillMaxHeight())
-            GridCell(items[1], onPlayClick, modifier = Modifier.weight(1f).fillMaxHeight())
+            cellContent(items[0], Modifier.weight(1f).fillMaxHeight())
+            cellContent(items[1], Modifier.weight(1f).fillMaxHeight())
         }
-        GridCell(items[2], onPlayClick, modifier = Modifier.weight(1f).fillMaxWidth())
+        cellContent(items[2], Modifier.weight(1f).fillMaxWidth())
     }
 }
 
-/**
- * 4 items: Classic 2×2 grid.
- */
 @Composable
 private fun GridLayout2x2(
     items: List<Podcast>,
-    onPlayClick: (Podcast) -> Unit,
+    cellContent: @Composable (Podcast, Modifier) -> Unit,
 ) {
     Column(
         verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -171,20 +195,18 @@ private fun GridLayout2x2(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             modifier = Modifier.weight(1f),
         ) {
-            GridCell(items[0], onPlayClick, modifier = Modifier.weight(1f).fillMaxHeight())
-            GridCell(items[1], onPlayClick, modifier = Modifier.weight(1f).fillMaxHeight())
+            cellContent(items[0], Modifier.weight(1f).fillMaxHeight())
+            cellContent(items[1], Modifier.weight(1f).fillMaxHeight())
         }
         Row(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             modifier = Modifier.weight(1f),
         ) {
-            GridCell(items[2], onPlayClick, modifier = Modifier.weight(1f).fillMaxHeight())
-            GridCell(items[3], onPlayClick, modifier = Modifier.weight(1f).fillMaxHeight())
+            cellContent(items[2], Modifier.weight(1f).fillMaxHeight())
+            cellContent(items[3], Modifier.weight(1f).fillMaxHeight())
         }
     }
 }
-
-// --- Shared Components ---
 
 @Composable
 private fun RowHeader(title: String) {
@@ -204,24 +226,41 @@ private fun RowHeader(title: String) {
 }
 
 @Composable
+@Suppress("LongMethod")
 private fun GridCell(
     podcast: Podcast,
-    onPlayClick: (Podcast) -> Unit,
+    mode: HeroGridMode,
+    onClick: (Podcast) -> Unit,
+    isNowPlaying: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val currentPodcast by androidx.compose.runtime.rememberUpdatedState(podcast)
-    val currentOnPlayClick by androidx.compose.runtime.rememberUpdatedState(onPlayClick)
+    val currentPodcast by rememberUpdatedState(podcast)
+    val currentOnClick by rememberUpdatedState(onClick)
+    val showProgress =
+        mode == HeroGridMode.Resume &&
+            podcast.resumeProgress != null &&
+            podcast.resumeProgress!! > 0f
+    val isNew =
+        mode == HeroGridMode.NewEpisodes &&
+            podcast.latestEpisode?.let { episode ->
+                episode.publishedDate > 0L &&
+                    (System.currentTimeMillis() / 1000L - episode.publishedDate) < NewEpisodeWindowSeconds
+            } == true
+    val titleFootHeight =
+        with(LocalDensity.current) {
+            TitleLineHeight.toDp() * TitleMaxLines
+        }
 
     val gradientBrush =
         remember {
             Brush.verticalGradient(
-                colors =
-                    listOf(
-                        Color.Transparent,
-                        Color.Black.copy(alpha = 0.15f),
-                        Color.Black.copy(alpha = 0.55f),
-                        Color.Black.copy(alpha = 0.85f),
-                        Color.Black.copy(alpha = 0.95f),
+                colorStops =
+                    arrayOf(
+                        0.0f to Color.Transparent,
+                        0.35f to Color.Black.copy(alpha = 0.15f),
+                        0.55f to Color.Black.copy(alpha = 0.45f),
+                        0.75f to Color.Black.copy(alpha = 0.75f),
+                        1.0f to Color.Black.copy(alpha = 0.92f),
                     ),
             )
         }
@@ -229,10 +268,20 @@ private fun GridCell(
     Box(
         modifier =
             modifier
-                .clip(RoundedCornerShape(14.dp))
+                .clip(GridCellCorner)
                 .background(MaterialTheme.colorScheme.surfaceContainer)
-                .expressiveClickable {
-                    currentOnPlayClick(currentPodcast)
+                .then(
+                    if (isNowPlaying) {
+                        Modifier.border(
+                            width = 2.dp,
+                            color = MaterialTheme.colorScheme.primary,
+                            shape = GridCellCorner,
+                        )
+                    } else {
+                        Modifier
+                    },
+                ).expressiveClickable {
+                    currentOnClick(currentPodcast)
                 },
     ) {
         OptimizedImage(
@@ -249,43 +298,78 @@ private fun GridCell(
                     },
         )
 
-        // Bottom content: Title + progress
+        if (isNew) {
+            Box(
+                modifier =
+                    Modifier
+                        .padding(6.dp)
+                        .align(Alignment.TopStart)
+                        .clip(MaterialTheme.shapes.extraSmall)
+                        .background(MaterialTheme.colorScheme.primary),
+            ) {
+                Text(
+                    text = "NEW",
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp, lineHeight = 8.sp),
+                    fontWeight = GoogleSansWeight.bold,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+                )
+            }
+        }
+
+        if (isNowPlaying) {
+            Box(
+                modifier =
+                    Modifier
+                        .padding(6.dp)
+                        .align(Alignment.TopEnd)
+                        .size(22.dp)
+                        .clip(androidx.compose.foundation.shape.CircleShape)
+                        .background(MaterialTheme.colorScheme.primary),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Pause,
+                    contentDescription = "Playing",
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
+        }
+
         Column(
             modifier =
                 Modifier
                     .align(Alignment.BottomStart)
+                    .fillMaxWidth()
                     .padding(10.dp),
-            verticalArrangement = Arrangement.spacedBy(3.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             val episodeTitle = podcast.latestEpisode?.title
             val primaryText = episodeTitle ?: podcast.title
-
-            // Episode title (primary)
-            Text(
-                text = primaryText,
-                style = MaterialTheme.typography.titleSmall,
-                fontWeight = GoogleSansWeight.bold,
-                color = Color.White,
-                maxLines = 2,
-                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                lineHeight = 16.sp,
-            )
-
-            // Podcast title (secondary)
-            if (episodeTitle != null) {
+            // Reserve 3 episode title lines (sp→dp); vertically center shorter titles.
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(titleFootHeight),
+                contentAlignment = Alignment.CenterStart,
+            ) {
                 Text(
-                    text = podcast.title,
-                    style = MaterialTheme.typography.bodySmall,
-                    fontWeight = GoogleSansWeight.medium,
-                    color = Color.White.copy(alpha = 0.8f),
-                    maxLines = 1,
-                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-                    lineHeight = 14.sp,
+                    text = primaryText,
+                    style =
+                        MaterialTheme.typography.titleSmall.copy(
+                            fontSize = TitleFontSize,
+                            lineHeight = TitleLineHeight,
+                            fontWeight = GoogleSansWeight.bold,
+                            color = Color.White,
+                        ),
+                    maxLines = TitleMaxLines,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
 
-            // Progress bar for resume sessions
-            if (podcast.resumeProgress != null && podcast.resumeProgress!! > 0f) {
+            if (showProgress) {
                 ProgressBar(
                     progress = podcast.resumeProgress!!,
                     modifier =
@@ -350,40 +434,37 @@ private fun Modifier.heroGridBackground(
             )
 
         val isJumpBackIn = title.contains("JUMP", ignoreCase = true)
+        val shapeAlpha = 0.06f
 
         onDrawBehind {
             if (isJumpBackIn) {
-                // Shape 1 (Top Left)
                 translate(left = shape1OffsetX, top = shape1OffsetY) {
                     drawOutline(
                         outline = outline1,
                         color = primaryColor,
-                        alpha = 0.10f,
+                        alpha = shapeAlpha,
                     )
                 }
-                // Shape 2 (Bottom Right)
                 translate(left = size.width - shape2Inset, top = size.height - shape2Inset) {
                     drawOutline(
                         outline = outline2,
                         color = primaryColor,
-                        alpha = 0.10f,
+                        alpha = shapeAlpha,
                     )
                 }
             } else {
-                // Shape 1 (Bottom Left)
                 translate(left = shape1OffsetX, top = size.height - shape2Inset) {
                     drawOutline(
                         outline = outline1,
                         color = primaryColor,
-                        alpha = 0.10f,
+                        alpha = shapeAlpha,
                     )
                 }
-                // Shape 2 (Top Right)
                 translate(left = size.width - shape2Inset, top = shape1OffsetY) {
                     drawOutline(
                         outline = outline2,
                         color = primaryColor,
-                        alpha = 0.10f,
+                        alpha = shapeAlpha,
                     )
                 }
             }

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/HomeFeedSpacing.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/HomeFeedSpacing.kt
@@ -1,0 +1,24 @@
+package cx.aswin.boxlore.feature.home.components
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/** Shared Home discovery spacing — rails, grids, and card feet. */
+internal object HomeFeedSpacing {
+    val RailCardWidth = 156.dp
+    val RailItemGap = 16.dp
+    val GridGap = 16.dp
+
+    /** 18sp line height reserved per title line in equal-height rail feet. */
+    val RailTitleLineHeight = 18.dp
+
+    val CardTextPadding = 12.dp
+
+    /** Hero + two 2×2 body rows (1+4+4). */
+    const val ForYouTotalCap = 9
+    const val ForYouBodyCount = 8
+    const val ExploreGridCap = 6
+
+    fun railTextFootHeight(titleMaxLines: Int): Dp =
+        RailTitleLineHeight * titleMaxLines.coerceAtLeast(1)
+}

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/HomeSkeleton.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/HomeSkeleton.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -42,7 +41,7 @@ fun HomeSkeleton(modifier: Modifier = Modifier) {
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Adaptive(150.dp),
         contentPadding = PaddingValues(bottom = 24.dp, start = 16.dp, end = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(HomeFeedSpacing.GridGap),
         verticalItemSpacing = 16.dp,
         modifier = modifier.fillMaxSize(),
     ) {
@@ -99,13 +98,13 @@ fun RisingSkeleton() {
         // Rail
         LazyRow(
             contentPadding = PaddingValues(horizontal = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(HomeFeedSpacing.RailItemGap),
         ) {
             items(4) {
                 Box(
                     modifier =
                         Modifier
-                            .width(160.dp)
+                            .width(HomeFeedSpacing.RailCardWidth)
                             .height(200.dp)
                             .clip(MaterialTheme.shapes.large)
                             .m3Shimmer(baseColor, highlightColor, shape = MaterialTheme.shapes.large),
@@ -144,13 +143,12 @@ fun GridSkeletonItem(modifier: Modifier = Modifier) {
                         .m3Shimmer(baseColor, highlightColor, shape = RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp)),
             )
 
-            // Text area skeleton matching padding and layout of FeedMediaCard
+            // Text area skeleton matching title-only FeedMediaCard grid foot
             Column(
                 modifier =
                     Modifier
-                        .padding(10.dp)
-                        .heightIn(min = 58.dp),
-                verticalArrangement = Arrangement.spacedBy(6.dp),
+                        .padding(HomeFeedSpacing.CardTextPadding),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 // Title line 1
                 Box(
@@ -167,16 +165,6 @@ fun GridSkeletonItem(modifier: Modifier = Modifier) {
                         Modifier
                             .fillMaxWidth(0.6f)
                             .height(14.dp)
-                            .clip(RoundedCornerShape(4.dp))
-                            .m3Shimmer(baseColor, highlightColor, shape = RoundedCornerShape(4.dp)),
-                )
-                Spacer(modifier = Modifier.height(2.dp))
-                // Artist line
-                Box(
-                    modifier =
-                        Modifier
-                            .width(80.dp)
-                            .height(12.dp)
                             .clip(RoundedCornerShape(4.dp))
                             .m3Shimmer(baseColor, highlightColor, shape = RoundedCornerShape(4.dp)),
                 )
@@ -334,27 +322,19 @@ fun EditorialRowsSkeleton(modifier: Modifier = Modifier) {
                                 ),
                     )
                     Spacer(modifier = Modifier.width(12.dp))
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        SkeletonBlock(
-                            width = 132.dp,
-                            height = 17.dp,
-                            baseColor = baseColor,
-                            highlightColor = highlightColor,
-                        )
-                        SkeletonBlock(
-                            width = 210.dp,
-                            height = 12.dp,
-                            baseColor = baseColor,
-                            highlightColor = highlightColor,
-                        )
-                    }
+                    SkeletonBlock(
+                        width = 132.dp,
+                        height = 17.dp,
+                        baseColor = baseColor,
+                        highlightColor = highlightColor,
+                    )
                 }
-                LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                LazyRow(horizontalArrangement = Arrangement.spacedBy(HomeFeedSpacing.RailItemGap)) {
                     items(4) {
                         Box(
                             modifier =
                                 Modifier
-                                    .width(156.dp)
+                                    .width(HomeFeedSpacing.RailCardWidth)
                                     .height(214.dp)
                                     .clip(MaterialTheme.shapes.large)
                                     .m3Shimmer(

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/LibrarySection.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/LibrarySection.kt
@@ -84,6 +84,7 @@ import cx.aswin.boxlore.feature.home.StablePodcastList
 val LocalLastSeenEpisodes = androidx.compose.runtime.compositionLocalOf<Map<String, String>> { emptyMap() }
 
 @Composable
+@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 fun YourShowsSection(
     subscribedPodcasts: StablePodcastList,
     latestEpisodes: StablePodcastList, // Enriched with latest episodes
@@ -92,6 +93,7 @@ fun YourShowsSection(
     isSelectedPodcastLoading: Boolean,
     isSelectedRssRefreshing: Boolean,
     episodePlaybackState: StablePlaybackStateMap,
+    softExpireProgressEpisodeIds: Set<String> = emptySet(),
     currentPlayingEpisodeId: String? = null,
     isPlaying: Boolean = false,
     onPodcastSelected: (String?) -> Unit,
@@ -604,6 +606,7 @@ fun YourShowsSection(
                                     val ep = podcast.latestEpisode
                                     if (ep != null) {
                                         val state = episodePlaybackState.map[ep.id]
+                                        val softExpire = softExpireProgressEpisodeIds.contains(ep.id)
                                         MixtapeEpisodeCard(
                                             episode = ep,
                                             podcast = podcast,
@@ -615,8 +618,13 @@ fun YourShowsSection(
                                                     cx.aswin.boxlore.core.model.PlaybackEntryPoint.HOME_MIXTAPE,
                                                 )
                                             },
-                                            overrideStatus = state?.first,
-                                            overrideProgress = state?.second,
+                                            overrideStatus =
+                                                if (softExpire) {
+                                                    cx.aswin.boxlore.core.model.EpisodeStatus.UNPLAYED
+                                                } else {
+                                                    state?.first
+                                                },
+                                            overrideProgress = if (softExpire) 0f else state?.second,
                                             currentPlayingEpisodeId = currentPlayingEpisodeId,
                                             isPlaying = isPlaying,
                                             isDownloaded = downloadedEpisodeIds.contains(ep.id),

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/PodcastCard.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/components/PodcastCard.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -36,19 +34,37 @@ import cx.aswin.boxlore.core.designsystem.components.OptimizedImage
 import cx.aswin.boxlore.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxlore.core.model.Podcast
 
+/**
+ * Layout density for discovery poster cards.
+ * Title-only posters reserve a fixed foot ([Rail]: 2 lines, [Grid]: 3) and vertically
+ * center shorter titles so rows stay equal height.
+ */
+enum class FeedMediaCardDensity {
+    Rail,
+    Grid,
+}
+
 @Composable
 fun PodcastCard(
     podcast: Podcast,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     showGenreChip: Boolean = false,
+    showSubtitle: Boolean = true,
+    density: FeedMediaCardDensity = FeedMediaCardDensity.Grid,
 ) {
     FeedMediaCard(
         imageUrl = podcast.imageUrl,
         title = podcast.title.replace("+", " "),
-        subtitle = podcast.artist.replace("+", " "),
+        subtitle = if (showSubtitle) podcast.artist.replace("+", " ") else null,
         onClick = onClick,
         modifier = modifier,
+        titleMaxLines =
+            when {
+                showSubtitle -> 2
+                density == FeedMediaCardDensity.Rail -> 2
+                else -> 3
+            },
         imageBadge = {
             if (showGenreChip && podcast.genre.isNotEmpty()) {
                 Surface(
@@ -99,15 +115,20 @@ fun PodcastCard(
 }
 
 @Composable
+@Suppress("LongParameterList")
 fun FeedMediaCard(
     imageUrl: String,
     title: String,
-    subtitle: String,
+    subtitle: String?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    titleMaxLines: Int = 2,
     imageBadge: @Composable (BoxScope.() -> Unit)? = null,
     imageOverlay: @Composable (BoxScope.() -> Unit)? = null,
 ) {
+    val lines = titleMaxLines.coerceAtLeast(1)
+    val showSubtitle = !subtitle.isNullOrBlank()
+
     OutlinedCard(
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
@@ -141,26 +162,45 @@ fun FeedMediaCard(
                 }
             }
 
-            Column(
-                modifier =
-                    Modifier
-                        .padding(10.dp)
-                        .heightIn(min = 58.dp),
-            ) {
-                Text(
-                    text = title,
-                    style = MaterialTheme.typography.titleMedium.copy(fontSize = 13.sp, lineHeight = 17.sp),
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Spacer(modifier = Modifier.height(6.dp))
-                Text(
-                    text = subtitle,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+            if (!showSubtitle) {
+                // Equal-height posters: reserve [lines] title lines; vertically center shorter titles.
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(HomeFeedSpacing.railTextFootHeight(lines) + HomeFeedSpacing.CardTextPadding * 2)
+                            .padding(HomeFeedSpacing.CardTextPadding),
+                    contentAlignment = Alignment.CenterStart,
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium.copy(fontSize = 14.sp, lineHeight = 18.sp),
+                        maxLines = lines,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            } else {
+                Column(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(HomeFeedSpacing.CardTextPadding),
+                ) {
+                    Text(
+                        text = title,
+                        style = MaterialTheme.typography.titleMedium.copy(fontSize = 14.sp, lineHeight = 18.sp),
+                        maxLines = lines,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = subtitle.orEmpty(),
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeUiAssemblyLogic.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/logic/HomeUiAssemblyLogic.kt
@@ -1,11 +1,12 @@
 package cx.aswin.boxlore.feature.home.logic
 
-import cx.aswin.boxlore.core.playback.MixtapeEngine
-import cx.aswin.boxlore.core.playback.PlaybackSession
 import cx.aswin.boxlore.core.model.Briefing
 import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.core.model.EpisodeStatus
 import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.core.playback.MixtapeEngine
+import cx.aswin.boxlore.core.playback.PlaybackSession
+import cx.aswin.boxlore.core.playback.PlaybackSkipPolicy
 import cx.aswin.boxlore.feature.home.HomeEditorialRow
 import cx.aswin.boxlore.feature.home.HomeListeningHistoryItem
 import cx.aswin.boxlore.feature.home.SmartHeroItem
@@ -15,7 +16,23 @@ internal data class HomeMixtapeCache(
     val unplayedCount: Int,
     val episodes: List<Episode>,
     val subSignature: Set<String>,
+    val staleRestartEnabled: Boolean = true,
 )
+
+internal fun homeMixtapeCacheOrNull(
+    podcasts: List<Podcast>?,
+    unplayedCount: Int?,
+    episodes: List<Episode>?,
+    subSignature: Set<String>?,
+    staleRestartEnabled: Boolean?,
+): HomeMixtapeCache? =
+    HomeMixtapeCache(
+        podcasts = podcasts ?: return null,
+        unplayedCount = unplayedCount ?: return null,
+        episodes = episodes ?: return null,
+        subSignature = subSignature ?: return null,
+        staleRestartEnabled = staleRestartEnabled ?: return null,
+    )
 
 internal data class HomeUiAssemblyResult(
     val heroItems: List<SmartHeroItem>,
@@ -26,6 +43,7 @@ internal data class HomeUiAssemblyResult(
     val discoverPodcasts: List<Podcast>,
     val recommendations: List<Episode>,
     val episodePlaybackState: Map<String, Pair<EpisodeStatus, Float>>,
+    val softExpireProgressEpisodeIds: Set<String>,
     val showImportBanner: Boolean,
     val briefing: Briefing?,
     val briefingChapters: List<cx.aswin.boxlore.core.model.Chapter>,
@@ -41,7 +59,7 @@ internal data class HomeUiAssemblyResult(
  * Ranking/mixtape builders are injected so this stays free of Android ViewModel deps.
  */
 internal object HomeUiAssemblyLogic {
-    @Suppress("LongParameterList")
+    @Suppress("LongParameterList", "LongMethod")
     suspend fun assemble(
         trendingList: List<Podcast>,
         rankedRecommendations: List<Episode>,
@@ -62,6 +80,8 @@ internal object HomeUiAssemblyLogic {
         rawBriefingChapters: List<cx.aswin.boxlore.core.model.Chapter>,
         briefingDismissedDate: String,
         briefingDismissedForever: Boolean,
+        staleRestartEnabled: Boolean = true,
+        nowMs: Long = System.currentTimeMillis(),
     ): HomeUiAssemblyResult {
         val completedCount = allHistory.count { it.isCompleted }
         val catchUp =
@@ -82,6 +102,7 @@ internal object HomeUiAssemblyLogic {
         val currentSubIds = subs.map { it.id }.toSet()
         val mixtapeCache =
             if (previousMixtape != null &&
+                previousMixtape.staleRestartEnabled == staleRestartEnabled &&
                 !HomeShowsOrderLogic.shouldInvalidateMixtapeCache(
                     previousMixtape.subSignature,
                     currentSubIds,
@@ -113,6 +134,7 @@ internal object HomeUiAssemblyLogic {
                     unplayedCount = mixtapeCount,
                     episodes = mixtapeEpisodes,
                     subSignature = currentSubIds,
+                    staleRestartEnabled = staleRestartEnabled,
                 )
         }
 
@@ -138,6 +160,18 @@ internal object HomeUiAssemblyLogic {
                 completedEpisodeIds = completedEpisodeIds,
             )
 
+        val softExpireProgressEpisodeIds =
+            if (staleRestartEnabled) {
+                allHistory
+                    .asSequence()
+                    .filter { !it.isCompleted && it.progressMs > 0L }
+                    .filter { PlaybackSkipPolicy.isStaleLastPlayed(it.lastPlayedAt, nowMs) }
+                    .map { it.episodeId }
+                    .toSet()
+            } else {
+                emptySet()
+            }
+
         val showBriefing =
             HomePlaybackStateLogic.shouldShowBriefing(
                 rawBriefing = rawBriefing,
@@ -156,6 +190,7 @@ internal object HomeUiAssemblyLogic {
             discoverPodcasts = discover,
             recommendations = rankedRecommendations,
             episodePlaybackState = episodePlaybackState,
+            softExpireProgressEpisodeIds = softExpireProgressEpisodeIds,
             showImportBanner = sortedSubs.isEmpty() && !hasDismissedImportBanner,
             briefing = if (showBriefing) rawBriefing else null,
             briefingChapters = if (showBriefing) rawBriefingChapters else emptyList(),

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/settings/SettingsScreen.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/settings/SettingsScreen.kt
@@ -115,8 +115,9 @@ data class PlaybackSettings(
             hideCompletedInHome = true,
             hideCompletedInSubs = true,
             hideCompletedInShowDetails = false,
+            restartForgottenEpisodes = true,
         ),
-    val actions: PlaybackActions = PlaybackActions({}, {}, {}, {}, {}, {}, {}, {}),
+    val actions: PlaybackActions = PlaybackActions({}, {}, {}, {}, {}, {}, {}, {}, {}),
 )
 
 @Composable

--- a/feature/home/src/main/java/cx/aswin/boxlore/feature/home/settings/pages/PlaybackSettingsPage.kt
+++ b/feature/home/src/main/java/cx/aswin/boxlore/feature/home/settings/pages/PlaybackSettingsPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.rounded.Home
 import androidx.compose.material.icons.rounded.NewReleases
 import androidx.compose.material.icons.rounded.Podcasts
 import androidx.compose.material.icons.rounded.Replay
+import androidx.compose.material.icons.rounded.Update
 import androidx.compose.runtime.Composable
 import cx.aswin.boxlore.feature.home.settings.components.SettingsChoiceRow
 import cx.aswin.boxlore.feature.home.settings.components.SettingsDivider
@@ -28,6 +29,7 @@ data class PlaybackUiState(
     val hideCompletedInHome: Boolean,
     val hideCompletedInSubs: Boolean,
     val hideCompletedInShowDetails: Boolean,
+    val restartForgottenEpisodes: Boolean = true,
 )
 
 /** Callbacks for [PlaybackSettingsPage], grouped to keep the page's parameter count small. */
@@ -40,6 +42,7 @@ data class PlaybackActions(
     val onSetHideCompletedInHome: (Boolean) -> Unit,
     val onSetHideCompletedInSubs: (Boolean) -> Unit,
     val onSetHideCompletedInShowDetails: (Boolean) -> Unit,
+    val onSetRestartForgottenEpisodes: (Boolean) -> Unit = {},
 )
 
 @Composable
@@ -134,6 +137,20 @@ internal fun PlaybackSettingsPage(
                 supportingText = "Mark the current episode complete first",
                 selected = state.skipBehavior == "mark_completed_skip",
                 onClick = { actions.onSetSkipBehavior("mark_completed_skip") },
+            )
+        }
+
+        SettingsGroup(
+            title = "Resume",
+            footer =
+                "When on, queue and mixtape start from the beginning if you haven’t played an episode in 7 days. Jump Back In and History always resume where you left off.",
+        ) {
+            SettingsSwitchRow(
+                title = "Restart forgotten episodes",
+                supportingText = "Queue and mixtape after 7 idle days",
+                checked = state.restartForgottenEpisodes,
+                onCheckedChange = actions.onSetRestartForgottenEpisodes,
+                icon = Icons.Rounded.Update,
             )
         }
 

--- a/feature/home/src/test/java/cx/aswin/boxlore/feature/home/components/EqualHeightPosterGridTest.kt
+++ b/feature/home/src/test/java/cx/aswin/boxlore/feature/home/components/EqualHeightPosterGridTest.kt
@@ -1,0 +1,23 @@
+package cx.aswin.boxlore.feature.home.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EqualHeightPosterGridTest {
+    @Test
+    fun `packs rows with gap between only`() {
+        // Row0 max(100,120)=120; Row1 max(80)=80; +8 gap → 208
+        assertEquals(208, equalHeightPosterGridExtent(listOf(100, 120, 80), columns = 2, verticalGap = 8))
+    }
+
+    @Test
+    fun `even equal heights sum rows and gaps`() {
+        // 2 rows of 100 + one gap 16 → 216
+        assertEquals(216, equalHeightPosterGridExtent(listOf(100, 100, 100, 100), columns = 2, verticalGap = 16))
+    }
+
+    @Test
+    fun `empty input is zero height`() {
+        assertEquals(0, equalHeightPosterGridExtent(emptyList(), columns = 2, verticalGap = 8))
+    }
+}

--- a/feature/player/src/main/java/cx/aswin/boxlore/feature/player/v2/logic/QueueLabelLogic.kt
+++ b/feature/player/src/main/java/cx/aswin/boxlore/feature/player/v2/logic/QueueLabelLogic.kt
@@ -7,6 +7,7 @@ internal fun queueSourceLabel(episode: Episode): String? = when (episode.context
     "AUTO_FILL" -> when (episode.contextSourceId) {
         "same_podcast" -> "Continuing series"
         "resume" -> "Pick up where you left off"
+        "resume_stale" -> "Starting over"
         "subscription" -> "From your subscriptions"
         "server_rec", "personalized_rec" -> "Recommended for you"
         "similar_episode" -> "Based on what you're playing"

--- a/feature/player/src/test/java/cx/aswin/boxlore/feature/player/v2/logic/QueueLabelLogicTest.kt
+++ b/feature/player/src/test/java/cx/aswin/boxlore/feature/player/v2/logic/QueueLabelLogicTest.kt
@@ -23,6 +23,7 @@ class QueueLabelLogicTest {
             mapOf(
                 "same_podcast" to "Continuing series",
                 "resume" to "Pick up where you left off",
+                "resume_stale" to "Starting over",
                 "subscription" to "From your subscriptions",
                 "server_rec" to "Recommended for you",
                 "personalized_rec" to "Recommended for you",


### PR DESCRIPTION
## Summary

- **Restart forgotten episodes** (Settings → Playback, default **on**): implicit plays (queue, mixtape, Smart Queue, casual) soft-expire mid-episode seek after **7 days** without `lastPlayedAt`. Explicit resume (Jump Back In / History) always seeks. Progress is never wiped.
- Soft-expire **chrome** stays honest: mixtape hides progress / “Xm left”; Smart Queue stamps `resume_stale` → queue label **“Starting over”**. Selection still uses the existing ~30-day unfinished band.
- Home discovery polish: title-only equal-height poster rails/grids (fixed 2-/3-line feet, vertically centered short titles), For You / Explore via `EqualHeightPosterGrid` (no bento stretch), calmer hero grid cells (resume plays; new episodes open info).

## Motivation

Listeners were often dropped mid-episode when a queue or mixtape resurfaced something they abandoned weeks ago — progress seek felt like a bug. Separately, “Based on Your Taste” and other discovery grids stretched short-title cards into tall empty surfaces (bento flush), and hero grids mixed dense chrome that fought the calmer discovery look.

This PR separates **intent** (I chose this unfinished episode vs the system queued it) from **selection** (still suggest unfinished items), and aligns discovery poster geometry so short and long titles share one row height without empty card bands.

## What changed

### Playback — intent-aware soft-expire

- `PlaybackSkipPolicy`:
  - `ResumeIntent` (`EXPLICIT` / `IMPLICIT`) + `resumeIntentFromEntryPoint`
  - `STALE_RESUME_MS` = 7 days; `isStaleLastPlayed`
  - `resolveInitialPosition` soft-expires only when flag on **and** intent is implicit **and** last played is stale; otherwise resumes as before
- Wired through `PlaybackRepository.checkSavedProgress`, intro/outro controller, queue coordinator / transport, and `BoxLorePlaybackService`
- Pref: `UserPreferencesRepository.restartForgottenEpisodesStream` / `setRestartForgottenEpisodes` (default `true`); key in `UserPreferenceKeys`
- Settings UI: Playback → Resume → **Restart forgotten episodes**
- Included in library backup / restore (`LibraryBackupManager` + settings nav wiring / `BoxLoreAppRoot`)

### Soft-expire chrome (selection unchanged)

- **Smart Queue**: `SOURCE_RESUME_STALE` when a resume-band pick would cold-start under the pref; `QueueLabelLogic` maps → **“Starting over”**
- **Mixtape / Your Shows**: `softExpireProgressEpisodeIds` suppresses progress bar + “Xm left” / live override status for soft-expired picks (still the same mixtape selection)
- Pref toggle invalidates mixtape cache via `staleRestartEnabled` on `HomeMixtapeCache` so chrome updates when the setting flips

### Home discovery layout

- `HomeFeedSpacing` — shared rail/grid gaps and title-foot heights
- `FeedMediaCard` / `PodcastCard` / `CuratedEpisodeCard` — title-only posters reserve fixed feet; grid = 3 lines, show rails = 2; shorter titles centered vertically
- `EqualHeightPosterGrid` replaces stretchy bento layout for For You body + Home Explore
- Hero grids (`HeroGridMode.Resume` / `NewEpisodes`): title-only cells, lighter scrim, progress + now-playing ring on resume, NEW badge + info tap on new episodes
- Because You Like / editorial rails / skeletons aligned to the same density tokens

### Docs & detekt

- Module READMEs (`:core:playback`, `:core:prefs`, `:feature:home`) updated for behavior ownership
- Targeted `@Suppress` on known large APIs plus `homeMixtapeCacheOrNull` to keep `detekt` green without a structural refactor of `YourShowsSection`

## Behavior & compatibility

| Surface | Before | After (pref on, default) |
|:--|:--|:--|
| Jump Back In / History | Mid-episode seek | Unchanged — always seek |
| Queue / mixtape / SQ / casual, played &lt; 7d ago | Mid-episode seek | Unchanged — still seek |
| Queue / mixtape / SQ / casual, idle &gt; 7d | Mid-episode seek | Start / intro-skip; **progress kept** |
| Pref off | n/a | Previous always-resume behavior for implicit plays |
| Mixtape / SQ **pick list** | Unfinished within suggestion band | Same band; only seek + chrome change |
| Discovery poster grids | Variable / stretched feet | Equal-height 3-line feet |
| Hero Jump back in | Mixed chrome / tap | Play + progress chrome |
| Hero New episodes | Mixed chrome / tap | Open episode info + NEW when fresh |

- No `applicationId`, Room, DataStore file rename, or media-ID changes
- New pref defaults **on**; backups round-trip the flag when present
- Older backups without the key restore to default `true`

## Impact (required)

### User impact — pick **exactly one**

- [x] `user-impact-high`
- [ ] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact

**What changes in the user’s life:**

If you left an episode halfway weeks ago and it shows up again from your queue or mixtape, boxlore starts that episode clean instead of dumping you in the middle — unless you open it from Jump Back In or History, which still pick up exactly where you were. You can turn this off anytime in Settings → Playback → **Restart forgotten episodes** (it’s on by default). Soft-expired mixtape cards no longer show a misleading progress bar, and Smart Queue may label those fills “Starting over.” Home discovery posters (Because You Like, Based on Your Taste, Explore) look calmer and more even: short titles sit centered in the same title space as long ones, and hero “Jump back in” / “New episodes” grids are clearer about play vs open.

### Backend — optional

- [ ] `backend-change`

## Test plan

- [x] `./gradlew detekt` green locally
- [x] Unit tests for skip policy (intent × flag × freshness), Smart Queue `resume_stale`, mixtape soft-expire helpers, prefs default, `EqualHeightPosterGrid` extent, queue label mapping
- [x] `./gradlew installDebug` on device during development
- [ ] Manual: Settings → Playback → toggle **Restart forgotten episodes**; confirm footer copy matches behavior
- [ ] Manual: Jump Back In on a mid-episode show → still resumes mid-episode with pref on
- [ ] Manual: play a soft-expired unfinished episode from mixtape / Smart Queue → starts near beginning; progress still in history
- [ ] Manual: mixtape card for soft-expired pick → no progress bar / “Xm left”
- [ ] Manual: Smart Queue row with `resume_stale` → **Starting over**
- [ ] Manual: Based on Your Taste / Explore grids → equal card heights; short titles vertically centered (no empty stretch band)
- [ ] Manual: Jump back in cell → plays; New episodes cell → episode info; NEW badge on fresh eps
- [ ] Required checks green: `testDebugUnitTest` + `coderabbit-threads-resolved`

## Notes

- Soft-expire is **seek policy only** — does not clear `progressMs` / listening history.
- Review scratch screenshots (`based-on-taste-review.png`, `hero-grid-review.png`) left untracked on purpose.
- Large composables (`YourShowsSection`, etc.) use existing-repo `@Suppress` pattern rather than a multi-file split in this PR.
