### PR TITLE
fix(onboarding): smooth welcome cover marquee and refresh Latest artifacts [skip changelog]

### DIFF
--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -1016,6 +1016,39 @@ def delete_published_release_branch(
     return [f"deleted release branch {branch}"]
 
 
+def resolve_latest_refresh(args: argparse.Namespace) -> None:
+    """Resolve build metadata for clobbering assets on an existing Latest release.
+
+    Requires the checked-out Gradle versionName/versionCode to match the Latest
+    GitHub release tag (e.g. Gradle 0.0.12 ↔ tag v0.0.12). Does not bump versions.
+    """
+    current = read_app_version()
+    latest_tag = args.latest_tag.strip()
+    if not latest_tag:
+        fail("Latest release tag is empty")
+    expected = _parse_release_tag(latest_tag)
+    if current.name != expected.name:
+        fail(
+            "Gradle versionName does not match the Latest GitHub release tag: "
+            f"Gradle={current.tag}, Latest={latest_tag}. "
+            "Publish a new release, or align app/build.gradle.kts with Latest before "
+            "refreshing artifacts."
+        )
+    print(
+        f"Refreshing artifacts for {current.tag} "
+        f"(versionCode={current.code}) from current checkout"
+    )
+    write_outputs(
+        {
+            "version": current.name,
+            "version_code": current.code,
+            "tag": current.tag,
+            "apk_asset": current.apk_asset,
+            "aab_asset": current.aab_asset,
+        }
+    )
+
+
 def delete_release_branch_after_publish(args: argparse.Namespace) -> None:
     repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
     token = os.environ.get("GITHUB_TOKEN", "").strip()
@@ -1055,6 +1088,12 @@ def main() -> None:
         help="Verify the checked-out master commit is a merged release",
     )
 
+    refresh_parser = subparsers.add_parser(
+        "resolve-latest-refresh",
+        help="Resolve Gradle metadata for refreshing Latest release artifacts",
+    )
+    refresh_parser.add_argument("--latest-tag", required=True)
+
     notes_parser = subparsers.add_parser(
         "notes",
         help="Extract release notes for the current Gradle version",
@@ -1086,6 +1125,8 @@ def main() -> None:
             verify_release(args)
         elif args.command == "verify-merged":
             verify_merged_commit()
+        elif args.command == "resolve-latest-refresh":
+            resolve_latest_refresh(args)
         elif args.command == "notes":
             write_release_notes(args)
         elif args.command == "notification":

--- a/.github/workflows/changelog-on-merge.yml
+++ b/.github/workflows/changelog-on-merge.yml
@@ -16,6 +16,7 @@ on:
         options:
           - prepare-release
           - publish-release
+          - refresh-latest-artifacts
           - backfill-changelog
       bump:
         description: Version bump for prepare-release
@@ -697,6 +698,393 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag }}
         run: python3 .github/scripts/prepare_release.py delete-release-branch --tag "$TAG"
+
+      - name: Remove protected build inputs
+        if: always()
+        run: |
+          rm -f local.properties
+          rm -f app/release.keystore
+          rm -f app/google-services.json
+
+  refresh-latest-artifacts:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.operation == 'refresh-latest-artifacts'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    concurrency:
+      group: refresh-latest-artifacts
+      cancel-in-progress: false
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: master
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
+
+      - name: Set up Java 17
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
+
+      - name: Install Android build-tools
+        run: |
+          set -euo pipefail
+          yes | sdkmanager --licenses >/dev/null || true
+          sdkmanager "build-tools;36.0.0" "platforms;android-36" "cmdline-tools;latest"
+
+      - name: Resolve Latest GitHub release tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest_tag="$(gh release view \
+            --repo "$GITHUB_REPOSITORY" \
+            --json tagName \
+            --jq '.tagName')"
+          if [[ -z "$latest_tag" ]]; then
+            echo "::error::No GitHub Latest release was found"
+            exit 1
+          fi
+          echo "tag=$latest_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve refresh metadata (Gradle must match Latest tag)
+        id: release
+        env:
+          LATEST_TAG: ${{ steps.latest.outputs.tag }}
+        run: |
+          python3 .github/scripts/prepare_release.py resolve-latest-refresh \
+            --latest-tag "$LATEST_TAG"
+
+      - name: Confirm Latest release exists for clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::GitHub release ${TAG} does not exist; cannot refresh artifacts"
+            exit 1
+          fi
+
+      - name: Materialize protected build inputs
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          BOXCAST_PUBLIC_KEY: ${{ secrets.BOXCAST_PUBLIC_KEY }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          BOXCAST_API_BASE_URL: ${{ vars.BOXCAST_API_BASE_URL }}
+          POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
+        run: |
+          python3 - <<'PY'
+          import base64
+          import binascii
+          import os
+          from pathlib import Path
+
+          required = (
+              "RELEASE_KEYSTORE_BASE64",
+              "GOOGLE_SERVICES_JSON_BASE64",
+              "KEY_STORE_PASSWORD",
+              "KEY_PASSWORD",
+              "BOXCAST_PUBLIC_KEY",
+              "POSTHOG_API_KEY",
+              "BOXCAST_API_BASE_URL",
+              "POSTHOG_HOST",
+          )
+          missing = [name for name in required if not os.environ.get(name)]
+          if missing:
+              raise SystemExit(
+                  "Missing protected release values: " + ", ".join(missing)
+              )
+
+          def decode_secret(name: str, path: Path) -> None:
+              try:
+                  payload = base64.b64decode(
+                      os.environ[name].strip(),
+                      validate=True,
+                  )
+              except (ValueError, binascii.Error) as exc:
+                  raise SystemExit(f"{name} is not valid Base64") from exc
+              if not payload:
+                  raise SystemExit(f"{name} decoded to an empty file")
+              path.parent.mkdir(parents=True, exist_ok=True)
+              path.write_bytes(payload)
+              path.chmod(0o600)
+
+          def property_value(name: str) -> str:
+              value = os.environ[name]
+              if not value.isascii() or any(char in value for char in "\r\n"):
+                  raise SystemExit(
+                      f"{name} must be a single-line ASCII value"
+                  )
+              escaped = value.replace("\\", "\\\\")
+              for char in ("=", ":", "#", "!"):
+                  escaped = escaped.replace(char, f"\\{char}")
+              if escaped.startswith(" "):
+                  escaped = "\\ " + escaped[1:]
+              return escaped
+
+          decode_secret("RELEASE_KEYSTORE_BASE64", Path("app/release.keystore"))
+          decode_secret(
+              "GOOGLE_SERVICES_JSON_BASE64",
+              Path("app/google-services.json"),
+          )
+          properties = {
+              "KEY_STORE_PASSWORD": property_value("KEY_STORE_PASSWORD"),
+              "KEY_PASSWORD": property_value("KEY_PASSWORD"),
+              "BOXCAST_API_BASE_URL": property_value("BOXCAST_API_BASE_URL"),
+              "BOXCAST_PUBLIC_KEY": property_value("BOXCAST_PUBLIC_KEY"),
+              "posthog.apiKey": property_value("POSTHOG_API_KEY"),
+              "posthog.host": property_value("POSTHOG_HOST"),
+          }
+          local_properties = Path("local.properties")
+          local_properties.write_text(
+              "".join(f"{key}={value}\n" for key, value in properties.items()),
+              encoding="ascii",
+          )
+          local_properties.chmod(0o600)
+          PY
+
+      - name: Verify release keystore identity
+        env:
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+          EXPECTED_CERT_SHA256: ${{ vars.RELEASE_CERT_SHA256 }}
+        run: |
+          expected="$(printf '%s' "$EXPECTED_CERT_SHA256" | tr -d ':' | tr '[:lower:]' '[:upper:]')"
+          if ! [[ "$expected" =~ ^[0-9A-F]{64}$ ]]; then
+            echo "::error::RELEASE_CERT_SHA256 must be a 64-digit SHA-256 fingerprint"
+            exit 1
+          fi
+          actual="$(
+            keytool -list -v \
+              -keystore app/release.keystore \
+              -alias upload \
+              -storepass:env KEY_STORE_PASSWORD 2>/dev/null |
+              awk '/SHA256:/{print $2; exit}' |
+              tr -d ':' |
+              tr '[:lower:]' '[:upper:]'
+          )"
+          if [[ "$actual" != "$expected" ]]; then
+            echo "::error::Release keystore certificate fingerprint mismatch"
+            exit 1
+          fi
+
+      - name: Build signed release APK and AAB
+        run: ./gradlew --no-daemon assembleRelease bundleRelease
+
+      - name: Verify artifact versions and signatures
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_VERSION: ${{ steps.release.outputs.version }}
+          EXPECTED_VERSION_CODE: ${{ steps.release.outputs.version_code }}
+          EXPECTED_CERT_SHA256: ${{ vars.RELEASE_CERT_SHA256 }}
+          KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          apk="app/build/outputs/apk/release/app-release.apk"
+          aab="app/build/outputs/bundle/release/app-release.aab"
+          [[ -s "$apk" ]] || { echo "::error::Signed release APK is missing"; exit 1; }
+          [[ -s "$aab" ]] || { echo "::error::Signed release AAB is missing"; exit 1; }
+
+          normalize_sha256() {
+            printf '%s' "$1" | tr -d '[:space:]:' | tr '[:lower:]' '[:upper:]'
+          }
+
+          extract_sha256_digest() {
+            printf '%s' "$1" | python3 .github/scripts/extract_cert_digest.py
+          }
+
+          sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+          if [[ -z "$sdk_root" ]]; then
+            echo "::error::ANDROID_SDK_ROOT/ANDROID_HOME is not set"
+            exit 1
+          fi
+
+          apkanalyzer="$(
+            find "$sdk_root/cmdline-tools" -type f -name apkanalyzer 2>/dev/null |
+              sort -V |
+              awk 'END { print }'
+          )"
+          [[ -x "$apkanalyzer" ]] || {
+            echo "::error::apkanalyzer not found under ${sdk_root}"
+            exit 1
+          }
+
+          apksigner="$(
+            find "$sdk_root/build-tools" -type f -name apksigner 2>/dev/null |
+              sort -V |
+              awk 'END { print }'
+          )"
+          [[ -x "$apksigner" ]] || {
+            echo "::error::apksigner not found under ${sdk_root}/build-tools"
+            ls -la "$sdk_root/build-tools" || true
+            exit 1
+          }
+          echo "Using apksigner at ${apksigner}"
+
+          apk_summary="$("$apkanalyzer" apk summary "$apk")"
+          read -r apk_application_id apk_version_code apk_version <<< "$apk_summary"
+          if [[ "$apk_application_id" != "cx.aswin.boxlore" ||
+                "$apk_version_code" != "$EXPECTED_VERSION_CODE" ||
+                "$apk_version" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::APK manifest does not match the release metadata"
+            exit 1
+          fi
+
+          bundletool_json="$RUNNER_TEMP/bundletool-release.json"
+          gh api repos/google/bundletool/releases/latest > "$bundletool_json"
+          bundletool_url="$(
+            jq -r '[.assets[] | select(.name | test("^bundletool-all-.*\\.jar$"))][0].browser_download_url // empty' \
+              "$bundletool_json"
+          )"
+          bundletool_digest="$(
+            jq -r '[.assets[] | select(.name | test("^bundletool-all-.*\\.jar$"))][0].digest // empty' \
+              "$bundletool_json"
+          )"
+          if [[ -z "$bundletool_url" || ! "$bundletool_digest" =~ ^sha256:[0-9a-fA-F]{64}$ ]]; then
+            echo "::error::Latest bundletool release has no verifiable JAR digest"
+            exit 1
+          fi
+          bundletool="$RUNNER_TEMP/bundletool.jar"
+          curl --fail --silent --show-error --location "$bundletool_url" --output "$bundletool"
+          printf '%s  %s\n' "${bundletool_digest#sha256:}" "$bundletool" |
+            sha256sum --check --status
+
+          aab_version="$(
+            java -jar "$bundletool" dump manifest \
+              --bundle="$aab" \
+              --xpath=/manifest/@android:versionName
+          )"
+          aab_version_code="$(
+            java -jar "$bundletool" dump manifest \
+              --bundle="$aab" \
+              --xpath=/manifest/@android:versionCode
+          )"
+          if [[ "$aab_version" != "$EXPECTED_VERSION" ||
+                "$aab_version_code" != "$EXPECTED_VERSION_CODE" ]]; then
+            echo "::error::AAB manifest does not match the release metadata"
+            exit 1
+          fi
+
+          expected_cert="$(normalize_sha256 "$EXPECTED_CERT_SHA256")"
+          if ! [[ "$expected_cert" =~ ^[0-9A-F]{64}$ ]]; then
+            echo "::error::RELEASE_CERT_SHA256 must be a 64-digit SHA-256 fingerprint"
+            exit 1
+          fi
+
+          keystore_blob="$(
+            keytool -list -v \
+              -keystore app/release.keystore \
+              -alias upload \
+              -storepass:env KEY_STORE_PASSWORD 2>/dev/null
+          )"
+          keystore_cert="$(extract_sha256_digest "$keystore_blob")"
+
+          apk_certs_blob="$("$apksigner" verify --print-certs "$apk" 2>&1)"
+          apk_cert="$(extract_sha256_digest "$apk_certs_blob")"
+
+          jarsigner -verify "$aab" >/dev/null
+          aab_blob="$(keytool -printcert -jarfile "$aab" 2>/dev/null)"
+          aab_cert="$(extract_sha256_digest "$aab_blob")"
+
+          if ! [[ "$keystore_cert" =~ ^[0-9A-F]{64}$ &&
+                  "$apk_cert" =~ ^[0-9A-F]{64}$ &&
+                  "$aab_cert" =~ ^[0-9A-F]{64}$ ]]; then
+            echo "::error::Could not parse one or more signing certificate digests"
+            echo "keystore_len=${#keystore_cert} apk_len=${#apk_cert} aab_len=${#aab_cert}"
+            echo "---- apksigner --print-certs (sanitized) ----"
+            printf '%s\n' "$apk_certs_blob" | sed -E 's/([0-9A-Fa-f]{2}:){8,}/<digest>/g' | sed -n '1,40p'
+            exit 1
+          fi
+
+          if [[ "$keystore_cert" != "$expected_cert" ||
+                "$apk_cert" != "$expected_cert" ||
+                "$aab_cert" != "$expected_cert" ]]; then
+            echo "::error::Built artifact signing certificate mismatch"
+            echo "expected=${expected_cert:0:8}…${expected_cert: -8}"
+            echo "keystore=${keystore_cert:0:8}…${keystore_cert: -8}"
+            echo "apk=${apk_cert:0:8}…${apk_cert: -8}"
+            echo "aab=${aab_cert:0:8}…${aab_cert: -8}"
+            exit 1
+          fi
+          echo "Verified APK/AAB signatures match release keystore ${expected_cert:0:8}…${expected_cert: -8}"
+
+      - name: Stage release assets
+        env:
+          APK_ASSET: ${{ steps.release.outputs.apk_asset }}
+          AAB_ASSET: ${{ steps.release.outputs.aab_asset }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/release-assets"
+          cp app/build/outputs/apk/release/app-release.apk \
+            "$RUNNER_TEMP/release-assets/$APK_ASSET"
+          cp app/build/outputs/bundle/release/app-release.aab \
+            "$RUNNER_TEMP/release-assets/$AAB_ASSET"
+          (
+            cd "$RUNNER_TEMP/release-assets"
+            sha256sum "$APK_ASSET" "$AAB_ASSET" > SHA256SUMS
+          )
+
+      - name: Clobber Latest release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          APK_ASSET: ${{ steps.release.outputs.apk_asset }}
+          AAB_ASSET: ${{ steps.release.outputs.aab_asset }}
+        run: |
+          assets=(
+            "$RUNNER_TEMP/release-assets/$APK_ASSET"
+            "$RUNNER_TEMP/release-assets/$AAB_ASSET"
+            "$RUNNER_TEMP/release-assets/SHA256SUMS"
+          )
+          gh release upload "$TAG" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+          echo "Replaced ${TAG} assets (APK/AAB/SHA256SUMS). No FCM, no notes rewrite, tag unchanged."
+
+      - name: Verify README latest-download APK
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+          APK_ASSET: ${{ steps.release.outputs.apk_asset }}
+        run: |
+          expected_apk="$RUNNER_TEMP/release-assets/$APK_ASSET"
+          downloaded_apk="$RUNNER_TEMP/readme-latest-$APK_ASSET"
+          expected_sha="$(sha256sum "$expected_apk" | awk '{print $1}')"
+          download_url="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download/${APK_ASSET}"
+
+          for attempt in {1..12}; do
+            if curl \
+              --fail \
+              --silent \
+              --show-error \
+              --location \
+              --header "Cache-Control: no-cache" \
+              "${download_url}?release=${TAG}&run=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+              --output "$downloaded_apk"; then
+              downloaded_sha="$(sha256sum "$downloaded_apk" | awk '{print $1}')"
+              if [[ "$downloaded_sha" == "$expected_sha" ]]; then
+                echo "README latest-download URL serves the refreshed ${TAG} APK."
+                exit 0
+              fi
+            fi
+            echo "Latest-download APK has not propagated yet (attempt ${attempt}/12)."
+            sleep 10
+          done
+
+          echo "::error::README latest-download URL does not serve the refreshed ${TAG} APK"
+          exit 1
 
       - name: Remove protected build inputs
         if: always()

--- a/feature/onboarding/README.md
+++ b/feature/onboarding/README.md
@@ -7,6 +7,7 @@ Owns first-run onboarding presentation: genre selection, search-based onboarding
 ## Public API
 
 - `OnboardingScreen` and `OnboardingViewModel` for the flow shell.
+- Welcome step uses a cinematic podcast-cover marquee (`CinematicBackgroundGrid`): motion runs on `graphicsLayer` (foreground chrome recomposes separately), cover Image count is capped to tiled loops, and animation starts after two frames so the first paint does not hitch.
 - Onboarding hero titles use `rememberCondensedGoogleSansFamily()` from `:core:designsystem` so condensed Google Sans Flex follows Appearance lettering roundness; AI onboarding uses centralized Google Sans Flex weight tokens.
 - `GenreOnboardingScreen`, `SearchOnboardingScreen`, `ImportOnboardingScreen`, `AiOnboardingScreen`, `AiChatOnboardingScreen`, and `AiSuggestionsScreen`.
 - `AiSuggestionCards`, AI onboarding components, option icons, chat input, and chat message list logic.

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingScreen.kt
@@ -15,12 +15,14 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -286,6 +288,14 @@ fun OnboardingScreen(
     }
 }
 
+/** One marquee loop: 6×(110dp card + 12dp gap) including the gap before the next loop. */
+private const val CoverLoopCount = 6
+private const val CoverCardDp = 110
+private const val CoverGapDp = 12
+private const val CoverLoopPeriodDp = CoverLoopCount * (CoverCardDp + CoverGapDp) // 732
+/** Enough tiled loops for entrance offsets (~2400dp) without ~480 Image nodes. */
+private const val CoverLoopRepeats = 8
+
 @Composable
 private fun WelcomeScreen(
     onHelpMeFind: () -> Unit,
@@ -298,13 +308,15 @@ private fun WelcomeScreen(
     val driftProgress = remember { Animatable(0f) }
 
     LaunchedEffect(Unit) {
-        // Run entrance and drift concurrently for a seamless transition
+        // Let the first cover frames compose/decode before motion — avoids start hitch.
+        withFrameNanos { }
+        withFrameNanos { }
         launch {
             entranceProgress.animateTo(
                 targetValue = 1f,
                 animationSpec =
                     tween(
-                        durationMillis = 4800, // Gentle 4.8 seconds
+                        durationMillis = 4800,
                         easing = LinearEasing,
                     ),
             )
@@ -316,7 +328,7 @@ private fun WelcomeScreen(
                     infiniteRepeatable(
                         animation =
                             tween(
-                                durationMillis = 25000, // Matched with 732dp loop distance for a smooth 29dp/s speed
+                                durationMillis = 25000, // 732dp loop ≈ 29dp/s
                                 easing = LinearEasing,
                             ),
                         repeatMode = RepeatMode.Restart,
@@ -325,99 +337,121 @@ private fun WelcomeScreen(
         }
     }
 
-    Scaffold(
-        modifier = Modifier.fillMaxSize(),
-        containerColor = MaterialTheme.colorScheme.surface,
-    ) { innerPadding ->
+    // Grid is a sibling of inset-padded chrome so status-bar/nav inset settle doesn't jitter covers,
+    // and so foreground recomposition (logo/CTAs) doesn't rebuild hundreds of Images each frame.
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.surface),
+    ) {
+        CinematicBackgroundGrid(
+            entranceProgress = entranceProgress,
+            driftProgress = driftProgress,
+        )
+
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            containerColor = Color.Transparent,
+        ) { innerPadding ->
+            WelcomeForeground(
+                entranceProgress = entranceProgress,
+                condensedFamily = condensedFamily,
+                onHelpMeFind = onHelpMeFind,
+                onSearch = onSearch,
+                onSkip = onSkip,
+                onImportClick = onImportClick,
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("LongMethod")
+private fun WelcomeForeground(
+    entranceProgress: Animatable<Float, AnimationVector1D>,
+    condensedFamily: FontFamily,
+    onHelpMeFind: () -> Unit,
+    onSearch: () -> Unit,
+    onSkip: () -> Unit,
+    onImportClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        val logoProgress = ((entranceProgress.value - 0.20f) / 0.55f).coerceIn(0f, 1f)
+        val logoEase = FastOutSlowInEasing.transform(logoProgress)
+
+        val scrimColor = MaterialTheme.colorScheme.surface
+        val scrimEdge = 0.68f - (logoEase * 0.23f)
+        val scrimMid = 0.76f - (logoEase * 0.24f)
+        val scrimFull = 0.81f - (logoEase * 0.24f)
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(innerPadding),
-        ) {
-            // 0. Shared animation progress (linear timeline mapped to FastOutSlowInEasing)
-            val logoProgress = ((entranceProgress.value - 0.20f) / 0.55f).coerceIn(0f, 1f)
-            val logoEase = FastOutSlowInEasing.transform(logoProgress)
-
-            // 1. Podcast Cover Grid — occupies entire background, always visible
-            CinematicBackgroundGrid(
-                entranceProgressProvider = { entranceProgress.value },
-                driftProgressProvider = { driftProgress.value },
-            )
-
-            // 2. Bottom-heavy gradient scrim — grows dynamically as logo/buttons shift up to cover the final logo position
-            val scrimColor = MaterialTheme.colorScheme.surface
-            val scrimEdge = 0.68f - (logoEase * 0.23f) // 0.68f → 0.45f
-            val scrimMid = 0.76f - (logoEase * 0.24f) // 0.76f → 0.52f
-            val scrimFull = 0.81f - (logoEase * 0.24f) // 0.81f → 0.57f
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .background(
-                            Brush.verticalGradient(
-                                colorStops =
-                                    arrayOf(
-                                        0.0f to scrimColor.copy(alpha = 0.0f),
-                                        (scrimEdge - 0.15f).coerceAtLeast(0f) to scrimColor.copy(alpha = 0.0f),
-                                        scrimEdge to scrimColor.copy(alpha = 0.5f),
-                                        scrimMid to scrimColor.copy(alpha = 0.9f),
-                                        scrimFull to scrimColor,
-                                        1.0f to scrimColor,
-                                    ),
-                            ),
+                    .background(
+                        Brush.verticalGradient(
+                            colorStops =
+                                arrayOf(
+                                    0.0f to scrimColor.copy(alpha = 0.0f),
+                                    (scrimEdge - 0.15f).coerceAtLeast(0f) to scrimColor.copy(alpha = 0.0f),
+                                    scrimEdge to scrimColor.copy(alpha = 0.5f),
+                                    scrimMid to scrimColor.copy(alpha = 0.9f),
+                                    scrimFull to scrimColor,
+                                    1.0f to scrimColor,
+                                ),
                         ),
-            )
+                    ),
+        )
 
-            // 3. Content — logo always visible, slides up to reveal buttons
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 28.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Bottom,
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
+
+            val logoScale = 1.3f - (logoEase * 0.3f)
+            val logoOffsetY = (1f - logoEase) * 150f
             Column(
                 modifier =
                     Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 28.dp),
+                        .graphicsLayer {
+                            scaleX = logoScale
+                            scaleY = logoScale
+                            translationY = logoOffsetY * density
+                        },
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Bottom,
             ) {
-                // Push everything to the bottom half
-                Spacer(modifier = Modifier.weight(1f))
+                Text(
+                    text = "Welcome to",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = GoogleSansWeight.bold,
+                    fontFamily = condensedFamily,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+                cx.aswin.boxlore.core.designsystem.components.BoxLoreLogo(
+                    textColor = MaterialTheme.colorScheme.primary,
+                )
+            }
 
-                // Logo block — always visible, starts bigger and centered in white space,
-                // then scales down and nudges up to make room for buttons.
-                val logoScale = 1.3f - (logoEase * 0.3f) // 1.3 → 1.0
-                val logoOffsetY = (1f - logoEase) * 150f // starts 150dp lower, ends at 0
-                Column(
-                    modifier =
-                        Modifier
-                            .graphicsLayer {
-                                scaleX = logoScale
-                                scaleY = logoScale
-                                translationY = logoOffsetY * density
-                            },
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Text(
-                        text = "Welcome to",
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = GoogleSansWeight.bold,
-                        fontFamily = condensedFamily,
-                        color = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.padding(bottom = 8.dp),
-                    )
-                    cx.aswin.boxlore.core.designsystem.components.BoxLoreLogo(
-                        textColor = MaterialTheme.colorScheme.primary,
-                    )
-                }
+            Spacer(modifier = Modifier.height(32.dp))
 
-                Spacer(modifier = Modifier.height(32.dp))
+            val btn1RawProgress = ((entranceProgress.value - 0.45f) / 0.30f).coerceIn(0f, 1f)
+            val btn2RawProgress = ((entranceProgress.value - 0.53f) / 0.30f).coerceIn(0f, 1f)
+            val btn3RawProgress = ((entranceProgress.value - 0.61f) / 0.30f).coerceIn(0f, 1f)
 
-                // Staggered button reveal — starts after the logo has mostly moved up
-                val btn1RawProgress = ((entranceProgress.value - 0.45f) / 0.30f).coerceIn(0f, 1f)
-                val btn2RawProgress = ((entranceProgress.value - 0.53f) / 0.30f).coerceIn(0f, 1f)
-                val btn3RawProgress = ((entranceProgress.value - 0.61f) / 0.30f).coerceIn(0f, 1f)
-
-                val btn1Alpha = FastOutSlowInEasing.transform(btn1RawProgress)
-                val btn2Alpha = FastOutSlowInEasing.transform(btn2RawProgress)
-                val btn3Alpha = FastOutSlowInEasing.transform(btn3RawProgress)
+            val btn1Alpha = FastOutSlowInEasing.transform(btn1RawProgress)
+            val btn2Alpha = FastOutSlowInEasing.transform(btn2RawProgress)
+            val btn3Alpha = FastOutSlowInEasing.transform(btn3RawProgress)
 
                 // Primary CTA
                 Box(
@@ -638,13 +672,12 @@ private fun WelcomeScreen(
                 Spacer(modifier = Modifier.height(36.dp))
             }
         }
-    }
 }
 
 @Composable
 private fun CinematicBackgroundGrid(
-    entranceProgressProvider: () -> Float,
-    driftProgressProvider: () -> Float,
+    entranceProgress: Animatable<Float, AnimationVector1D>,
+    driftProgress: Animatable<Float, AnimationVector1D>,
 ) {
     val context = LocalContext.current
     val allCovers =
@@ -658,60 +691,49 @@ private fun CinematicBackgroundGrid(
 
     if (allCovers.isEmpty()) return
 
-    // 4 rows of covers — top half of the screen
     val row1Covers = remember(allCovers) { allCovers.filterIndexed { idx, _ -> idx % 4 == 0 } }
     val row2Covers = remember(allCovers) { allCovers.filterIndexed { idx, _ -> idx % 4 == 1 } }
     val row3Covers = remember(allCovers) { allCovers.filterIndexed { idx, _ -> idx % 4 == 2 } }
     val row4Covers = remember(allCovers) { allCovers.filterIndexed { idx, _ -> idx % 4 == 3 } }
 
-    val SmoothBurstEasing = CubicBezierEasing(0.25f, 0.1f, 0.25f, 1.0f)
+    val smoothBurstEasing = remember { CubicBezierEasing(0.25f, 0.1f, 0.25f, 1.0f) }
 
     Column(
-        modifier =
-            Modifier
-                .fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(CoverGapDp.dp, Alignment.Top),
     ) {
         Spacer(modifier = Modifier.height(8.dp))
         ScrollingRow(
             covers = row1Covers,
-            translationX = {
-                val ent = entranceProgressProvider()
-                val scrollProgress = (ent / 0.75f).coerceIn(0f, 1f)
-                val scrollEase = SmoothBurstEasing.transform(scrollProgress)
-                val drft = driftProgressProvider()
-                -2200f + (600f * scrollEase) + (732f * drft)
-            },
+            entranceProgress = entranceProgress,
+            driftProgress = driftProgress,
+            baseOffsetDp = -2200f,
+            direction = 1f,
+            entranceEasing = smoothBurstEasing,
         )
         ScrollingRow(
             covers = row2Covers,
-            translationX = {
-                val ent = entranceProgressProvider()
-                val scrollProgress = (ent / 0.75f).coerceIn(0f, 1f)
-                val scrollEase = SmoothBurstEasing.transform(scrollProgress)
-                val drft = driftProgressProvider()
-                -100f - (600f * scrollEase) - (732f * drft)
-            },
+            entranceProgress = entranceProgress,
+            driftProgress = driftProgress,
+            baseOffsetDp = -100f,
+            direction = -1f,
+            entranceEasing = smoothBurstEasing,
         )
         ScrollingRow(
             covers = row3Covers,
-            translationX = {
-                val ent = entranceProgressProvider()
-                val scrollProgress = (ent / 0.75f).coerceIn(0f, 1f)
-                val scrollEase = SmoothBurstEasing.transform(scrollProgress)
-                val drft = driftProgressProvider()
-                -2400f + (600f * scrollEase) + (732f * drft)
-            },
+            entranceProgress = entranceProgress,
+            driftProgress = driftProgress,
+            baseOffsetDp = -2400f,
+            direction = 1f,
+            entranceEasing = smoothBurstEasing,
         )
         ScrollingRow(
             covers = row4Covers,
-            translationX = {
-                val ent = entranceProgressProvider()
-                val scrollProgress = (ent / 0.75f).coerceIn(0f, 1f)
-                val scrollEase = SmoothBurstEasing.transform(scrollProgress)
-                val drft = driftProgressProvider()
-                -300f - (600f * scrollEase) - (732f * drft)
-            },
+            entranceProgress = entranceProgress,
+            driftProgress = driftProgress,
+            baseOffsetDp = -300f,
+            direction = -1f,
+            entranceEasing = smoothBurstEasing,
         )
     }
 }
@@ -719,29 +741,49 @@ private fun CinematicBackgroundGrid(
 @Composable
 private fun ScrollingRow(
     covers: List<Int>,
-    translationX: () -> Float,
+    entranceProgress: Animatable<Float, AnimationVector1D>,
+    driftProgress: Animatable<Float, AnimationVector1D>,
+    baseOffsetDp: Float,
+    direction: Float,
+    entranceEasing: Easing,
 ) {
-    // Take exactly 6 covers for a precise 732dp (6 * 122dp) seamless restart loop
-    val loopCovers = remember(covers) { covers.take(6) }
-    // Repeat covers list 20 times to simulate an infinite list within the bounds of scroll + drift
-    val infiniteCovers = remember(loopCovers) { List(20) { loopCovers }.flatten() }
+    val loopCovers =
+        remember(covers) {
+            if (covers.isEmpty()) {
+                emptyList()
+            } else {
+                List(CoverLoopCount) { index -> covers[index % covers.size] }
+            }
+        }
+    val tiledCovers =
+        remember(loopCovers) {
+            List(CoverLoopRepeats) { loopCovers }.flatten()
+        }
 
     Row(
         modifier =
             Modifier
                 .fillMaxWidth()
                 .wrapContentWidth(unbounded = true, align = Alignment.Start)
-                .graphicsLayer { this.translationX = translationX().dp.toPx() },
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                .graphicsLayer {
+                    val scrollProgress = (entranceProgress.value / 0.75f).coerceIn(0f, 1f)
+                    val scrollEase = entranceEasing.transform(scrollProgress)
+                    val translationDp =
+                        baseOffsetDp +
+                            direction * (600f * scrollEase) +
+                            direction * (CoverLoopPeriodDp.toFloat() * driftProgress.value)
+                    translationX = translationDp.dp.toPx()
+                },
+        horizontalArrangement = Arrangement.spacedBy(CoverGapDp.dp),
     ) {
-        infiniteCovers.forEach { drawableResId ->
+        tiledCovers.forEach { drawableResId ->
             val cardShape = RoundedCornerShape(16.dp)
-            Card(
+            Box(
                 modifier =
                     Modifier
-                        .size(110.dp),
-                shape = cardShape,
-                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                        .size(CoverCardDp.dp)
+                        .clip(cardShape)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
             ) {
                 Image(
                     painter = painterResource(id = drawableResId),


### PR DESCRIPTION
## Summary

- Smooth the onboarding welcome podcast-cover marquee (less start jitter).
- Add `refresh-latest-artifacts` workflow_dispatch to rebuild and clobber APK/AAB/SHA256SUMS on the existing Latest GitHub release (no version bump, no FCM).

## Motivation

The welcome cover grid hitching on first paint made launch feel rough. Separately, small post-release fixes should be shippable to GitHub downloaders without cutting a full new version or pinging everyone via FCM.

## What changed

### Onboarding welcome marquee

- Cover motion reads animatables only inside `graphicsLayer`; logo/CTAs recompose separately
- Fewer tiled Images per row (8 loops × 6 covers) instead of ~480 nodes
- Wait two frames before starting entrance/drift
- Grid ignores inset padding so status-bar settle doesn’t nudge covers
- Lighter clipped boxes instead of elevated cards
- Module README note

### Release workflow

- New operation `refresh-latest-artifacts` in Changelog and Release
- `prepare_release.py resolve-latest-refresh` requires Gradle version to match Latest tag
- Builds signed APK/AAB, verifies certs/versions, `gh release upload --clobber`
- Does **not** announce / FCM, rewrite notes, or move the tag

## Behavior & compatibility

- Welcome animation looks the same, should start smoother
- Refresh path only replaces GitHub Latest assets; Play Store unchanged
- Fails if master Gradle version ≠ Latest tag (intentional)

## Impact (required)

### User impact

- [x] `user-impact-medium`

### Listener impact

**What changes in the user’s life:**

The first onboarding screen’s moving podcast covers should start more smoothly, without the brief stutter at the beginning. (The release-workflow change only affects how maintainers ship GitHub download builds.)

### Backend

- [ ] `backend-change`

## Test plan

- [x] Local `resolve-latest-refresh` match/mismatch smoke check
- [ ] Cold open onboarding (clear app data) and watch cover marquee start
- [ ] After merge: Actions → Changelog and Release → `refresh-latest-artifacts` when ready to update Latest APK/AAB
- [ ] Required checks green before merge

## Notes

- Does not update Play Console; upload AAB there separately if needed.