### PR TITLE
fix(ci): raise Gradle heap so release R8 can finish [skip changelog]

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,8 @@ android.useAndroidX=true
 # dual-reference rewrite warnings in CI. Keep AndroidX-only resolution.
 android.enableJetifier=false
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+# 2g OOMs R8 on GitHub-hosted publish-release (AGP 9 minify).
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 # Resolve relative captureRoboImage() paths against the Roborazzi output dir
 # (screenshots/baselines) instead of each module's working directory.
 roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory


### PR DESCRIPTION
## Summary
- Raise Gradle/R8 heap from 2g to 4g so `publish-release` can minify the v0.0.16 AAB.
- Leave app version at **0.0.16** so notes still come from [release PR #976](https://github.com/boxcreate/boxlore/pull/976) (CHANGELOG / What's New). Rolling back to 0.0.15 would make `publish-release` look up the previous release notes.

## Motivation
GitHub-hosted `publish-release` for v0.0.16 died in `:app:minifyReleaseWithR8` with `OutOfMemoryError`. `org.gradle.jvmargs=-Xmx2048m` was the Android Studio default from the first commit, never raised.

## What changed
- `gradle.properties`: `-Xmx4g`

## Behavior & compatibility
No listener-facing change. Local and CI Gradle daemons get a 4g heap.

## Impact (required)

### User impact — pick **exactly one**

- [x] `no-user-impact`

### Backend — optional, **pairable** with any user-impact level

- [ ] `backend-change`

## Release copy (verbatim — highest priority)

### CHANGELOG.md (developer copy)

<!-- release-copy:changelog:start -->

<!-- release-copy:changelog:end -->

### README What's New / Upcoming (listener copy)

<!-- release-copy:readme:start -->

<!-- release-copy:readme:end -->

## Test plan

- [x] Version left at 0.0.16 / versionCode 16
- [ ] Required checks green
- [ ] After merge, re-dispatch **Changelog and Release** → `publish-release` (auto-publish only fires on the prepare commit itself)

## Notes
Do not re-run `prepare-release`. `verify-merged` finds `release: prepare v0.0.16` via git log and reads notes from the existing CHANGELOG / README regions.