### PR TITLE
fix(player): stop expanded sheet from collapsing on content fling

### DIFF
--- a/feature/player/README.md
+++ b/feature/player/README.md
@@ -10,6 +10,7 @@ Owns player presentation: mini player, full player sheet, queue screen UI, contr
 - The collapsed v2 mini player follows Appearance → Navigation: Floating is a 64dp pill with 32dp corners; Classic restores the 72dp legacy shape with 26dp top and 14dp bottom corners. Both retain circular artwork, a primary play/pause control, and smaller circular seek controls.
 - `v2.FullPlayerV2`, `FullPlayerV2Content`, `FullPlayerV2Sheets`, `ControlDeck`, and `ControlDeckQuickActions` provide full-player presentation pieces.
 - The expanded-player transport group gives play/pause and both seek controls the same brief, coordinated width feedback when pressed or tapped.
+- Nested scroll in the expanded sheet stops at the content top; collapsing to the mini player takes a new downward swipe from that rest position.
 - `QueueScreen`, `PlayerControls`, `ChaptersSheet`, and `TranscriptView` support player sub-surfaces.
 - `v2.logic.*` contains JVM-testable layout, control, queue-label, transcript-dialog, mini-player, and seekbar logic.
 - Player UI uses centralized Google Sans Flex weight tokens from `:core:designsystem`.
@@ -62,7 +63,7 @@ Main Kotlin files should remain below 1000 lines; extracted full-player content,
 ## Testing notes
 
 - Unit tests live under `feature/player/src/test`.
-- Existing coverage includes time formatting and v2 logic for controls, layout, seekbar, queue labels, queue podcast display, transcript dialogs, mini-player dismissal, and chapter art flow.
+- Existing coverage includes time formatting and v2 logic for controls, layout, nested-scroll collapse handoff, seekbar, queue labels, queue podcast display, transcript dialogs, mini-player dismissal, and chapter art flow.
 - Compose UI test tags for player controls should remain stable when added or expanded.
 
 ```bash

--- a/feature/player/src/main/java/cx/aswin/boxlore/feature/player/v2/PlayerSheetScaffold.kt
+++ b/feature/player/src/main/java/cx/aswin/boxlore/feature/player/v2/PlayerSheetScaffold.kt
@@ -62,6 +62,7 @@ import cx.aswin.boxlore.core.designsystem.theme.ExpressiveMotion
 import cx.aswin.boxlore.core.designsystem.theme.LocalEffectiveDarkTheme
 import cx.aswin.boxlore.feature.player.v2.logic.calculatePlayerSheetGeometry
 import cx.aswin.boxlore.feature.player.v2.logic.PlayerSheetGeometryInput
+import cx.aswin.boxlore.feature.player.v2.logic.PlayerSheetNestedScrollLogic
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.roundToInt
 import kotlinx.coroutines.NonCancellable
@@ -639,6 +640,8 @@ private fun rememberPlayerSheetNestedScrollConnection(
     density: Density
 ): NestedScrollConnection = remember(sheetState, density) {
     object : NestedScrollConnection {
+        private var contentOwnsGesture = false
+
         override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
             return consumePlayerSheetPreScroll(sheetState, available)
         }
@@ -648,7 +651,19 @@ private fun rememberPlayerSheetNestedScrollConnection(
             available: Offset,
             source: NestedScrollSource
         ): Offset {
-            return consumePlayerSheetPostScroll(sheetState, available, source)
+            if (source == NestedScrollSource.UserInput) {
+                contentOwnsGesture =
+                    PlayerSheetNestedScrollLogic.contentOwnsGestureAfterScroll(
+                        contentOwnsGesture,
+                        consumed.y,
+                    )
+            }
+            return consumePlayerSheetPostScroll(
+                sheetState = sheetState,
+                available = available,
+                source = source,
+                contentOwnsGesture = contentOwnsGesture,
+            )
         }
 
         override suspend fun onPreFling(available: Velocity): Velocity {
@@ -656,7 +671,20 @@ private fun rememberPlayerSheetNestedScrollConnection(
         }
 
         override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-            return settlePlayerSheetPostFling(sheetState, available, density)
+            try {
+                if (
+                    !PlayerSheetNestedScrollLogic.shouldSettleSheetOnPostFling(
+                        contentOwnsGesture = contentOwnsGesture,
+                        sheetOffset = sheetState.requireOffset(),
+                        animationRunning = sheetState.isAnimationRunning,
+                    )
+                ) {
+                    return Velocity.Zero
+                }
+                return settlePlayerSheetPostFling(sheetState, available, density)
+            } finally {
+                contentOwnsGesture = false
+            }
         }
     }
 }
@@ -676,9 +704,19 @@ private fun consumePlayerSheetPreScroll(
 private fun consumePlayerSheetPostScroll(
     sheetState: AnchoredDraggableState<PlayerSheetValue>,
     available: Offset,
-    source: NestedScrollSource
+    source: NestedScrollSource,
+    contentOwnsGesture: Boolean,
 ): Offset {
-    if (source != NestedScrollSource.UserInput) return Offset.Zero
+    if (
+        !PlayerSheetNestedScrollLogic.shouldMoveSheetOnPostScroll(
+            contentOwnsGesture = contentOwnsGesture,
+            sheetOffset = sheetState.requireOffset(),
+            availableY = available.y,
+            sourceIsUserInput = source == NestedScrollSource.UserInput,
+        )
+    ) {
+        return Offset.Zero
+    }
     return Offset(0f, sheetState.dispatchRawDelta(available.y))
 }
 

--- a/feature/player/src/main/java/cx/aswin/boxlore/feature/player/v2/logic/PlayerSheetNestedScrollLogic.kt
+++ b/feature/player/src/main/java/cx/aswin/boxlore/feature/player/v2/logic/PlayerSheetNestedScrollLogic.kt
@@ -1,0 +1,40 @@
+package cx.aswin.boxlore.feature.player.v2.logic
+
+/**
+ * Nested-scroll handoff between full-player content and the mini/full sheet.
+ *
+ * A swipe that is still scrolling queue/notes must stop at the content top.
+ * Collapsing the sheet requires a new downward swipe from that rest position.
+ */
+internal object PlayerSheetNestedScrollLogic {
+    const val EXPANDED_OFFSET_EPS = 0.5f
+
+    fun isFullyExpanded(sheetOffset: Float): Boolean = sheetOffset <= EXPANDED_OFFSET_EPS
+
+    fun contentOwnsGestureAfterScroll(
+        alreadyOwned: Boolean,
+        childConsumedY: Float,
+    ): Boolean = alreadyOwned || childConsumedY != 0f
+
+    fun shouldMoveSheetOnPostScroll(
+        contentOwnsGesture: Boolean,
+        sheetOffset: Float,
+        availableY: Float,
+        sourceIsUserInput: Boolean,
+    ): Boolean {
+        if (!sourceIsUserInput || availableY == 0f) return false
+        // Leftover downward overscroll from a content scroll must not start collapse.
+        if (contentOwnsGesture && isFullyExpanded(sheetOffset) && availableY > 0f) return false
+        return true
+    }
+
+    fun shouldSettleSheetOnPostFling(
+        contentOwnsGesture: Boolean,
+        sheetOffset: Float,
+        animationRunning: Boolean,
+    ): Boolean {
+        if (animationRunning) return false
+        if (contentOwnsGesture && isFullyExpanded(sheetOffset)) return false
+        return true
+    }
+}

--- a/feature/player/src/test/java/cx/aswin/boxlore/feature/player/v2/logic/PlayerSheetNestedScrollLogicTest.kt
+++ b/feature/player/src/test/java/cx/aswin/boxlore/feature/player/v2/logic/PlayerSheetNestedScrollLogicTest.kt
@@ -1,0 +1,109 @@
+package cx.aswin.boxlore.feature.player.v2.logic
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PlayerSheetNestedScrollLogicTest {
+    @Test
+    fun childConsumptionLocksTheGestureToContent() {
+        assertFalse(
+            PlayerSheetNestedScrollLogic.contentOwnsGestureAfterScroll(
+                alreadyOwned = false,
+                childConsumedY = 0f,
+            ),
+        )
+        assertTrue(
+            PlayerSheetNestedScrollLogic.contentOwnsGestureAfterScroll(
+                alreadyOwned = false,
+                childConsumedY = 12f,
+            ),
+        )
+        assertTrue(
+            PlayerSheetNestedScrollLogic.contentOwnsGestureAfterScroll(
+                alreadyOwned = true,
+                childConsumedY = 0f,
+            ),
+        )
+    }
+
+    @Test
+    fun leftoverDownwardOverscrollDoesNotCollapseWhileContentOwnsGesture() {
+        assertFalse(
+            PlayerSheetNestedScrollLogic.shouldMoveSheetOnPostScroll(
+                contentOwnsGesture = true,
+                sheetOffset = 0f,
+                availableY = 80f,
+                sourceIsUserInput = true,
+            ),
+        )
+    }
+
+    @Test
+    fun downwardDragFromRestAtTopStillMovesTheSheet() {
+        assertTrue(
+            PlayerSheetNestedScrollLogic.shouldMoveSheetOnPostScroll(
+                contentOwnsGesture = false,
+                sheetOffset = 0f,
+                availableY = 80f,
+                sourceIsUserInput = true,
+            ),
+        )
+    }
+
+    @Test
+    fun leftoverFlingDoesNotSettleWhileContentOwnsExpandedSheet() {
+        assertFalse(
+            PlayerSheetNestedScrollLogic.shouldSettleSheetOnPostFling(
+                contentOwnsGesture = true,
+                sheetOffset = 0f,
+                animationRunning = false,
+            ),
+        )
+    }
+
+    @Test
+    fun flingFromRestAtTopStillSettlesTheSheet() {
+        assertTrue(
+            PlayerSheetNestedScrollLogic.shouldSettleSheetOnPostFling(
+                contentOwnsGesture = false,
+                sheetOffset = 0f,
+                animationRunning = false,
+            ),
+        )
+    }
+
+    @Test
+    fun alreadyDraggedSheetStillSettlesEvenIfContentOwnedTheGesture() {
+        assertTrue(
+            PlayerSheetNestedScrollLogic.shouldSettleSheetOnPostFling(
+                contentOwnsGesture = true,
+                sheetOffset = 200f,
+                animationRunning = false,
+            ),
+        )
+    }
+
+    @Test
+    fun runningAnimationSkipsASecondSettle() {
+        assertFalse(
+            PlayerSheetNestedScrollLogic.shouldSettleSheetOnPostFling(
+                contentOwnsGesture = false,
+                sheetOffset = 80f,
+                animationRunning = true,
+            ),
+        )
+    }
+
+    @Test
+    fun nonUserInputNeverMovesTheSheet() {
+        assertFalse(
+            PlayerSheetNestedScrollLogic.shouldMoveSheetOnPostScroll(
+                contentOwnsGesture = false,
+                sheetOffset = 0f,
+                availableY = 80f,
+                sourceIsUserInput = false,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Expanded player content scroll now stops at the top instead of carrying leftover fling into a minimize.
- Collapsing to the mini player takes a new downward swipe from that rest position.

## Motivation

Scrolling down to the queue (or notes) and then swiping back up handed leftover nested-scroll velocity to the sheet. The player minimized in the same gesture, with no resistance at the content top.

## What changed

- Nested-scroll post-scroll/post-fling ignore leftover downward overscroll when the gesture was already scrolling content and the sheet is still fully expanded.
- A downward swipe that starts at the content top still collapses the sheet (unchanged).
- Extracted `PlayerSheetNestedScrollLogic` with JVM coverage for the handoff rules.

## Behavior & compatibility

- Before: one swipe back to the top could also minimize the expanded player.
- After: that swipe stops at the content top; a second downward swipe minimizes.
- No API, storage, or identity changes.

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-critical`
- [ ] `user-impact-high`
- [x] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact — **required when** `user-impact-critical`, `user-impact-high`, or `user-impact-medium`

**What changes in the user’s life:**

When the full player is open and you scroll down to the queue, swiping back up stops at the top of the player. It no longer keeps going and shrinks to the mini player. Swipe down again when you actually want to minimize.

### Backend — optional, **pairable** with any user-impact level

- [ ] `backend-change`

## Release copy (verbatim — highest priority)

### CHANGELOG.md (developer copy)

<!-- release-copy:changelog:start -->

### Fixed
- Stop the expanded player from minimizing when a content swipe reaches the top; collapsing now takes a new downward swipe.

<!-- release-copy:changelog:end -->

### README What's New / Upcoming (listener copy)

<!-- release-copy:readme:start -->

### Improved
- Scrolling the full player back to the top no longer shrinks it to the mini player. Swipe down again when you want to minimize.

<!-- release-copy:readme:end -->

## Test plan

- [x] Built / installed locally (`./gradlew installDebug`) when UI or app behavior changed
- [x] Unit tests for nested-scroll collapse handoff (`PlayerSheetNestedScrollLogicTest`)
- [ ] Manual: expand player, scroll to queue, swipe back up — stops at top
- [ ] Manual: from that rest position, swipe down — minimizes to mini player
- [ ] Manual: already at top, swipe down — still minimizes in one gesture
- [ ] Required checks are green before merge completes