### PR TITLE
fix(onboarding): paint import chrome behind the status bar

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -13,12 +13,13 @@ The application module owns the Android app shell: `BoxLoreApplication`, `MainAc
 - FCM (`BoxLoreFcmService`) owns notification_received / tap extras (`notification_type`, podcast/episode ids for snake+camel keys). Generic push intents propagate those extras so taps are not always `"push"`. For `type=new_episode`, opted-in PI shows run the same full `refreshFromFeed` as launch sync (`NewEpisodePushHydration`, 1000-oldest PI baseline in parallel) so extras land in Room for Home chips and Library; the payload enclosure/guid still selects the notification episode. If the payload has no usable episode id, the tap opens the podcast page.
 - Library backup/import analytics (`trackBackupRestoreResult`, import failed) use allowlisted error codes from `LibraryBackupAnalyticsErrors` — never raw exception text.
 - `MainActivity` / `BoxLoreAppRoot` own deep-link and session-restore analytics at the shell layer.
+- Full-screen library import (`OpmlImportDialog`) is an in-window overlay (JSON and OPML share the same selector). It paints the theme background behind the status bar / cutout (`ImportDialogSystemBars`) and pads content with `WindowInsets.safeDrawing` so chrome matches the page instead of an OEM Dialog scrim.
 - App-shell UI uses the centralized Google Sans Flex weight tokens from `:core:designsystem`.
 - `SharedAppDependenciesHolder` and `DownloadsDependenciesHolder` are installed from the application so workers and Media3 services reuse the same graph.
 - `HomeScreenWidgetsInstaller` installs `NowPlayingWidgetDependencies` (via `NowPlayingWidgetPlaybackAdapter`) and `LibraryWidgetDependencies` (via `WidgetLibrarySourceAdapter`) so home-screen widgets share the app-scoped `PlaybackRepository` / library ports without a second graph. Transport calls hop to `Dispatchers.Main`. Lettering-roundness changes re-render bitmap labels so ROND matches Appearance.
 - `DownloadServiceLauncherHolder` is installed with `MediaDownloadService::class.java` so `:core:downloads` can launch the foreground download service without depending on `:core:playback`.
 - `LegacyWorkerFactory` maps legacy worker class names to current worker implementations for WorkManager continuity.
-- `MainActivity` hosts theme, edge-to-edge setup, app update hooks, surveys, OPML import state (full-screen `OpmlImportDialog` so onboarding welcome never shows through), the selected floating or classic navigation presentation, and the player overlay.
+- `MainActivity` hosts theme, edge-to-edge setup, app update hooks, surveys, library import state (full-screen `OpmlImportDialog` overlay so onboarding welcome never shows through), the selected floating or classic navigation presentation, and the player overlay.
 - NPS survey UI (`surveys/`) applies `NpsSurveyBranching` after each answer so detractor / passive / promoter open-text paths end instead of falling through into the next score band (PostHog open-question `end` branching is not reliably persisted via API).
 - `BoxLoreNavHost` owns app route registration and delegates screen bodies to feature modules; stack-slide transitions follow the visible Home → Explore → Library → Lore order, and Home’s first committed content frame unlocks the floating Lore launch animation.
 - Cold-start destination precedence (see `StartDestinationResolver`): incomplete onboarding → offline Downloads (no deep link) → Appearance **Open app to** Subscriptions (no deep link) → Home. Deep links and push `target_route` still win over Open app to. When cold start opens Subscriptions, `openedToSubscriptionsOnLaunch` makes Back navigate to Home (not Library hub); Library-tile entry still pops to Library.
@@ -58,6 +59,7 @@ src/main/java/cx/aswin/boxlore/
     announcement/
     libraryimport/
       OpmlImportDialog.kt
+      ImportDialogSystemBars.kt
       OpmlImportEffects.kt
       OpmlImportProgressContent.kt
   updates/
@@ -90,7 +92,7 @@ Routes include onboarding, home, learn, briefing, settings, debug, explore, libr
 
 ## Testing notes
 
-- Unit tests live under `app/src/test`, including app container smoke coverage, worker factory mapping, FCM payload parsing (type + snake/camel ids, feedUrl/guid/enclosure), new-episode route/id helpers, opted-in feed hydration before notify, library backup analytics error codes, push-target route allowlisting, cold-start destination precedence (`StartDestinationResolverTest`), and launch-Subscriptions Back decisions (`LaunchSubscriptionsBackDecisionTest`).
+- Unit tests live under `app/src/test`, including app container smoke coverage, worker factory mapping, FCM payload parsing (type + snake/camel ids, feedUrl/guid/enclosure), new-episode route/id helpers, opted-in feed hydration before notify, library backup analytics error codes, import-dialog system-bar edge-to-edge (`ImportDialogSystemBarsTest`), push-target route allowlisting, cold-start destination precedence (`StartDestinationResolverTest`), and launch-Subscriptions Back decisions (`LaunchSubscriptionsBackDecisionTest`).
 - Navigation and feature UI behavior are covered mainly in feature module tests and Maestro smoke flows.
 
 ```bash

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportDialogSystemBars.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportDialogSystemBars.kt
@@ -1,0 +1,43 @@
+package cx.aswin.boxlore.ui.libraryimport
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import android.view.Window
+import android.view.WindowManager
+import androidx.core.view.WindowCompat
+
+/**
+ * Library import (JSON and OPML) draws in the Activity window. Some OEMs still
+ * paint a contrast scrim over the status bar; this keeps bars transparent, draws
+ * the theme background into the cutout, and matches icon appearance to the page.
+ */
+internal object ImportDialogSystemBars {
+    @Suppress("DEPRECATION")
+    fun apply(
+        window: Window,
+        backgroundArgb: Int,
+        darkTheme: Boolean,
+    ) {
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.setBackgroundDrawable(ColorDrawable(backgroundArgb))
+        window.attributes =
+            window.attributes.apply {
+                layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            }
+        @Suppress("DEPRECATION")
+        window.statusBarColor = Color.TRANSPARENT
+        @Suppress("DEPRECATION")
+        window.navigationBarColor = Color.TRANSPARENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isStatusBarContrastEnforced = false
+            window.isNavigationBarContrastEnforced = false
+        }
+        val lightIcons = !darkTheme
+        WindowCompat.getInsetsController(window, window.decorView).apply {
+            isAppearanceLightStatusBars = lightIcons
+            isAppearanceLightNavigationBars = lightIcons
+        }
+    }
+}

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportDialog.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportDialog.kt
@@ -1,6 +1,7 @@
 package cx.aswin.boxlore.ui.libraryimport
 
-import android.view.WindowManager
+import android.app.Activity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
@@ -13,28 +14,29 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
+import androidx.compose.ui.zIndex
+import cx.aswin.boxlore.core.designsystem.theme.LocalEffectiveDarkTheme
 import cx.aswin.boxlore.core.model.Podcast
 
 sealed interface OpmlImportState {
@@ -115,61 +117,56 @@ fun OpmlImportDialog(
             onResult = { uri -> uri?.let { onImportOpmlSelected(it) } },
         )
     val canDismiss = canDismissImportState(state)
+    BackHandler {
+        if (canDismiss) onDismissRequest()
+    }
 
-    Dialog(
-        onDismissRequest = {
-            if (canDismiss) onDismissRequest()
-        },
-        properties =
-            DialogProperties(
-                usePlatformDefaultWidth = false,
-                decorFitsSystemWindows = false,
-            ),
+    // Draw in the Activity window (not a Dialog) so JSON and OPML share the same
+    // edge-to-edge chrome as welcome. OEM Dialog windows keep an opaque black bar.
+    val view = LocalView.current
+    val backgroundColor = MaterialTheme.colorScheme.background
+    val darkTheme = LocalEffectiveDarkTheme.current
+    SideEffect {
+        val window = (view.context as? Activity)?.window ?: return@SideEffect
+        ImportDialogSystemBars.apply(
+            window = window,
+            backgroundArgb = backgroundColor.toArgb(),
+            darkTheme = darkTheme,
+        )
+    }
+
+    Surface(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .zIndex(200f)
+                .pointerInput(Unit) { /* Block touch-through to welcome / player. */ },
+        color = backgroundColor,
     ) {
-        // Dialog windows default to wrap-content height; force true full-screen so the
-        // welcome cinematic background cannot show above a short panel.
-        val dialogWindow = (LocalView.current.parent as? DialogWindowProvider)?.window
-        SideEffect {
-            dialogWindow?.setLayout(
-                WindowManager.LayoutParams.MATCH_PARENT,
-                WindowManager.LayoutParams.MATCH_PARENT,
-            )
-        }
-
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background,
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets.safeDrawing)
+                    .padding(horizontal = 24.dp, vertical = 16.dp),
         ) {
-            Scaffold(
-                modifier = Modifier.fillMaxSize(),
-                containerColor = MaterialTheme.colorScheme.background,
-            ) { innerPadding ->
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding)
-                            .padding(horizontal = 24.dp, vertical = 16.dp),
-                ) {
-                    if (canDismiss) {
-                        ImportCloseButton(
-                            onClick = onDismissRequest,
-                            modifier = Modifier.align(Alignment.TopEnd),
-                        )
-                    }
-                    ImportDialogBody(
-                        state = state,
-                        onDismissRequest = onDismissRequest,
-                        onSelectionChanged = onSelectionChanged,
-                        onConfirmCompleted = onConfirmCompleted,
-                        onSkipCompleted = onSkipCompleted,
-                        onPickJson = {
-                            importJsonLauncher.launch(arrayOf("application/json"))
-                        },
-                        onPickOpml = { importOpmlLauncher.launch(arrayOf("*/*")) },
-                    )
-                }
+            if (canDismiss) {
+                ImportCloseButton(
+                    onClick = onDismissRequest,
+                    modifier = Modifier.align(Alignment.TopEnd),
+                )
             }
+            ImportDialogBody(
+                state = state,
+                onDismissRequest = onDismissRequest,
+                onSelectionChanged = onSelectionChanged,
+                onConfirmCompleted = onConfirmCompleted,
+                onSkipCompleted = onSkipCompleted,
+                onPickJson = {
+                    importJsonLauncher.launch(arrayOf("application/json"))
+                },
+                onPickOpml = { importOpmlLauncher.launch(arrayOf("*/*")) },
+            )
         }
     }
 }

--- a/app/src/test/java/cx/aswin/boxlore/ui/libraryimport/ImportDialogSystemBarsTest.kt
+++ b/app/src/test/java/cx/aswin/boxlore/ui/libraryimport/ImportDialogSystemBarsTest.kt
@@ -1,0 +1,63 @@
+package cx.aswin.boxlore.ui.libraryimport
+
+import android.app.Application
+import android.graphics.Color
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.core.view.WindowCompat
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class ImportDialogSystemBarsTest {
+    private lateinit var activity: ComponentActivity
+
+    @Before
+    fun setUp() {
+        activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun apply_paintsThemeBackgroundAndUsesLightIconsInLightTheme() {
+        val window = activity.window
+        ImportDialogSystemBars.apply(
+            window = window,
+            backgroundArgb = 0xFFF0EBE0.toInt(),
+            darkTheme = false,
+        )
+
+        assertEquals(Color.TRANSPARENT, window.statusBarColor)
+        assertEquals(Color.TRANSPARENT, window.navigationBarColor)
+        assertFalse(window.isStatusBarContrastEnforced)
+        assertFalse(window.isNavigationBarContrastEnforced)
+        assertEquals(
+            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES,
+            window.attributes.layoutInDisplayCutoutMode,
+        )
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        assertTrue(controller.isAppearanceLightStatusBars)
+        assertTrue(controller.isAppearanceLightNavigationBars)
+    }
+
+    @Test
+    fun apply_usesDarkIconsInDarkTheme() {
+        val window = activity.window
+        ImportDialogSystemBars.apply(
+            window = window,
+            backgroundArgb = 0xFF111316.toInt(),
+            darkTheme = true,
+        )
+        val controller = WindowCompat.getInsetsController(window, window.decorView)
+        assertFalse(controller.isAppearanceLightStatusBars)
+        assertFalse(controller.isAppearanceLightNavigationBars)
+    }
+}

--- a/config/ktlint/app-baseline.xml
+++ b/config/ktlint/app-baseline.xml
@@ -378,10 +378,10 @@
         <error line="237" column="13" source="standard:function-naming" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportDialog.kt">
-        <error line="92" column="5" source="standard:function-naming" />
-        <error line="160" column="13" source="standard:function-naming" />
-        <error line="183" column="13" source="standard:function-naming" />
-        <error line="235" column="13" source="standard:function-naming" />
+        @error line="98" column="5" source="standard:function-naming" />
+        <error line="175" column="13" source="standard:function-naming" />
+        <error line="198" column="13" source="standard:function-naming" />
+        <error line="250" column="13" source="standard:function-naming" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportEffects.kt">
         <error line="21" column="5" source="standard:function-naming" />


### PR DESCRIPTION
## Summary

- Library import (JSON and OPML) is no longer a Compose `Dialog` window. It draws as a full-screen overlay in the activity window so the status bar matches the page.
- Content is padded with `WindowInsets.safeDrawing` so the close control and selector sit below the cutout.
- OEM contrast scrims are turned off on the activity window while import is open.

## Motivation

On Xiaomi (and similar OEMs), a full-screen Dialog keeps an opaque black status bar. Opening import from welcome showed a black strip over a cream/theme-colored page. Tweaking the Dialog window was not enough.

## What changed

- `OpmlImportDialog` is an in-window overlay (JSON and OPML share the same selector).
- `ImportDialogSystemBars` keeps bars transparent, paints the theme background into the cutout, and matches icon appearance to light/dark theme.
- `BackHandler` dismisses when the current step allows it.
- Unit coverage in `ImportDialogSystemBarsTest`.

## Behavior & compatibility

- **Before:** Import from welcome (and other entry points) opened a Dialog whose status bar stayed black while the page used the theme color.
- **After:** JSON and OPML import use the same overlay; the status bar is the page color, with content inset for the punch-hole / system bars.
- Import file picking, restore, and onboarding completion paths are unchanged.

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-critical`
- [ ] `user-impact-high`
- [x] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact

**What changes in the user’s life:**

Importing a library from welcome (JSON or OPML) no longer shows a black strip at the top of the screen. The status bar matches the rest of the import page.

### Backend — optional

- [ ] `backend-change`

## Release copy (verbatim — highest priority)

### CHANGELOG.md (developer copy)

<!-- release-copy:changelog:start -->

### Fixed
- Draw library import (JSON and OPML) in the activity window so OEM Dialog status-bar scrims cannot mismatch the page color.

<!-- release-copy:changelog:end -->

### README What's New / Upcoming (listener copy)

<!-- release-copy:readme:start -->

### Polish
- Importing your library from welcome no longer shows a black bar at the top of the screen.

<!-- release-copy:readme:end -->

## Test plan

- [x] Built / installed locally (`./gradlew installDebug`)
- [x] `:app:testDebugUnitTest --tests ImportDialogSystemBarsTest`
- [ ] Welcome → Import: status bar matches the selector page (JSON and OPML)
- [ ] Close / back still dismisses the selector; file pickers still open
- [ ] Required checks are green before merge completes