### PR TITLE
feat(explore): use title-only curated cards in For You bento

### DIFF
--- a/feature/explore/README.md
+++ b/feature/explore/README.md
@@ -11,7 +11,7 @@ Owns Explore discovery and the Learn tab presentation: browse/search discovery, 
 - Explore list and selector-FAB clearance uses designsystem’s shared navigation-style / mini-player padding contract so controls remain above either app chrome.
 - Trending genre row (`ExploreGenreSelector`) uses shared `PillFilterChip` icon+label pills (same language as onboarding search) with All + top genres + **More** opening the existing Browse Genres bottom sheet.
 - For You mood row (`ExploreVibeChipRow`) sits in the same sticky header slot as genres (matched 8dp spacing). Soft 12dp capsules with per-mood icons + chromatic fill — distinct from stadium genre pills. Titles come from shared `CuratedMoods` (same as Home daypart rails). Mood results and search idle “Suggested for you” titles share scrollable `ExploreIconTitleHeader` (12dp top / 8dp bottom); suggestion blocks are left-aligned icon + title cards.
-- Explore For You recommendations use a featured hero plus staggered `ExploreEpisodeBentoCard`s (full recommendation list; not equal-height poster grid / not capped like Home’s 1+8).
+- Explore For You keeps a featured hero plus a staggered recommendation grid; body cards use shared `CuratedEpisodeCard` (square art, episode title only — no podcast/show name), matching Home “Based on Your Taste” card style without forcing equal-height rows.
 - `LearnScreen` and `LearnViewModel` for the Learn route (curiosity cards, queue/play actions).
 - `LearnHistoryScreen` and `LearnHistoryViewModel` for Learn history.
 - `LearnCuriosityHistoryStore` for Learn history persistence through prefs APIs.

--- a/feature/explore/src/main/java/cx/aswin/boxlore/feature/explore/ExploreScreen.kt
+++ b/feature/explore/src/main/java/cx/aswin/boxlore/feature/explore/ExploreScreen.kt
@@ -106,6 +106,7 @@ import coil.compose.SubcomposeAsyncImage
 import coil.compose.SubcomposeAsyncImageContent
 import cx.aswin.boxlore.core.designsystem.components.AnimatedShapesFallback
 import cx.aswin.boxlore.core.designsystem.components.BoxLoreLoader
+import cx.aswin.boxlore.core.designsystem.components.CuratedEpisodeCard
 import cx.aswin.boxlore.core.designsystem.components.OptimizedImage
 import cx.aswin.boxlore.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxlore.core.model.Podcast
@@ -611,7 +612,7 @@ fun ExploreContent(
                 }
 
                 if (state.selectedTab == 1) {
-                    // For You — same hero + equal-height poster grid as Home “Based on Your Taste”
+                    // For You — staggered bento layout; title-only posters (no show name) like Home taste cards
                     val recs = state.recommendations
                     val showContent = recs.isNotEmpty()
                     val showSkeletons = state.isRecommendationsLoading && recs.isEmpty()
@@ -664,12 +665,16 @@ fun ExploreContent(
                                 id = episode.podcastId ?: "",
                                 title = episode.podcastTitle ?: "Podcast",
                                 artist = "",
-                                imageUrl = episode.podcastImageUrl?.takeIf { it.isNotBlank() } ?: episode.imageUrl?.takeIf { it.isNotBlank() } ?: "",
+                                imageUrl = episode.podcastImageUrl?.takeIf { it.isNotBlank() }
+                                    ?: episode.imageUrl?.takeIf { it.isNotBlank() }
+                                    ?: "",
                                 description = "",
                                 genre = episode.podcastGenre ?: "Podcast"
                             )
-                            ExploreEpisodeBentoCard(
+                            CuratedEpisodeCard(
+                                podcast = parentPodcast,
                                 episode = episode,
+                                showSubtitle = false,
                                 onClick = {
                                     cx.aswin.boxlore.core.analytics.AnalyticsHelper.trackExploreRecommendationCardTapped(
                                         episodeId = episode.id,
@@ -679,7 +684,7 @@ fun ExploreContent(
                                         positionIndex = index + 1
                                     )
                                     onEpisodeClick(episode, parentPodcast)
-                                }
+                                },
                             )
                         }
                     }


### PR DESCRIPTION
## Summary

- Explore For You body recommendations use shared `CuratedEpisodeCard` (square art, episode title only) instead of `ExploreEpisodeBentoCard` with podcast/show name.
- Keeps the existing staggered bento layout — no equal-height poster grid or Home-style 1+8 cap.

## Motivation

For You should share Home “Based on Your Taste” card chrome (calmer title-only posters) without forcing every card into the same-height grid.

## What changed

- `ExploreScreen` For You tab: staggered items after the hero render `CuratedEpisodeCard(showSubtitle = false)`.
- Module README updated to describe the layout + card style.

## Behavior & compatibility

- Same recommendation list and hero; only body card presentation changes (no podcast name under art).
- Search and other Explore surfaces still use `ExploreEpisodeBentoCard` where applicable.

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-high`
- [ ] `user-impact-medium`
- [x] `user-impact-low`
- [ ] `no-user-impact`

## Test plan

- [ ] Open Explore → For You: hero unchanged; body cards are square title-only posters in a staggered grid
- [ ] Confirm podcast/show names are not shown under body cards
- [ ] Confirm full recommendation list still loads (not capped at 9)
- [ ] Spot-check Explore search episode results still show the previous bento card (with show name if applicable)