### PR TITLE
fix(onboarding): restore search/OPML suggestions handoff loader and seed filtering

### DIFF
--- a/feature/onboarding/README.md
+++ b/feature/onboarding/README.md
@@ -12,7 +12,8 @@ Owns first-run onboarding presentation: genre selection, search-based onboarding
 - `GenreOnboardingScreen`, `SearchOnboardingScreen`, `ImportOnboardingScreen`, `AiOnboardingScreen`, `AiChatOnboardingScreen`, and `AiSuggestionsScreen`. Search uses progressive Meili typeahead + hybrid `/search` (`searchPodcastsGrouped`) with **Matches** / **Also found** sections. Search genre chips use shared `PillFilterChip` from `:core:designsystem`. AI suggestions use the shared 11-country `RegionSegmentedSelector` (persisted via `UserPreferencesRepository.setRegion`, which also seeds recommended content languages). Curriculum / genre-synth / similar-shows requests use `discoveryLocaleForRegion` so `country` and `languages` stay canonical together; the proxy expands and `startsWith`-filters podcast languages.
 - Suggestions (“Designed for you”) is a **single screen**: one compact headline, a single-row scrollable taste-lane chip strip (full titles, no ellipsis; per-lane selection badges), a one-line purpose + Select all toolbar, and a 2-column select grid. Descriptions open in a Material bottom sheet. Finish CTA stays pinned. Shared by genre, AI, search, and OPML flows.
 - `AiSuggestionCards`, AI onboarding components, option icons, chat input, and chat message list logic.
-- Pure helpers including `OnboardingGenreLimits`, `OnboardingSearchBackStep`, `OnboardingCurriculumLogic`, `OnboardingSuggestionsLanes`, and `OnboardingDiscoveryLocale`.
+- Pure helpers including `OnboardingGenreLimits`, `OnboardingSearchBackStep`, `OnboardingCurriculumLogic`, `OnboardingSuggestionsLanes`, `OnboardingSuggestionsPresentation`, and `OnboardingDiscoveryLocale`.
+- Search / OPML → suggestions handoff: continue clears stale curriculum/charts, shows a loader while `isAiLoading` / `isSynthesizing` (via `OnboardingSuggestionsPresentation.isLoading`), subscribes seed picks, then filters those seed IDs out of similar-shows lanes so the grid only offers new shows. Seeds stay in `selectedPodcasts` for finish counting; similar shows are **not** auto-selected. Search CTA is “Continue with N”; suggestions finish uses “Start without adding” / “Add N & start”. Back to SEARCH / Welcome clears suggestion payloads but keeps picks and search query.
 
 ## Internal structure
 
@@ -33,6 +34,7 @@ src/main/java/cx/aswin/boxlore/feature/onboarding/
   OnboardingScreen.kt
   OnboardingSearchBackStep.kt
   OnboardingSuggestionsLanes.kt
+  OnboardingSuggestionsPresentation.kt
   OnboardingUiModels.kt
   OnboardingViewModel.kt
   OnboardingViewModelAi.kt
@@ -63,7 +65,7 @@ src/main/java/cx/aswin/boxlore/feature/onboarding/
 ## Testing notes
 
 - Unit tests live under `feature/onboarding/src/test`.
-- Existing coverage includes genre limits, search back-step behavior, curriculum logic, AI option icons, and AI chat message list logic.
+- Existing coverage includes genre limits, search back-step behavior, curriculum logic, suggestions presentation (loading gate / seed filter / back-clear), AI option icons, and AI chat message list logic.
 - ViewModel tests should use fakes for prefs, catalog, network, and analytics dependencies.
 
 ```bash

--- a/feature/onboarding/README.md
+++ b/feature/onboarding/README.md
@@ -40,6 +40,7 @@ src/main/java/cx/aswin/boxlore/feature/onboarding/
   OnboardingViewModelAi.kt
   OnboardingViewModelGenre.kt
   OnboardingViewModelSearch.kt
+  OnboardingViewModelSimilarShows.kt
   SearchOnboardingScreen.kt
 ```
 ## Dependencies

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/AiSuggestionCards.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/AiSuggestionCards.kt
@@ -129,37 +129,43 @@ private fun SuggestionCardArtwork(
     isSubscribed: Boolean,
     onOpenDetails: (Podcast) -> Unit,
 ) {
+    // Match [FeedMediaCard]: round art bottom corners so the text band peeks through as a soft curve.
+    val artBottomShape = RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp)
     Box(
         modifier =
             Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f),
     ) {
-        OptimizedImage(
-            url = podcast.imageUrl,
-            proxyWidth = 400,
-            contentDescription = podcast.title,
-            contentScale = ContentScale.Crop,
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .clip(RoundedCornerShape(bottomStart = 14.dp, bottomEnd = 14.dp)),
-        )
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .background(
-                        Brush.verticalGradient(
-                            colorStops =
-                                arrayOf(
-                                    0f to Color.Transparent,
-                                    0.55f to Color.Transparent,
-                                    1f to Color.Black.copy(alpha = 0.45f),
-                                ),
+                    .clip(artBottomShape),
+        ) {
+            OptimizedImage(
+                url = podcast.imageUrl,
+                proxyWidth = 400,
+                contentDescription = podcast.title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                colorStops =
+                                    arrayOf(
+                                        0f to Color.Transparent,
+                                        0.55f to Color.Transparent,
+                                        1f to Color.Black.copy(alpha = 0.45f),
+                                    ),
+                            ),
                         ),
-                    ),
-        )
+            )
+        }
         SuggestionCardGenreChip(genre = podcast.genre.trim())
         IconButton(
             onClick = { onOpenDetails(podcast) },

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/AiSuggestionsScreen.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/AiSuggestionsScreen.kt
@@ -83,14 +83,8 @@ internal fun AiSuggestionsScreen(
     onRetry: () -> Unit,
     onFinish: () -> Unit,
 ) {
-    val isLoading =
-        uiState.isLoadingPodcasts &&
-            uiState.aiCurriculumRows.isEmpty() &&
-            uiState.genreChartsPodcasts.isEmpty()
-    val isError =
-        uiState.onboardingError != null &&
-            uiState.aiCurriculumRows.isEmpty() &&
-            uiState.genreChartsPodcasts.isEmpty()
+    val isLoading = OnboardingSuggestionsPresentation.isLoading(uiState)
+    val isError = OnboardingSuggestionsPresentation.isError(uiState)
 
     val lanes =
         remember(uiState.aiCurriculumRows, uiState.genreChartsPodcasts, uiState.selectedGenres) {
@@ -519,58 +513,46 @@ private fun SuggestionsFinishBar(
 internal fun suggestionsFinishCtaLabel(
     uiState: OnboardingUiState,
     selectedCount: Int,
-): String {
-    if (!uiState.reachedSuggestionsViaSearchFlow) {
-        return if (selectedCount > 0) {
-            "Subscribe & start · $selectedCount"
-        } else {
-            "Start without subscribing"
-        }
-    }
-    val recommendedIds =
-        uiState.aiCurriculumRows
-            .flatMap { it.podcasts }
-            .map { it.id.toString() }
-            .toSet()
-    val selectedRecommendationsCount = uiState.subscribedPodcastIds.count { it in recommendedIds }
-    return if (selectedRecommendationsCount > 0) {
-        "Subscribe & start · +$selectedRecommendationsCount recommended"
-    } else {
-        "Start without subscribing"
-    }
-}
+): String = OnboardingSuggestionsPresentation.finishCtaLabel(uiState, selectedCount)
 
 @Composable
 private fun SuggestionsLoadingState(
     uiState: OnboardingUiState,
     modifier: Modifier = Modifier,
 ) {
+    val copy = OnboardingSuggestionsPresentation.loadingCopy(uiState)
     Box(
         modifier = modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+            modifier = Modifier.padding(horizontal = 32.dp, vertical = 24.dp),
         ) {
             BoxLoreLoader.Expressive(size = 80.dp)
-            Text(
-                text =
-                    when {
-                        uiState.reachedSuggestionsViaOpmlFlow ->
-                            "Your OPML shows are subscribed!\nGathering new shows inspired by your library…"
-                        uiState.reachedSuggestionsViaSearchFlow ->
-                            "Subscribed to ${uiState.selectedPodcasts.size} shows!\nFinding similar shows you might love…"
-                        else -> "Synthesizing your feed…"
-                    },
-                style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        fontWeight = GoogleSansWeight.bold,
-                        textAlign = TextAlign.Center,
-                    ),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    text = copy.title,
+                    style =
+                        MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = GoogleSansWeight.bold,
+                            textAlign = TextAlign.Center,
+                        ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Text(
+                    text = copy.subtitle,
+                    style =
+                        MaterialTheme.typography.bodyLarge.copy(
+                            textAlign = TextAlign.Center,
+                        ),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
     }
 }

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingSuggestionsPresentation.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingSuggestionsPresentation.kt
@@ -114,5 +114,8 @@ internal object OnboardingSuggestionsPresentation {
             aiLoadingStage = AiLoadingStage.IDLE,
             onboardingError = null,
             suggestionSeedCount = 0,
+            reachedSuggestionsViaSearchFlow = false,
+            reachedSuggestionsViaOpmlFlow = false,
+            reachedSuggestionsViaAiFlow = false,
         )
 }

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingSuggestionsPresentation.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingSuggestionsPresentation.kt
@@ -1,0 +1,118 @@
+package cx.aswin.boxlore.feature.onboarding
+
+import cx.aswin.boxlore.core.network.model.OnboardingCurriculumRowDto
+
+/**
+ * Pure presentation helpers for the shared suggestions screen (genre / AI / search / OPML).
+ */
+internal object OnboardingSuggestionsPresentation {
+    fun isLoading(uiState: OnboardingUiState): Boolean {
+        val awaitingContent =
+            uiState.isLoadingPodcasts || uiState.isAiLoading || uiState.isSynthesizing
+        return awaitingContent &&
+            uiState.aiCurriculumRows.isEmpty() &&
+            uiState.genreChartsPodcasts.isEmpty()
+    }
+
+    fun isError(uiState: OnboardingUiState): Boolean =
+        uiState.onboardingError != null &&
+            uiState.aiCurriculumRows.isEmpty() &&
+            uiState.genreChartsPodcasts.isEmpty()
+
+    /**
+     * Drops seed / already-picked show IDs from similar-shows curriculum rows so the
+     * suggestions grid only offers new shows. Empty rows are removed.
+     */
+    fun filterCurriculumRowsExcluding(
+        rows: List<OnboardingCurriculumRowDto>,
+        excludeIds: Set<String>,
+    ): List<OnboardingCurriculumRowDto> {
+        if (excludeIds.isEmpty()) return rows.filter { it.podcasts.isNotEmpty() }
+        return rows.mapNotNull { row ->
+            val kept =
+                row.podcasts.filter { podcast ->
+                    podcast.id.toString() !in excludeIds
+                }
+            if (kept.isEmpty()) null else row.copy(podcasts = kept)
+        }
+    }
+
+    /** Finish-bar CTA on the shared suggestions screen. */
+    fun finishCtaLabel(
+        uiState: OnboardingUiState,
+        selectedCount: Int,
+    ): String {
+        val isSeedFlow =
+            uiState.reachedSuggestionsViaSearchFlow || uiState.reachedSuggestionsViaOpmlFlow
+        if (isSeedFlow) {
+            val recommendedIds =
+                uiState.aiCurriculumRows
+                    .flatMap { it.podcasts }
+                    .map { it.id.toString() }
+                    .toSet()
+            val selectedRecommendationsCount =
+                uiState.subscribedPodcastIds.count { it in recommendedIds }
+            return if (selectedRecommendationsCount > 0) {
+                "Add $selectedRecommendationsCount & start"
+            } else {
+                "Start without adding"
+            }
+        }
+        return if (selectedCount > 0) {
+            "Subscribe & start · $selectedCount"
+        } else {
+            "Start without subscribing"
+        }
+    }
+
+    data class LoadingCopy(
+        val title: String,
+        val subtitle: String,
+    )
+
+    fun loadingCopy(uiState: OnboardingUiState): LoadingCopy =
+        when {
+            uiState.reachedSuggestionsViaOpmlFlow ->
+                LoadingCopy(
+                    title = "Import complete",
+                    subtitle = "Finding shows inspired by your library…",
+                )
+            uiState.reachedSuggestionsViaSearchFlow ->
+                LoadingCopy(
+                    title =
+                        if (uiState.suggestionSeedCount > 0) {
+                            "Subscribed to ${uiState.suggestionSeedCount} " +
+                                if (uiState.suggestionSeedCount == 1) "show" else "shows"
+                        } else {
+                            "Shows subscribed"
+                        },
+                    subtitle = "Looking for more you might like…",
+                )
+            else ->
+                LoadingCopy(
+                    title = "Designing your feed",
+                    subtitle = "Matching shows to your taste…",
+                )
+        }
+
+    /** Whether back from suggestions should wipe curriculum/charts (search / OPML paths). */
+    fun shouldClearSuggestionPayloadOnBack(nextStep: OnboardingStep): Boolean =
+        nextStep == OnboardingStep.SEARCH || nextStep == OnboardingStep.WELCOME
+
+    /** Clears suggestion payloads / loading flags while preserving picks and search query. */
+    fun withClearedSuggestionPayload(
+        state: OnboardingUiState,
+        nextStep: OnboardingStep,
+    ): OnboardingUiState =
+        state.copy(
+            currentStep = nextStep,
+            aiCurriculumRows = emptyList(),
+            genreChartsPodcasts = emptyList(),
+            isAiLoading = false,
+            isSynthesizing = false,
+            isLoadingPodcasts = false,
+            aiLoadingStage = AiLoadingStage.IDLE,
+            onboardingError = null,
+            suggestionSeedCount = 0,
+        )
+}

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingUiModels.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingUiModels.kt
@@ -54,6 +54,8 @@ data class OnboardingUiState(
     val reachedSuggestionsViaAiFlow: Boolean = false,
     val reachedSuggestionsViaSearchFlow: Boolean = false,
     val reachedSuggestionsViaOpmlFlow: Boolean = false,
+    /** Count of search/OPML seed shows used for the suggestions loader copy (stable during fetch). */
+    val suggestionSeedCount: Int = 0,
     val hasSentCustomInput: Boolean = false,
     val popularPodcasts: List<Podcast> = emptyList(),
     val isPopularLoading: Boolean = false,

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelAi.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelAi.kt
@@ -490,7 +490,15 @@ internal fun OnboardingViewModel.navigateBackFromSuggestions() {
             state.reachedSuggestionsViaOpmlFlow -> OnboardingStep.WELCOME
             else -> OnboardingStep.LENGTH_PICKER
         }
-    _uiState.update { it.copy(currentStep = nextStep) }
+    val clearSuggestionPayload =
+        OnboardingSuggestionsPresentation.shouldClearSuggestionPayloadOnBack(nextStep)
+    _uiState.update {
+        if (clearSuggestionPayload) {
+            OnboardingSuggestionsPresentation.withClearedSuggestionPayload(it, nextStep)
+        } else {
+            it.copy(currentStep = nextStep)
+        }
+    }
     if (nextStep == OnboardingStep.AI_ONBOARDING) {
         turnStartMs = System.currentTimeMillis()
     } else if (nextStep == OnboardingStep.LENGTH_PICKER) {

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelAi.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelAi.kt
@@ -477,6 +477,8 @@ internal fun OnboardingViewModel.navigateToSuggestions() {
         it.copy(
             currentStep = OnboardingStep.AI_SUGGESTIONS,
             reachedSuggestionsViaAiFlow = true,
+            reachedSuggestionsViaSearchFlow = false,
+            reachedSuggestionsViaOpmlFlow = false,
         )
     }
 }

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelSearch.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelSearch.kt
@@ -4,8 +4,6 @@ import android.util.Log
 import androidx.lifecycle.viewModelScope
 import cx.aswin.boxlore.core.analytics.AnalyticsHelper
 import cx.aswin.boxlore.core.model.Podcast
-import cx.aswin.boxlore.core.network.model.OnboardingSelectedShowDto
-import cx.aswin.boxlore.core.network.model.OnboardingSimilarShowsRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
@@ -353,94 +351,6 @@ fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<P
         region = _uiState.value.currentRegion,
         errorContext = "generateRecommendationsFromOpml",
     )
-}
-
-/**
- * Shared search/OPML similar-shows fetch: clear payloads, call API, filter seed IDs, no auto-select.
- */
-private fun OnboardingViewModel.launchSimilarShowsFetch(
-    seedShows: List<Podcast>,
-    seedIds: Set<String>,
-    seedCount: Int,
-    region: String,
-    errorContext: String,
-    beforeApi: suspend () -> Unit = {},
-) {
-    val finalAction: () -> Unit = {
-        _uiState.update {
-            it.copy(
-                isAiLoading = true,
-                isSynthesizing = true,
-                aiLoadingStage = AiLoadingStage.SYNTHESIZING_PREFERENCES,
-                onboardingError = null,
-                aiCurriculumRows = emptyList(),
-                genreChartsPodcasts = emptyList(),
-                suggestionSeedCount = seedCount,
-            )
-        }
-        viewModelScope.launch {
-            try {
-                beforeApi()
-                val locale = discoveryLocaleForRegion(region)
-                val request =
-                    OnboardingSimilarShowsRequest(
-                        shows =
-                            seedShows.distinctBy { it.title.lowercase().trim() }.take(20).map {
-                                OnboardingSelectedShowDto(
-                                    title = it.title,
-                                    description = it.description ?: "",
-                                )
-                            },
-                        country = locale.country,
-                        languages = locale.languages,
-                    )
-
-                val response =
-                    withContext(Dispatchers.IO) {
-                        podcastRepository.api
-                            .getSimilarShows(
-                                publicKey = podcastRepository.publicKey,
-                                request = request,
-                            ).execute()
-                    }
-
-                if (response.isSuccessful && response.body() != null) {
-                    val rows =
-                        OnboardingSuggestionsPresentation.filterCurriculumRowsExcluding(
-                            rows =
-                                response.body()!!.map {
-                                    it.copy(episodes = emptyList())
-                                },
-                            excludeIds = seedIds,
-                        )
-                    _uiState.update { state ->
-                        state.copy(
-                            aiCurriculumRows = rows,
-                            isAiLoading = false,
-                            isSynthesizing = false,
-                            aiLoadingStage = AiLoadingStage.IDLE,
-                            onboardingError = null,
-                        )
-                    }
-                } else {
-                    throw Exception("Failed to load similar shows from backend: ${response.code()}")
-                }
-            } catch (e: Exception) {
-                Log.e("OnboardingViewModel", "Error in $errorContext", e)
-                _uiState.update { state ->
-                    state.copy(
-                        isAiLoading = false,
-                        isSynthesizing = false,
-                        aiLoadingStage = AiLoadingStage.IDLE,
-                        onboardingError =
-                            "We encountered a temporary issue generating recommendations. Let's try again.",
-                    )
-                }
-            }
-        }
-    }
-    lastFailedAction = finalAction
-    finalAction()
 }
 
 internal fun OnboardingViewModel.skipOnboarding(onDone: () -> Unit) {

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelSearch.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelSearch.kt
@@ -6,7 +6,6 @@ import cx.aswin.boxlore.core.analytics.AnalyticsHelper
 import cx.aswin.boxlore.core.model.Podcast
 import cx.aswin.boxlore.core.network.model.OnboardingSelectedShowDto
 import cx.aswin.boxlore.core.network.model.OnboardingSimilarShowsRequest
-import cx.aswin.boxlore.core.network.model.toPodcast
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
@@ -309,86 +308,18 @@ internal fun OnboardingViewModel.generateRecommendationsFromSearch() {
         )
     }
 
-    val finalAction: () -> Unit = {
-        _uiState.update {
-            it.copy(
-                isAiLoading = true,
-                isSynthesizing = true,
-                aiLoadingStage = AiLoadingStage.SYNTHESIZING_PREFERENCES,
-                onboardingError = null,
-                aiCurriculumRows = emptyList(),
-                genreChartsPodcasts = emptyList(),
-                suggestionSeedCount = seedCount,
-            )
-        }
-        viewModelScope.launch {
-            try {
-                // Subscribe to manually selected shows first
-                for (podcast in selectedShows) {
-                    subscriptionRepository.subscribe(podcast)
-                }
-
-                val locale = discoveryLocaleForRegion(currentState.currentRegion)
-                val request =
-                    OnboardingSimilarShowsRequest(
-                        shows =
-                            selectedShows.distinctBy { it.title.lowercase().trim() }.take(20).map {
-                                OnboardingSelectedShowDto(
-                                    title = it.title,
-                                    description = it.description ?: "",
-                                )
-                            },
-                        country = locale.country,
-                        languages = locale.languages,
-                    )
-
-                val response =
-                    withContext(Dispatchers.IO) {
-                        podcastRepository.api
-                            .getSimilarShows(
-                                publicKey = podcastRepository.publicKey,
-                                request = request,
-                            ).execute()
-                    }
-
-                if (response.isSuccessful && response.body() != null) {
-                    val rows =
-                        OnboardingSuggestionsPresentation.filterCurriculumRowsExcluding(
-                            rows =
-                                response.body()!!.map {
-                                    it.copy(episodes = emptyList())
-                                },
-                            excludeIds = seedIds,
-                        )
-
-                    // Seeds stay selected/subscribed; do not auto-check similar-show recommendations.
-                    _uiState.update { state ->
-                        state.copy(
-                            aiCurriculumRows = rows,
-                            isAiLoading = false,
-                            isSynthesizing = false,
-                            aiLoadingStage = AiLoadingStage.IDLE,
-                            onboardingError = null,
-                        )
-                    }
-                } else {
-                    throw Exception("Failed to load similar shows from backend: ${response.code()}")
-                }
-            } catch (e: Exception) {
-                Log.e("OnboardingViewModel", "Error in generateRecommendationsFromSearch", e)
-                _uiState.update { state ->
-                    state.copy(
-                        isAiLoading = false,
-                        isSynthesizing = false,
-                        aiLoadingStage = AiLoadingStage.IDLE,
-                        onboardingError = "We encountered a temporary issue generating recommendations. Let's try again.",
-                    )
-                }
+    launchSimilarShowsFetch(
+        seedShows = selectedShows,
+        seedIds = seedIds,
+        seedCount = seedCount,
+        region = currentState.currentRegion,
+        errorContext = "generateRecommendationsFromSearch",
+        beforeApi = {
+            for (podcast in selectedShows) {
+                subscriptionRepository.subscribe(podcast)
             }
-        }
-    }
-    lastFailedAction = finalAction
-    finalAction()
+        },
+    )
 }
 
 fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<Podcast>) {
@@ -415,6 +346,26 @@ fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<P
         )
     }
 
+    launchSimilarShowsFetch(
+        seedShows = importedPodcasts,
+        seedIds = seedIds,
+        seedCount = seedCount,
+        region = _uiState.value.currentRegion,
+        errorContext = "generateRecommendationsFromOpml",
+    )
+}
+
+/**
+ * Shared search/OPML similar-shows fetch: clear payloads, call API, filter seed IDs, no auto-select.
+ */
+private fun OnboardingViewModel.launchSimilarShowsFetch(
+    seedShows: List<Podcast>,
+    seedIds: Set<String>,
+    seedCount: Int,
+    region: String,
+    errorContext: String,
+    beforeApi: suspend () -> Unit = {},
+) {
     val finalAction: () -> Unit = {
         _uiState.update {
             it.copy(
@@ -429,11 +380,12 @@ fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<P
         }
         viewModelScope.launch {
             try {
-                val locale = discoveryLocaleForRegion(_uiState.value.currentRegion)
+                beforeApi()
+                val locale = discoveryLocaleForRegion(region)
                 val request =
                     OnboardingSimilarShowsRequest(
                         shows =
-                            importedPodcasts.distinctBy { it.title.lowercase().trim() }.take(20).map {
+                            seedShows.distinctBy { it.title.lowercase().trim() }.take(20).map {
                                 OnboardingSelectedShowDto(
                                     title = it.title,
                                     description = it.description ?: "",
@@ -461,8 +413,6 @@ fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<P
                                 },
                             excludeIds = seedIds,
                         )
-
-                    // Imported shows stay selected; do not auto-check similar-show recommendations.
                     _uiState.update { state ->
                         state.copy(
                             aiCurriculumRows = rows,
@@ -476,13 +426,14 @@ fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<P
                     throw Exception("Failed to load similar shows from backend: ${response.code()}")
                 }
             } catch (e: Exception) {
-                Log.e("OnboardingViewModel", "Error in generateRecommendationsFromOpml", e)
+                Log.e("OnboardingViewModel", "Error in $errorContext", e)
                 _uiState.update { state ->
                     state.copy(
                         isAiLoading = false,
                         isSynthesizing = false,
                         aiLoadingStage = AiLoadingStage.IDLE,
-                        onboardingError = "We encountered a temporary issue generating recommendations. Let's try again.",
+                        onboardingError =
+                            "We encountered a temporary issue generating recommendations. Let's try again.",
                     )
                 }
             }

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelSearch.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelSearch.kt
@@ -290,6 +290,9 @@ internal fun OnboardingViewModel.generateRecommendationsFromSearch() {
     val selectedShows = currentState.selectedPodcasts.values.toList()
     if (selectedShows.isEmpty()) return
 
+    val seedIds = selectedShows.map { it.id }.toSet()
+    val seedCount = seedIds.size
+
     _uiState.update {
         it.copy(
             currentStep = OnboardingStep.AI_SUGGESTIONS,
@@ -297,8 +300,12 @@ internal fun OnboardingViewModel.generateRecommendationsFromSearch() {
             isSynthesizing = true,
             aiLoadingStage = AiLoadingStage.SYNTHESIZING_PREFERENCES,
             onboardingError = null,
+            aiCurriculumRows = emptyList(),
+            genreChartsPodcasts = emptyList(),
+            suggestionSeedCount = seedCount,
             reachedSuggestionsViaSearchFlow = true,
             reachedSuggestionsViaAiFlow = false,
+            reachedSuggestionsViaOpmlFlow = false,
         )
     }
 
@@ -309,6 +316,9 @@ internal fun OnboardingViewModel.generateRecommendationsFromSearch() {
                 isSynthesizing = true,
                 aiLoadingStage = AiLoadingStage.SYNTHESIZING_PREFERENCES,
                 onboardingError = null,
+                aiCurriculumRows = emptyList(),
+                genreChartsPodcasts = emptyList(),
+                suggestionSeedCount = seedCount,
             )
         }
         viewModelScope.launch {
@@ -343,34 +353,21 @@ internal fun OnboardingViewModel.generateRecommendationsFromSearch() {
 
                 if (response.isSuccessful && response.body() != null) {
                     val rows =
-                        response.body()!!.map {
-                            it.copy(episodes = emptyList())
-                        }
+                        OnboardingSuggestionsPresentation.filterCurriculumRowsExcluding(
+                            rows =
+                                response.body()!!.map {
+                                    it.copy(episodes = emptyList())
+                                },
+                            excludeIds = seedIds,
+                        )
 
-                    val newPodcasts = rows.flatMap { it.podcasts }.map { it.toPodcast() }
-                    // Filter out podcasts that are already in selectedPodcasts to avoid resetting selections
-                    val defaultSelectedIds =
-                        buildSet {
-                            rows.forEach { row ->
-                                row.podcasts.firstOrNull()?.let { add(it.id.toString()) }
-                            }
-                        }
-                    // Only auto-select recommendations that are NOT already manually selected
-                    val recommendationsToSelect =
-                        newPodcasts.filter {
-                            it.id in defaultSelectedIds &&
-                                it.id !in currentState.selectedPodcasts.keys
-                        }
-
+                    // Seeds stay selected/subscribed; do not auto-check similar-show recommendations.
                     _uiState.update { state ->
-                        val newSelected = state.selectedPodcasts + recommendationsToSelect.associateBy { it.id }
                         state.copy(
                             aiCurriculumRows = rows,
                             isAiLoading = false,
                             isSynthesizing = false,
                             aiLoadingStage = AiLoadingStage.IDLE,
-                            selectedPodcasts = newSelected,
-                            subscribedPodcastIds = newSelected.keys,
                             onboardingError = null,
                         )
                     }
@@ -397,6 +394,9 @@ internal fun OnboardingViewModel.generateRecommendationsFromSearch() {
 fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<Podcast>) {
     if (importedPodcasts.isEmpty()) return
 
+    val seedIds = importedPodcasts.map { it.id }.toSet()
+    val seedCount = seedIds.size
+
     _uiState.update {
         it.copy(
             currentStep = OnboardingStep.AI_SUGGESTIONS,
@@ -404,10 +404,14 @@ fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<P
             isSynthesizing = true,
             aiLoadingStage = AiLoadingStage.SYNTHESIZING_PREFERENCES,
             onboardingError = null,
+            aiCurriculumRows = emptyList(),
+            genreChartsPodcasts = emptyList(),
+            suggestionSeedCount = seedCount,
             reachedSuggestionsViaSearchFlow = false,
             reachedSuggestionsViaAiFlow = false,
             reachedSuggestionsViaOpmlFlow = true,
             selectedPodcasts = importedPodcasts.associateBy { p -> p.id },
+            subscribedPodcastIds = seedIds,
         )
     }
 
@@ -418,6 +422,9 @@ fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<P
                 isSynthesizing = true,
                 aiLoadingStage = AiLoadingStage.SYNTHESIZING_PREFERENCES,
                 onboardingError = null,
+                aiCurriculumRows = emptyList(),
+                genreChartsPodcasts = emptyList(),
+                suggestionSeedCount = seedCount,
             )
         }
         viewModelScope.launch {
@@ -447,32 +454,21 @@ fun OnboardingViewModel.generateRecommendationsFromOpml(importedPodcasts: List<P
 
                 if (response.isSuccessful && response.body() != null) {
                     val rows =
-                        response.body()!!.map {
-                            it.copy(episodes = emptyList())
-                        }
+                        OnboardingSuggestionsPresentation.filterCurriculumRowsExcluding(
+                            rows =
+                                response.body()!!.map {
+                                    it.copy(episodes = emptyList())
+                                },
+                            excludeIds = seedIds,
+                        )
 
-                    val newPodcasts = rows.flatMap { it.podcasts }.map { it.toPodcast() }
-                    val defaultSelectedIds =
-                        buildSet {
-                            rows.forEach { row ->
-                                row.podcasts.firstOrNull()?.let { add(it.id.toString()) }
-                            }
-                        }
-                    val recommendationsToSelect =
-                        newPodcasts.filter {
-                            it.id in defaultSelectedIds &&
-                                it.id !in importedPodcasts.map { p -> p.id }
-                        }
-
+                    // Imported shows stay selected; do not auto-check similar-show recommendations.
                     _uiState.update { state ->
-                        val newSelected = state.selectedPodcasts + recommendationsToSelect.associateBy { it.id }
                         state.copy(
                             aiCurriculumRows = rows,
                             isAiLoading = false,
                             isSynthesizing = false,
                             aiLoadingStage = AiLoadingStage.IDLE,
-                            selectedPodcasts = newSelected,
-                            subscribedPodcastIds = newSelected.keys,
                             onboardingError = null,
                         )
                     }

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelSimilarShows.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/OnboardingViewModelSimilarShows.kt
@@ -1,0 +1,99 @@
+package cx.aswin.boxlore.feature.onboarding
+
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.core.network.model.OnboardingSelectedShowDto
+import cx.aswin.boxlore.core.network.model.OnboardingSimilarShowsRequest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Shared search/OPML similar-shows fetch: clear payloads, call API, filter seed IDs, no auto-select.
+ */
+internal fun OnboardingViewModel.launchSimilarShowsFetch(
+    seedShows: List<Podcast>,
+    seedIds: Set<String>,
+    seedCount: Int,
+    region: String,
+    errorContext: String,
+    beforeApi: suspend () -> Unit = {},
+) {
+    val finalAction: () -> Unit = {
+        _uiState.update {
+            it.copy(
+                isAiLoading = true,
+                isSynthesizing = true,
+                aiLoadingStage = AiLoadingStage.SYNTHESIZING_PREFERENCES,
+                onboardingError = null,
+                aiCurriculumRows = emptyList(),
+                genreChartsPodcasts = emptyList(),
+                suggestionSeedCount = seedCount,
+            )
+        }
+        viewModelScope.launch {
+            try {
+                beforeApi()
+                val locale = discoveryLocaleForRegion(region)
+                val request =
+                    OnboardingSimilarShowsRequest(
+                        shows =
+                            seedShows.distinctBy { it.title.lowercase().trim() }.take(20).map {
+                                OnboardingSelectedShowDto(
+                                    title = it.title,
+                                    description = it.description ?: "",
+                                )
+                            },
+                        country = locale.country,
+                        languages = locale.languages,
+                    )
+
+                val response =
+                    withContext(Dispatchers.IO) {
+                        podcastRepository.api
+                            .getSimilarShows(
+                                publicKey = podcastRepository.publicKey,
+                                request = request,
+                            ).execute()
+                    }
+
+                if (response.isSuccessful && response.body() != null) {
+                    val rows =
+                        OnboardingSuggestionsPresentation.filterCurriculumRowsExcluding(
+                            rows =
+                                response.body()!!.map {
+                                    it.copy(episodes = emptyList())
+                                },
+                            excludeIds = seedIds,
+                        )
+                    _uiState.update { state ->
+                        state.copy(
+                            aiCurriculumRows = rows,
+                            isAiLoading = false,
+                            isSynthesizing = false,
+                            aiLoadingStage = AiLoadingStage.IDLE,
+                            onboardingError = null,
+                        )
+                    }
+                } else {
+                    throw Exception("Failed to load similar shows from backend: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                Log.e("OnboardingViewModel", "Error in $errorContext", e)
+                _uiState.update { state ->
+                    state.copy(
+                        isAiLoading = false,
+                        isSynthesizing = false,
+                        aiLoadingStage = AiLoadingStage.IDLE,
+                        onboardingError =
+                            "We encountered a temporary issue generating recommendations. Let's try again.",
+                    )
+                }
+            }
+        }
+    }
+    lastFailedAction = finalAction
+    finalAction()
+}

--- a/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/SearchOnboardingScreen.kt
+++ b/feature/onboarding/src/main/java/cx/aswin/boxlore/feature/onboarding/SearchOnboardingScreen.kt
@@ -393,7 +393,7 @@ internal fun OnboardingSearchScreen(
                             if (isAiSideTrip) {
                                 "Subscribe & Continue Chat (${subscribedIds.size})"
                             } else {
-                                "Done (${subscribedIds.size} selected)"
+                                "Continue with ${subscribedIds.size}"
                             },
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = GoogleSansWeight.bold,

--- a/feature/onboarding/src/test/java/cx/aswin/boxlore/feature/onboarding/OnboardingSuggestionsPresentationTest.kt
+++ b/feature/onboarding/src/test/java/cx/aswin/boxlore/feature/onboarding/OnboardingSuggestionsPresentationTest.kt
@@ -156,6 +156,39 @@ class OnboardingSuggestionsPresentationTest {
     }
 
     @Test
+    fun `isError only when error set and content empty`() {
+        assertTrue(
+            OnboardingSuggestionsPresentation.isError(
+                OnboardingUiState(onboardingError = "boom"),
+            ),
+        )
+        assertFalse(OnboardingSuggestionsPresentation.isError(OnboardingUiState()))
+        assertFalse(
+            OnboardingSuggestionsPresentation.isError(
+                OnboardingUiState(
+                    onboardingError = "boom",
+                    aiCurriculumRows =
+                        listOf(
+                            OnboardingCurriculumRowDto(
+                                rowTitle = "Lane",
+                                podcasts = listOf(OnboardingCurriculumPodcastDto(id = 1, title = "A")),
+                            ),
+                        ),
+                ),
+            ),
+        )
+        assertFalse(
+            OnboardingSuggestionsPresentation.isError(
+                OnboardingUiState(
+                    onboardingError = "boom",
+                    genreChartsPodcasts =
+                        listOf(Podcast(id = "c1", title = "Chart", artist = "Host", imageUrl = "")),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `withClearedSuggestionPayload keeps picks and clears rows`() {
         val pick = Podcast(id = "p1", title = "Kept", artist = "Host", imageUrl = "")
         val cleared =
@@ -187,6 +220,26 @@ class OnboardingSuggestionsPresentationTest {
         assertEquals(null, cleared.onboardingError)
         assertEquals(mapOf(pick.id to pick), cleared.selectedPodcasts)
         assertEquals("news", cleared.searchQuery)
+        assertFalse(cleared.reachedSuggestionsViaSearchFlow)
+        assertFalse(cleared.reachedSuggestionsViaOpmlFlow)
+        assertFalse(cleared.reachedSuggestionsViaAiFlow)
+        assertEquals(
+            "Subscribe & start · 1",
+            OnboardingSuggestionsPresentation.finishCtaLabel(
+                cleared.copy(
+                    subscribedPodcastIds = setOf(pick.id),
+                    aiCurriculumRows =
+                        listOf(
+                            OnboardingCurriculumRowDto(
+                                rowTitle = "Later AI",
+                                podcasts = listOf(OnboardingCurriculumPodcastDto(id = 9, title = "X")),
+                            ),
+                        ),
+                    reachedSuggestionsViaAiFlow = true,
+                ),
+                selectedCount = 1,
+            ),
+        )
         assertTrue(OnboardingSuggestionsPresentation.shouldClearSuggestionPayloadOnBack(OnboardingStep.SEARCH))
         assertTrue(OnboardingSuggestionsPresentation.shouldClearSuggestionPayloadOnBack(OnboardingStep.WELCOME))
         assertFalse(

--- a/feature/onboarding/src/test/java/cx/aswin/boxlore/feature/onboarding/OnboardingSuggestionsPresentationTest.kt
+++ b/feature/onboarding/src/test/java/cx/aswin/boxlore/feature/onboarding/OnboardingSuggestionsPresentationTest.kt
@@ -1,0 +1,196 @@
+package cx.aswin.boxlore.feature.onboarding
+
+import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.core.network.model.OnboardingCurriculumPodcastDto
+import cx.aswin.boxlore.core.network.model.OnboardingCurriculumRowDto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OnboardingSuggestionsPresentationTest {
+    @Test
+    fun `isLoading is true for search and OPML ai flags when content empty`() {
+        assertTrue(
+            OnboardingSuggestionsPresentation.isLoading(
+                OnboardingUiState(isAiLoading = true, isSynthesizing = true),
+            ),
+        )
+        assertTrue(
+            OnboardingSuggestionsPresentation.isLoading(
+                OnboardingUiState(isLoadingPodcasts = true),
+            ),
+        )
+    }
+
+    @Test
+    fun `isLoading is false when idle empty or when content already present`() {
+        assertFalse(OnboardingSuggestionsPresentation.isLoading(OnboardingUiState()))
+        assertFalse(
+            OnboardingSuggestionsPresentation.isLoading(
+                OnboardingUiState(
+                    isAiLoading = true,
+                    aiCurriculumRows =
+                        listOf(
+                            OnboardingCurriculumRowDto(
+                                rowTitle = "Lane",
+                                podcasts = listOf(OnboardingCurriculumPodcastDto(id = 1, title = "A")),
+                            ),
+                        ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `filterCurriculumRowsExcluding drops seed ids and empty rows`() {
+        val rows =
+            listOf(
+                OnboardingCurriculumRowDto(
+                    rowTitle = "Seeds only",
+                    podcasts =
+                        listOf(
+                            OnboardingCurriculumPodcastDto(id = 1, title = "Seed"),
+                        ),
+                ),
+                OnboardingCurriculumRowDto(
+                    rowTitle = "Mixed",
+                    podcasts =
+                        listOf(
+                            OnboardingCurriculumPodcastDto(id = 1, title = "Seed"),
+                            OnboardingCurriculumPodcastDto(id = 2, title = "New"),
+                        ),
+                ),
+            )
+        val filtered =
+            OnboardingSuggestionsPresentation.filterCurriculumRowsExcluding(
+                rows = rows,
+                excludeIds = setOf("1"),
+            )
+        assertEquals(1, filtered.size)
+        assertEquals("Mixed", filtered.single().rowTitle)
+        assertEquals(listOf(2L), filtered.single().podcasts.map { it.id })
+    }
+
+    @Test
+    fun `loadingCopy is structured for search OPML and default`() {
+        assertEquals(
+            OnboardingSuggestionsPresentation.LoadingCopy(
+                title = "Subscribed to 3 shows",
+                subtitle = "Looking for more you might like…",
+            ),
+            OnboardingSuggestionsPresentation.loadingCopy(
+                OnboardingUiState(reachedSuggestionsViaSearchFlow = true, suggestionSeedCount = 3),
+            ),
+        )
+        assertEquals(
+            OnboardingSuggestionsPresentation.LoadingCopy(
+                title = "Subscribed to 1 show",
+                subtitle = "Looking for more you might like…",
+            ),
+            OnboardingSuggestionsPresentation.loadingCopy(
+                OnboardingUiState(reachedSuggestionsViaSearchFlow = true, suggestionSeedCount = 1),
+            ),
+        )
+        assertEquals(
+            OnboardingSuggestionsPresentation.LoadingCopy(
+                title = "Import complete",
+                subtitle = "Finding shows inspired by your library…",
+            ),
+            OnboardingSuggestionsPresentation.loadingCopy(
+                OnboardingUiState(reachedSuggestionsViaOpmlFlow = true),
+            ),
+        )
+        assertEquals(
+            OnboardingSuggestionsPresentation.LoadingCopy(
+                title = "Designing your feed",
+                subtitle = "Matching shows to your taste…",
+            ),
+            OnboardingSuggestionsPresentation.loadingCopy(OnboardingUiState()),
+        )
+    }
+
+    @Test
+    fun `finishCtaLabel for seed flows avoids start without subscribing`() {
+        val seedOnly =
+            OnboardingUiState(
+                reachedSuggestionsViaSearchFlow = true,
+                suggestionSeedCount = 2,
+                subscribedPodcastIds = setOf("s1", "s2"),
+            )
+        assertEquals(
+            "Start without adding",
+            OnboardingSuggestionsPresentation.finishCtaLabel(seedOnly, selectedCount = 2),
+        )
+
+        val withExtras =
+            seedOnly.copy(
+                aiCurriculumRows =
+                    listOf(
+                        OnboardingCurriculumRowDto(
+                            rowTitle = "Similar",
+                            podcasts =
+                                listOf(
+                                    OnboardingCurriculumPodcastDto(id = 9, title = "Rec"),
+                                ),
+                        ),
+                    ),
+                subscribedPodcastIds = setOf("s1", "s2", "9"),
+            )
+        assertEquals(
+            "Add 1 & start",
+            OnboardingSuggestionsPresentation.finishCtaLabel(withExtras, selectedCount = 3),
+        )
+
+        assertEquals(
+            "Subscribe & start · 4",
+            OnboardingSuggestionsPresentation.finishCtaLabel(
+                OnboardingUiState(subscribedPodcastIds = setOf("a", "b", "c", "d")),
+                selectedCount = 4,
+            ),
+        )
+        assertEquals(
+            "Start without subscribing",
+            OnboardingSuggestionsPresentation.finishCtaLabel(OnboardingUiState(), selectedCount = 0),
+        )
+    }
+
+    @Test
+    fun `withClearedSuggestionPayload keeps picks and clears rows`() {
+        val pick = Podcast(id = "p1", title = "Kept", artist = "Host", imageUrl = "")
+        val cleared =
+            OnboardingSuggestionsPresentation.withClearedSuggestionPayload(
+                state =
+                    OnboardingUiState(
+                        selectedPodcasts = mapOf(pick.id to pick),
+                        searchQuery = "news",
+                        aiCurriculumRows =
+                            listOf(
+                                OnboardingCurriculumRowDto(
+                                    rowTitle = "Stale",
+                                    podcasts = listOf(OnboardingCurriculumPodcastDto(id = 9, title = "X")),
+                                ),
+                            ),
+                        isAiLoading = true,
+                        isSynthesizing = true,
+                        suggestionSeedCount = 2,
+                        onboardingError = "boom",
+                        reachedSuggestionsViaSearchFlow = true,
+                    ),
+                nextStep = OnboardingStep.SEARCH,
+            )
+        assertEquals(OnboardingStep.SEARCH, cleared.currentStep)
+        assertTrue(cleared.aiCurriculumRows.isEmpty())
+        assertFalse(cleared.isAiLoading)
+        assertFalse(cleared.isSynthesizing)
+        assertEquals(0, cleared.suggestionSeedCount)
+        assertEquals(null, cleared.onboardingError)
+        assertEquals(mapOf(pick.id to pick), cleared.selectedPodcasts)
+        assertEquals("news", cleared.searchQuery)
+        assertTrue(OnboardingSuggestionsPresentation.shouldClearSuggestionPayloadOnBack(OnboardingStep.SEARCH))
+        assertTrue(OnboardingSuggestionsPresentation.shouldClearSuggestionPayloadOnBack(OnboardingStep.WELCOME))
+        assertFalse(
+            OnboardingSuggestionsPresentation.shouldClearSuggestionPayloadOnBack(OnboardingStep.AI_ONBOARDING),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Fix suggestions loading gate so search/OPML `isAiLoading` / `isSynthesizing` show a real loader instead of an empty “No suggestions yet” state.
- Clear stale curriculum on continue/back; filter seed picks out of similar-show lanes; do not auto-select recommendations on search/OPML.
- Tighten CTAs (“Continue with N”, “Start without adding” / “Add N & start”) and structured loader copy; match FeedMediaCard bottom art clip.

## Listener impact
### What changes in the user’s life
After choosing shows in “I know my shows” (or OPML), continue now shows a clear “subscribed → finding more” loading screen, then optional similar shows that aren’t already picked — without stale cards flashing on back.

## Test plan
- [ ] Search onboarding: pick shows → Continue → loader (“Subscribed to N shows”) → suggestions without seed cards checked
- [ ] Tap no extras → CTA “Start without adding”; pick extras → “Add N & start”
- [ ] Back from suggestions → search picks preserved, no stale suggestion flash on re-enter
- [ ] OPML path: same loader/filter/no auto-select behavior
- [ ] Genre/AI suggestions still auto-select / “Subscribe & start” as before
- [ ] Suggestion cards show curved art bottom corners like home/explore