### PR TITLE
docs: promote Play Store CTA and show live Play vs GitHub versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,23 @@
 
 <br/>
 
+<!-- download-play:start -->
+<a href="https://play.google.com/store/apps/details?id=cx.aswin.boxlore">
+  <img src="docs/images/card_playstore_v6.svg" height="80" alt="Get it on Google Play"/>
+</a>
+<!-- download-play:end -->
+&nbsp;&nbsp;
 <!-- download-apk:start -->
 <a href="https://github.com/boxcreate/boxlore/releases/latest/download/boxlore-v0.0.14.apk">
-  <img src="docs/images/card_github_v6.svg" height="72" alt="Download boxlore podcast app APK on GitHub"/>
+  <img src="docs/images/card_github_v6.svg" height="64" alt="Download boxlore podcast app APK on GitHub"/>
 </a>
 <!-- download-apk:end -->
-&nbsp;&nbsp;
-<a href="https://play.google.com/store/apps/details?id=cx.aswin.boxlore">
-  <img src="docs/images/card_playstore_v6.svg" height="72" alt="Coming soon on Google Play"/>
-</a>
+
+<br/>
+
+<a href="https://play.google.com/store/apps/details?id=cx.aswin.boxlore"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fplay.rajkumaar.co.in%2Fversion%3Fid%3Dcx.aswin.boxlore&amp;label=Google%20Play&amp;color=3DDC84&amp;style=flat-square&amp;logo=googleplay&amp;logoColor=white" alt="Google Play version"/></a>
+&nbsp;
+<a href="https://github.com/boxcreate/boxlore/releases/latest"><img src="https://img.shields.io/github/v/release/boxcreate/boxlore?style=flat-square&amp;logo=github&amp;label=GitHub&amp;color=6750A4" alt="GitHub latest release"/></a>
 
 <br/><br/>
 
@@ -171,11 +179,17 @@ Export anytime: **Profile → Backup & Restore** (OPML or full JSON).
 
 <a id="install"></a>
 
-Use the **GitHub APK** button at the top of this page (latest release asset) or get it on Play:
+Get it on **Google Play**, or grab the GitHub APK (latest release asset).
+
+Version badges above update live: **Google Play** from the public store listing, **GitHub** from the latest release tag (they can differ while a build is rolling out).
 
 <div align="center">
   <a href="https://play.google.com/store/apps/details?id=cx.aswin.boxlore">
-    <img src="docs/images/card_playstore_v6.svg" height="72" alt="Coming soon on Google Play"/>
+    <img src="docs/images/card_playstore_v6.svg" height="80" alt="Get it on Google Play"/>
+  </a>
+  &nbsp;&nbsp;
+  <a href="https://github.com/boxcreate/boxlore/releases/latest/download/boxlore-v0.0.14.apk">
+    <img src="docs/images/card_github_v6.svg" height="64" alt="Download boxlore podcast app APK on GitHub"/>
   </a>
 </div>
 

--- a/docs/images/card_playstore_v6.svg
+++ b/docs/images/card_playstore_v6.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="240" height="72" viewBox="0 0 240 72" role="img" aria-label="Coming soon on Google Play">
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="72" viewBox="0 0 240 72" role="img" aria-label="Get it on Google Play">
   <defs>
     <linearGradient id="gpBg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#2B2930"/>
@@ -14,6 +14,6 @@
     <path fill="#4285F4" d="M19.8 9.3 1.6.1C.9-.3.2.1.2 1.2L15.7 14.7z"/>
     <path fill="#34A853" d="M19.8 18.7 15.7 14.7.2 28.2c.3 1.1 1.1 1.3 1.9.8z"/>
   </g>
-  <text x="84" y="29" font-family="Roboto, 'Google Sans', 'Segoe UI', system-ui, sans-serif" font-size="10" font-weight="600" letter-spacing="1.4" fill="#CAC4D0">COMING SOON ON</text>
+  <text x="84" y="29" font-family="Roboto, 'Google Sans', 'Segoe UI', system-ui, sans-serif" font-size="10" font-weight="600" letter-spacing="1.4" fill="#CAC4D0">GET IT ON</text>
   <text x="84" y="50" font-family="Roboto, 'Google Sans', 'Segoe UI', system-ui, sans-serif" font-size="20" font-weight="700" fill="#E6E1E5">Google Play</text>
 </svg>


### PR DESCRIPTION
## Summary
- Play Store card is primary (“Get it on Google Play”); GitHub APK is secondary.
- Live version badges: Google Play (public listing scrape) vs GitHub latest release.
- Install section notes that the two can differ during rollout.

## Test plan
- [ ] README top shows Play button first / larger, then GitHub APK
- [ ] Play badge shows live store version (currently ~0.0.13)
- [ ] GitHub badge shows latest release (currently v0.0.14)
- [ ] Install section copy matches