### PR TITLE
feat(info): add bulk episode selection

### DIFF
--- a/config/ktlint/feature-info-baseline.xml
+++ b/config/ktlint/feature-info-baseline.xml
@@ -27,9 +27,9 @@
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoScreen.kt">
         <error line="119" column="5" source="standard:function-naming" />
-        <error line="476" column="21" source="standard:function-naming" />
-        <error line="597" column="1" source="standard:indent" />
-        <error line="598" column="1" source="standard:indent" />
+        <error line="483" column="21" source="standard:function-naming" />
+        <error line="604" column="1" source="standard:indent" />
+        <error line="605" column="1" source="standard:indent" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoUiModels.kt">
         <error line="39" column="9" source="standard:no-consecutive-comments" />
@@ -84,9 +84,9 @@
         <error line="247" column="13" source="standard:function-naming" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeSelectionToolbar.kt">
-        <error line="59" column="14" source="standard:function-naming" />
-        <error line="128" column="13" source="standard:function-naming" />
-        <error line="195" column="13" source="standard:function-naming" />
+        <error line="60" column="14" source="standard:function-naming" />
+        <error line="140" column="13" source="standard:function-naming" />
+        <error line="207" column="13" source="standard:function-naming" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeToolbar.kt">
         <error line="3" column="1" source="standard:import-ordering" />

--- a/config/ktlint/feature-info-baseline.xml
+++ b/config/ktlint/feature-info-baseline.xml
@@ -26,14 +26,16 @@
         <error line="306" column="141" source="standard:max-line-length" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoScreen.kt">
-        <error line="111" column="5" source="standard:function-naming" />
-        <error line="404" column="21" source="standard:function-naming" />
+        <error line="119" column="5" source="standard:function-naming" />
+        <error line="476" column="21" source="standard:function-naming" />
+        <error line="597" column="1" source="standard:indent" />
+        <error line="598" column="1" source="standard:indent" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoUiModels.kt">
         <error line="39" column="9" source="standard:no-consecutive-comments" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoViewModel.kt">
-        <error line="61" column="17" source="standard:backing-property-naming" />
+        <error line="70" column="17" source="standard:backing-property-naming" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeActionRail.kt">
         <error line="3" column="1" source="standard:import-ordering" />
@@ -81,6 +83,11 @@
         <error line="157" column="13" source="standard:function-naming" />
         <error line="247" column="13" source="standard:function-naming" />
     </file>
+    <file name="src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeSelectionToolbar.kt">
+        <error line="59" column="14" source="standard:function-naming" />
+        <error line="128" column="13" source="standard:function-naming" />
+        <error line="195" column="13" source="standard:function-naming" />
+    </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeToolbar.kt">
         <error line="3" column="1" source="standard:import-ordering" />
         <error line="75" column="1" source="standard:no-unused-imports" />
@@ -92,12 +99,12 @@
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/components/PodcastInfoChrome.kt">
         <error line="147" column="14" source="standard:function-naming" />
-        <error line="260" column="14" source="standard:function-naming" />
-        <error line="355" column="14" source="standard:function-naming" />
-        <error line="396" column="13" source="standard:function-naming" />
-        <error line="463" column="13" source="standard:function-naming" />
-        <error line="530" column="13" source="standard:function-naming" />
-        <error line="594" column="14" source="standard:function-naming" />
+        <error line="274" column="14" source="standard:function-naming" />
+        <error line="376" column="14" source="standard:function-naming" />
+        <error line="417" column="13" source="standard:function-naming" />
+        <error line="484" column="13" source="standard:function-naming" />
+        <error line="551" column="13" source="standard:function-naming" />
+        <error line="615" column="14" source="standard:function-naming" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/components/PodcastInfoMetadataChips.kt">
         <error line="3" column="1" source="standard:import-ordering" />
@@ -126,12 +133,15 @@
         <error line="130" column="13" source="standard:function-naming" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/components/PodcastTrailerCards.kt">
-        <error line="3" column="1" source="standard:import-ordering" />
-        <error line="39" column="1" source="standard:no-unused-imports" />
-        <error line="52" column="5" source="standard:function-naming" />
-        <error line="164" column="5" source="standard:function-naming" />
-        <error line="327" column="1" source="standard:no-consecutive-blank-lines" />
-        <error line="329" column="5" source="standard:function-naming" />
+        <error line="70" column="14" source="standard:function-naming" />
+        <error line="93" column="13" source="standard:function-naming" />
+        <error line="150" column="14" source="standard:function-naming" />
+        <error line="199" column="13" source="standard:function-naming" />
+        <error line="253" column="13" source="standard:function-naming" />
+        <error line="286" column="13" source="standard:function-naming" />
+        <error line="329" column="13" source="standard:function-naming" />
+        <error line="414" column="13" source="standard:function-naming" />
+        <error line="470" column="5" source="standard:function-naming" />
     </file>
     <file name="src/main/java/cx/aswin/boxlore/feature/info/logic/EpisodeSupplementMergeLogic.kt">
         <error line="19" column="20" source="standard:multiline-expression-wrapping" />

--- a/feature/info/README.md
+++ b/feature/info/README.md
@@ -6,7 +6,7 @@ Owns podcast and episode detail presentation: subscribe actions, RSS refresh act
 
 ## Public API
 
-- `PodcastInfoScreen` and `PodcastInfoViewModel`. Subscribed shows expose **Pin** / **Unpin** in the overflow menu (same max-5 list as Your Shows; at capacity a snackbar explains the limit).
+- `PodcastInfoScreen` and `PodcastInfoViewModel`. Long-pressing an episode enters multi-selection; the floating toolbar can download, mark completed, play, or append selected episodes to the queue. Its overflow can select only cards currently visible on screen, or fetch up to 1,000 show episodes for Select all / Select older / Select newer; fetched episode metadata is retained only while selection is active. Episode sorting remains available. Subscribed shows expose **Pin** / **Unpin** in the overflow menu (same max-5 list as Your Shows; at capacity a snackbar explains the limit).
 - `EpisodeInfoScreen` and `EpisodeInfoViewModel` (similar episodes use prefs `content_languages` + region).
 - `InfoViewModelAssembler` for podcast and episode ViewModel factories.
 - `InfoListeningProgressItem` and supporting components/sections for detail UI.
@@ -56,7 +56,7 @@ src/main/java/cx/aswin/boxlore/feature/info/
 ## Testing notes
 
 - Unit tests live under `feature/info/src/test`.
-- Existing coverage includes assembler behavior, catalog port behavior and errors, offline merge logic, listening-progress mapping, duration formatting, metadata chip logic, feed grouping, toolbar logic, HTML stripping, podcast info ViewModel logic, pull-to-refresh target (RSS vs opted-in direct feed), episode-supplement merge/eligibility, episode list artwork fallback, and `PodcastInfoSupplementSupport` refresh / PI-only baseline / auto-opt-in / search union. Home pin persistence, capacity, and unsubscribe cleanup are covered in `:core:prefs` (`HomePinnedShowsTest`, `UserPreferencesRepositoryTest`) rather than constructing `PodcastInfoViewModel`.
+- Existing coverage includes assembler behavior, catalog port behavior and errors, offline merge logic, listening-progress mapping, duration formatting, metadata chip logic, feed grouping, selection range/order logic, toolbar logic, HTML stripping, podcast info ViewModel logic, pull-to-refresh target (RSS vs opted-in direct feed), episode-supplement merge/eligibility, episode list artwork fallback, and `PodcastInfoSupplementSupport` refresh / PI-only baseline / auto-opt-in / search union. Home pin persistence, capacity, and unsubscribe cleanup are covered in `:core:prefs` (`HomePinnedShowsTest`, `UserPreferencesRepositoryTest`) rather than constructing `PodcastInfoViewModel`.
 - Catalog HTTP paths are covered in `:core:catalog` tests.
 
 ```bash

--- a/feature/info/README.md
+++ b/feature/info/README.md
@@ -6,7 +6,7 @@ Owns podcast and episode detail presentation: subscribe actions, RSS refresh act
 
 ## Public API
 
-- `PodcastInfoScreen` and `PodcastInfoViewModel`. Long-pressing an episode enters multi-selection; the floating toolbar can download, mark completed, play, or append selected episodes to the queue. Its overflow can select only cards currently visible on screen, or fetch up to 1,000 show episodes for Select all / Select older / Select newer; fetched episode metadata is retained only while selection is active. Episode sorting remains available. Subscribed shows expose **Pin** / **Unpin** in the overflow menu (same max-5 list as Your Shows; at capacity a snackbar explains the limit).
+- `PodcastInfoScreen` and `PodcastInfoViewModel`. Long-pressing an episode enters multi-selection; the floating toolbar can download, mark completed (or mark unplayed when every selected episode is already complete), play, or append selected episodes to the queue. Its overflow can select only cards currently visible on screen, or fetch up to 1,000 show episodes for Select all / Select older / Select newer; fetched episode metadata is retained only while selection is active. Episode sorting remains available. Subscribed shows expose **Pin to Home screen** / **Unpin from Home screen** in the overflow menu (same max-5 list as Your Shows; at capacity a snackbar explains the limit).
 - `EpisodeInfoScreen` and `EpisodeInfoViewModel` (similar episodes use prefs `content_languages` + region).
 - `InfoViewModelAssembler` for podcast and episode ViewModel factories.
 - `InfoListeningProgressItem` and supporting components/sections for detail UI.

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoScreen.kt
@@ -368,6 +368,13 @@ fun PodcastInfoScreen(
                             selectedIds = selectedEpisodeIds.toSet(),
                         )
                     }
+                val markSelectionAsUnplayed =
+                    remember(selectedEpisodes, completedEpisodeIds) {
+                        PodcastEpisodeSelectionLogic.shouldMarkUnplayed(
+                            selectedEpisodes = selectedEpisodes,
+                            completedEpisodeIds = completedEpisodeIds,
+                        )
+                    }
                 val clearEpisodeSelection = {
                     selectionRequestGeneration += 1
                     selectedEpisodeIds = emptyList()
@@ -720,7 +727,7 @@ fun PodcastInfoScreen(
                                     selectedEpisodes.any {
                                         it.id !in downloadedEpisodeIds && it.id !in downloadingEpisodeIds
                                     },
-                                canMarkCompleted = selectedEpisodes.any { it.id !in completedEpisodeIds },
+                                markAsUnplayed = markSelectionAsUnplayed,
                                 canAddToQueue = selectedEpisodes.any { it.id !in queuedEpisodeIds },
                                 hasRangeAnchor =
                                     selectionAnchorEpisodeId != null &&
@@ -736,8 +743,12 @@ fun PodcastInfoScreen(
                                     viewModel.downloadEpisodes(selectedEpisodes)
                                     clearEpisodeSelection()
                                 },
-                                onMarkCompleted = {
-                                    viewModel.markEpisodesCompleted(selectedEpisodes)
+                                onToggleCompletion = {
+                                    if (markSelectionAsUnplayed) {
+                                        viewModel.markEpisodesUncompleted(selectedEpisodes)
+                                    } else {
+                                        viewModel.markEpisodesCompleted(selectedEpisodes)
+                                    }
                                     clearEpisodeSelection()
                                 },
                                 onPlay = {

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoScreen.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoScreen.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -86,7 +87,12 @@ import cx.aswin.boxlore.core.designsystem.theme.TrackScreenSession
 import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.core.model.Person
 import cx.aswin.boxlore.feature.info.components.EpisodeFeedItemRow
+import cx.aswin.boxlore.feature.info.components.EpisodeFeedRowUi
 import cx.aswin.boxlore.feature.info.components.EpisodeListIndicators
+import cx.aswin.boxlore.feature.info.components.EpisodeSelectionToolbar
+import cx.aswin.boxlore.feature.info.components.EpisodeSelectionToolbarActions
+import cx.aswin.boxlore.feature.info.components.EpisodeSelectionToolbarState
+import cx.aswin.boxlore.feature.info.components.EpisodeSelectionUi
 import cx.aswin.boxlore.feature.info.components.EpisodeToolbar
 import cx.aswin.boxlore.feature.info.components.MarkAllEpisodesDialog
 import cx.aswin.boxlore.feature.info.components.MissingEpisodesChip
@@ -97,6 +103,8 @@ import cx.aswin.boxlore.feature.info.components.ToolbarWarningBanner
 import cx.aswin.boxlore.feature.info.components.handleAutoDownloadToggle
 import cx.aswin.boxlore.feature.info.components.handleNotificationsToggle
 import cx.aswin.boxlore.feature.info.components.handleToolbarWarningAction
+import cx.aswin.boxlore.feature.info.logic.EpisodeSelectionRange
+import cx.aswin.boxlore.feature.info.logic.PodcastEpisodeSelectionLogic
 import cx.aswin.boxlore.feature.info.logic.ToolbarWarning
 import cx.aswin.boxlore.feature.info.logic.groupEpisodes
 import cx.aswin.boxlore.feature.info.logic.resolveAutoScrollTarget
@@ -137,6 +145,13 @@ fun PodcastInfoScreen(
     var showMarkAllUnplayedDialog by remember { mutableStateOf(false) }
     var showPodcastPlaybackSettings by remember { mutableStateOf(false) }
     var showMissingEpisodesConfirm by remember { mutableStateOf(false) }
+    var selectedEpisodeIds by remember(podcastId) { mutableStateOf(emptyList<String>()) }
+    var selectionAnchorEpisodeId by remember(podcastId) { mutableStateOf<String?>(null) }
+    var selectionEpisodePool by remember(podcastId) { mutableStateOf(emptyList<Episode>()) }
+    var isLoadingFullSelection by remember(podcastId) { mutableStateOf(false) }
+    var selectionRequestGeneration by remember(podcastId) { mutableStateOf(0) }
+    val selectedEpisodeIdSet = selectedEpisodeIds.toSet()
+    val selectionActive = selectedEpisodeIds.isNotEmpty()
     val snackbarHostState = remember { SnackbarHostState() }
 
     // Permission Launcher for Android 13+ Notification Permission
@@ -167,6 +182,13 @@ fun PodcastInfoScreen(
     BackHandler(enabled = isSearchActive) {
         isSearchActive = false
         viewModel.searchEpisodes("") // Optional: Clear search on close? Or keep it? Let's clear for now.
+    }
+    BackHandler(enabled = selectionActive) {
+        selectionRequestGeneration += 1
+        selectedEpisodeIds = emptyList()
+        selectionAnchorEpisodeId = null
+        selectionEpisodePool = emptyList()
+        isLoadingFullSelection = false
     }
 
     TrackScreenSession(
@@ -339,6 +361,56 @@ fun PodcastInfoScreen(
                         }
                     }
                 val feedItems = remember(displayEpisodes) { groupEpisodes(displayEpisodes) }
+                val selectedEpisodes =
+                    remember(state.episodes, selectionEpisodePool, selectedEpisodeIds) {
+                        PodcastEpisodeSelectionLogic.selectedEpisodes(
+                            episodes = selectionEpisodePool + state.episodes,
+                            selectedIds = selectedEpisodeIds.toSet(),
+                        )
+                    }
+                val clearEpisodeSelection = {
+                    selectionRequestGeneration += 1
+                    selectedEpisodeIds = emptyList()
+                    selectionAnchorEpisodeId = null
+                    selectionEpisodePool = emptyList()
+                    isLoadingFullSelection = false
+                }
+                val selectionLimitMessage = stringResource(R.string.episode_selection_limit)
+                val selectFullRange: (EpisodeSelectionRange) -> Unit = { range ->
+                    selectionRequestGeneration += 1
+                    val requestGeneration = selectionRequestGeneration
+                    isLoadingFullSelection = true
+                    coroutineScope.launch {
+                        try {
+                            val window = viewModel.loadEpisodeSelectionWindow()
+                            if (requestGeneration != selectionRequestGeneration) return@launch
+                            val eligibleEpisodes =
+                                if (hideCompleted) {
+                                    window.episodes.filter { it.id !in completedEpisodeIds }
+                                } else {
+                                    window.episodes
+                                }
+                            selectionEpisodePool = eligibleEpisodes
+                            selectedEpisodeIds =
+                                PodcastEpisodeSelectionLogic
+                                    .addRange(
+                                        selectedIds = selectedEpisodeIds.toSet(),
+                                        episodes = eligibleEpisodes,
+                                        anchorEpisodeId = selectionAnchorEpisodeId,
+                                        range = range,
+                                        newestFirst = window.newestFirst,
+                                    ).toList()
+                            isLoadingFullSelection = false
+                            if (window.isTruncated) {
+                                snackbarHostState.showSnackbar(selectionLimitMessage)
+                            }
+                        } finally {
+                            if (requestGeneration == selectionRequestGeneration) {
+                                isLoadingFullSelection = false
+                            }
+                        }
+                    }
+                }
 
                 LaunchedEffect(state, completedEpisodeIds, feedItems, ongoingEpisodeIds) {
                     if (state.currentSort == EpisodeSort.OLDEST && feedItems.isNotEmpty()) {
@@ -409,7 +481,10 @@ fun PodcastInfoScreen(
                             PaddingValues(
                                 top = collapsedHeaderHeight + 16.dp,
                                 bottom =
-                                    WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + bottomContentPadding + 16.dp,
+                                    WindowInsets.navigationBars
+                                        .asPaddingValues()
+                                        .calculateBottomPadding() + bottomContentPadding +
+                                        if (selectionActive) 92.dp else 16.dp,
                             ),
                         verticalArrangement = Arrangement.spacedBy(14.dp),
                     ) {
@@ -492,13 +567,39 @@ fun PodcastInfoScreen(
                             EpisodeFeedItemRow(
                                 feedItem = feedItem,
                                 viewModel = viewModel,
-                                accentColor = accentColor,
-                                indicators = episodeListIndicators,
-                                autoScrolledEpisodeId = autoScrolledEpisodeId,
+                                ui =
+                                    EpisodeFeedRowUi(
+                                        accentColor = accentColor,
+                                        indicators = episodeListIndicators,
+                                        autoScrolledEpisodeId = autoScrolledEpisodeId,
+                                        podcastImageUrl =
+                                            state.podcast.imageUrl.takeIf { it.isNotEmpty() }
+                                                ?: state.podcast.fallbackImageUrl,
+                                    ),
                                 onEpisodeClick = onEpisodeClick,
-                                podcastImageUrl =
-                                    state.podcast.imageUrl.takeIf { it.isNotEmpty() }
-                                        ?: state.podcast.fallbackImageUrl,
+                                selection =
+                                    EpisodeSelectionUi(
+                                        selectedEpisodeIds = selectedEpisodeIdSet,
+                                        isActive = selectionActive,
+                                        onToggle = { episode ->
+                                            val updated =
+                                                PodcastEpisodeSelectionLogic.toggle(
+                                                    selectedIds = selectedEpisodeIdSet,
+                                                    episodeId = episode.id,
+                                                )
+                                            selectedEpisodeIds = updated.toList()
+                                            selectionAnchorEpisodeId = episode.id.takeIf { updated.isNotEmpty() }
+                                        },
+                                        onLongPress = { episode ->
+                                            selectedEpisodeIds =
+                                                PodcastEpisodeSelectionLogic
+                                                    .toggle(
+                                                selectedIds = selectedEpisodeIdSet,
+                                                episodeId = episode.id,
+                                                    ).toList()
+                                            selectionAnchorEpisodeId = episode.id
+                                        },
+                                    ),
                             )
 
                             if (state.searchResults == null &&
@@ -574,7 +675,7 @@ fun PodcastInfoScreen(
                     context = context,
                     actions =
                         PodcastInfoTopOverlayActions(
-                            onBack = onBack,
+                            onBack = if (selectionActive) clearEpisodeSelection else onBack,
                             onMarkAllPlayed = { showMarkAllPlayedDialog = true },
                             onMarkAllUnplayed = { showMarkAllUnplayedDialog = true },
                             onToggleHideCompleted = { viewModel.toggleHideCompleted() },
@@ -594,6 +695,85 @@ fun PodcastInfoScreen(
                             },
                         ),
                 )
+
+                AnimatedVisibility(
+                    visible = selectionActive,
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(
+                                start = 12.dp,
+                                end = 12.dp,
+                                bottom =
+                                    WindowInsets.navigationBars
+                                        .asPaddingValues()
+                                        .calculateBottomPadding() + bottomContentPadding + 12.dp,
+                            ),
+                    enter = slideInVertically { height -> height } + fadeIn(),
+                    exit = slideOutVertically { height -> height } + fadeOut(),
+                ) {
+                    EpisodeSelectionToolbar(
+                        state =
+                            EpisodeSelectionToolbarState(
+                                selectedCount = selectedEpisodeIds.size,
+                                canDownload =
+                                    selectedEpisodes.any {
+                                        it.id !in downloadedEpisodeIds && it.id !in downloadingEpisodeIds
+                                    },
+                                canMarkCompleted = selectedEpisodes.any { it.id !in completedEpisodeIds },
+                                canAddToQueue = selectedEpisodes.any { it.id !in queuedEpisodeIds },
+                                hasRangeAnchor =
+                                    selectionAnchorEpisodeId != null &&
+                                        (selectionEpisodePool + state.episodes).any {
+                                            it.id == selectionAnchorEpisodeId
+                                        },
+                                isLoadingFullSelection = isLoadingFullSelection,
+                            ),
+                        actions =
+                            EpisodeSelectionToolbarActions(
+                                onClear = clearEpisodeSelection,
+                                onDownload = {
+                                    viewModel.downloadEpisodes(selectedEpisodes)
+                                    clearEpisodeSelection()
+                                },
+                                onMarkCompleted = {
+                                    viewModel.markEpisodesCompleted(selectedEpisodes)
+                                    clearEpisodeSelection()
+                                },
+                                onPlay = {
+                                    viewModel.playEpisodes(selectedEpisodes)
+                                    clearEpisodeSelection()
+                                },
+                                onAddToQueue = {
+                                    viewModel.addEpisodesToQueue(selectedEpisodes)
+                                    clearEpisodeSelection()
+                                },
+                                onSelectVisible = {
+                                    val visibleItemKeys =
+                                        listState.layoutInfo.visibleItemsInfo
+                                            .mapNotNull { item -> item.key as? String }
+                                            .toSet()
+                                    val visibleEpisodes =
+                                        PodcastEpisodeSelectionLogic
+                                            .visibleEpisodes(feedItems, visibleItemKeys)
+                                            .filterNot { hideCompleted && it.id in completedEpisodeIds }
+                                    selectionEpisodePool =
+                                        (selectionEpisodePool + visibleEpisodes).distinctBy(Episode::id)
+                                    selectedEpisodeIds =
+                                        (selectedEpisodeIdSet + visibleEpisodes.map(Episode::id)).toList()
+                                },
+                                onSelectAll = {
+                                    selectFullRange(EpisodeSelectionRange.ALL)
+                                },
+                                onSelectOlder = {
+                                    selectFullRange(EpisodeSelectionRange.OLDER)
+                                },
+                                onSelectNewer = {
+                                    selectFullRange(EpisodeSelectionRange.NEWER)
+                                },
+                            ),
+                    )
+                }
 
                 if (showMissingEpisodesConfirm) {
                     AlertDialog(
@@ -718,7 +898,7 @@ fun PodcastInfoScreen(
                 }
 
                 val jumpPillVisible =
-                    targetJumpEpisode != null && !isTargetVisible && isFabVisible
+                    targetJumpEpisode != null && !isTargetVisible && isFabVisible && !selectionActive
                 SnackbarHost(
                     hostState = snackbarHostState,
                     modifier =
@@ -728,7 +908,11 @@ fun PodcastInfoScreen(
                             .padding(
                                 bottom =
                                     bottomContentPadding + 16.dp +
-                                        if (jumpPillVisible) 56.dp else 0.dp,
+                                        when {
+                                            jumpPillVisible -> 56.dp
+                                            selectionActive -> 72.dp
+                                            else -> 0.dp
+                                        },
                             ),
                 )
 

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoViewModel.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoViewModel.kt
@@ -350,6 +350,14 @@ class PodcastInfoViewModel(
         }
     }
 
+    fun markEpisodesUncompleted(episodes: List<Episode>) {
+        val targets = episodes.distinctBy(Episode::id)
+        if (targets.isEmpty()) return
+        viewModelScope.launch {
+            playbackRepository.markAllEpisodesUncompleted(episodes = targets)
+        }
+    }
+
     fun playEpisodes(episodes: List<Episode>) {
         val currentState = _uiState.value as? PodcastInfoUiState.Success ?: return
         val targets = episodes.distinctBy(Episode::id)

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoViewModel.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/PodcastInfoViewModel.kt
@@ -6,11 +6,14 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import cx.aswin.boxlore.core.domain.ports.EpisodeSupplementPort
 import cx.aswin.boxlore.core.model.Episode
+import cx.aswin.boxlore.core.model.PlaybackEntryPoint
 import cx.aswin.boxlore.core.model.Podcast
+import cx.aswin.boxlore.core.playback.addToQueue
 import cx.aswin.boxlore.core.playback.addToQueueNext
 import cx.aswin.boxlore.core.playback.completedEpisodeIds
 import cx.aswin.boxlore.core.playback.likedEpisodes
 import cx.aswin.boxlore.core.playback.markAllEpisodesUncompleted
+import cx.aswin.boxlore.core.playback.playQueue
 import cx.aswin.boxlore.core.playback.removeFromQueue
 import cx.aswin.boxlore.core.playback.toggleCompletion
 import cx.aswin.boxlore.core.playback.toggleLike
@@ -33,6 +36,12 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+
+internal data class PodcastEpisodeSelectionWindow(
+    val episodes: List<Episode>,
+    val newestFirst: Boolean,
+    val isTruncated: Boolean,
+)
 
 @Suppress("kotlin:S6310")
 class PodcastInfoViewModel(
@@ -316,6 +325,92 @@ class PodcastInfoViewModel(
         }
     }
 
+    fun downloadEpisodes(episodes: List<Episode>) {
+        val currentState = _uiState.value as? PodcastInfoUiState.Success ?: return
+        val unavailableIds = downloadedEpisodeIds.value + downloadingEpisodeIds.value
+        episodes
+            .distinctBy(Episode::id)
+            .filterNot { it.id in unavailableIds }
+            .forEach { episode ->
+                downloadRepository.addDownload(episode, currentState.podcast)
+            }
+    }
+
+    fun markEpisodesCompleted(episodes: List<Episode>) {
+        val currentState = _uiState.value as? PodcastInfoUiState.Success ?: return
+        val targets = episodes.distinctBy(Episode::id)
+        if (targets.isEmpty()) return
+        viewModelScope.launch {
+            playbackRepository.markAllEpisodesCompleted(
+                episodes = targets,
+                podcastId = currentState.podcast.id,
+                podcastTitle = currentState.podcast.title,
+                podcastImageUrl = currentState.podcast.imageUrl,
+            )
+        }
+    }
+
+    fun playEpisodes(episodes: List<Episode>) {
+        val currentState = _uiState.value as? PodcastInfoUiState.Success ?: return
+        val targets = episodes.distinctBy(Episode::id)
+        if (targets.isEmpty()) return
+        playedEpisodes.addAll(targets.map(Episode::id))
+        viewModelScope.launch {
+            playbackRepository.playQueue(
+                episodes = targets,
+                podcast = currentState.podcast,
+                startIndex = 0,
+                entryPoint = PlaybackEntryPoint.GENERIC,
+            )
+        }
+    }
+
+    fun addEpisodesToQueue(episodes: List<Episode>) {
+        val currentState = _uiState.value as? PodcastInfoUiState.Success ?: return
+        viewModelScope.launch {
+            episodes.distinctBy(Episode::id).forEach { episode ->
+                val added =
+                    playbackRepository.addToQueue(
+                        episode = episode,
+                        podcast = currentState.podcast,
+                    )
+                if (added) {
+                    cx.aswin.boxlore.core.analytics.AnalyticsHelper.trackQueueModified(
+                        action = "add",
+                        episodeId = episode.id,
+                        podcastId = currentState.podcast.id,
+                        queueSize = playbackRepository.playerState.value.queue.size,
+                    )
+                }
+            }
+        }
+    }
+
+    internal suspend fun loadEpisodeSelectionWindow(): PodcastEpisodeSelectionWindow {
+        val currentState = _uiState.value as? PodcastInfoUiState.Success
+        val newestFirst = currentState?.currentSort != EpisodeSort.OLDEST
+        if (currentState == null) {
+            return PodcastEpisodeSelectionWindow(emptyList(), newestFirst, isTruncated = false)
+        }
+        val sort = if (newestFirst) "newest" else "oldest"
+        val page =
+            repository.getEpisodesPaginated(
+                feedId = currentPodcastId,
+                limit = MAX_SELECTION_EPISODES,
+                offset = 0,
+                sort = sort,
+            )
+        val episodes =
+            (page.episodes + currentState.episodes)
+                .distinctBy(Episode::id)
+                .take(MAX_SELECTION_EPISODES)
+        return PodcastEpisodeSelectionWindow(
+            episodes = episodes,
+            newestFirst = newestFirst,
+            isTruncated = page.hasMore,
+        )
+    }
+
     fun isDownloaded(episodeId: String): kotlinx.coroutines.flow.Flow<Boolean> = downloadRepository.isDownloaded(episodeId)
 
     fun isDownloading(episodeId: String): kotlinx.coroutines.flow.Flow<Boolean> =
@@ -329,6 +424,7 @@ class PodcastInfoViewModel(
     companion object {
         private const val TAG = "PodcastInfoViewModel"
         private const val PAGE_SIZE = 20
+        private const val MAX_SELECTION_EPISODES = 1_000
         private const val SEARCH_DEBOUNCE_MS = 500L
     }
 

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeListItem.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeListItem.kt
@@ -56,7 +56,10 @@ fun EpisodeListItem(
     isQueued: Boolean,
     isCompleted: Boolean,
     isUpNext: Boolean = false,
+    selectionActive: Boolean = false,
+    isSelected: Boolean = false,
     onClick: () -> Unit,
+    onLongClick: () -> Unit = {},
     onPlayClick: () -> Unit,
     onToggleLike: () -> Unit,
     onQueueClick: () -> Unit,
@@ -70,13 +73,31 @@ fun EpisodeListItem(
         modifier =
             modifier
                 .fillMaxWidth()
-                .expressiveClickable(onClick = onClick),
+                .expressiveClickable(
+                    onLongClickLabel = "Select episode",
+                    onLongClick = onLongClick,
+                    onClick = onClick,
+                ),
         shape = MaterialTheme.shapes.large,
         colors =
             androidx.compose.material3.CardDefaults.outlinedCardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                containerColor =
+                    if (isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainer
+                    },
             ),
-        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
+        border =
+            BorderStroke(
+                width = if (isSelected) 2.dp else 0.5.dp,
+                color =
+                    if (isSelected) {
+                        MaterialTheme.colorScheme.primary
+                    } else {
+                        MaterialTheme.colorScheme.outlineVariant
+                    },
+            ),
         elevation =
             androidx.compose.material3.CardDefaults
                 .outlinedCardElevation(defaultElevation = 1.dp),
@@ -104,21 +125,40 @@ fun EpisodeListItem(
                         )
                     }
 
-                    if (isCompleted) {
+                    if (isSelected || isCompleted) {
                         Box(
                             modifier =
                                 Modifier
                                     .align(Alignment.TopEnd)
                                     .padding(4.dp)
                                     .size(20.dp)
-                                    .background(MaterialTheme.colorScheme.secondaryContainer, CircleShape)
-                                    .border(1.dp, MaterialTheme.colorScheme.onSecondaryContainer, CircleShape),
+                                    .background(
+                                        if (isSelected) {
+                                            MaterialTheme.colorScheme.primary
+                                        } else {
+                                            MaterialTheme.colorScheme.secondaryContainer
+                                        },
+                                        CircleShape,
+                                    ).border(
+                                        1.dp,
+                                        if (isSelected) {
+                                            MaterialTheme.colorScheme.onPrimary
+                                        } else {
+                                            MaterialTheme.colorScheme.onSecondaryContainer
+                                        },
+                                        CircleShape,
+                                    ),
                             contentAlignment = Alignment.Center,
                         ) {
                             Icon(
                                 imageVector = Icons.Rounded.Check,
-                                contentDescription = "Completed",
-                                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                contentDescription = if (isSelected) "Selected" else "Completed",
+                                tint =
+                                    if (isSelected) {
+                                        MaterialTheme.colorScheme.onPrimary
+                                    } else {
+                                        MaterialTheme.colorScheme.onSecondaryContainer
+                                    },
                                 modifier = Modifier.size(14.dp),
                             )
                         }
@@ -278,55 +318,55 @@ fun EpisodeListItem(
                 }
             }
 
-            Spacer(modifier = Modifier.height(14.dp))
+            if (!selectionActive) {
+                Spacer(modifier = Modifier.height(14.dp))
 
-            // 2. Control Row
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween, // Push play button to edge
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .animateContentSize(),
-            ) {
-                // Secondary Controls (Tonal squircle for premium feel on card)
-                cx.aswin.boxlore.core.designsystem.components.AdvancedPlayerControls(
-                    isLiked = isLiked,
-                    isDownloaded = isDownloaded,
-                    isDownloading = isDownloading,
-                    colorScheme = MaterialTheme.colorScheme,
-                    onLikeClick = onToggleLike,
-                    onDownloadClick = onDownloadClick,
-                    onQueueClick = onQueueClick,
-                    style = cx.aswin.boxlore.core.designsystem.components.ControlStyle.TonalSquircle,
-                    overrideColor = accentColor,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    showAddQueueIcon = true,
-                    isQueued = isQueued,
-                    showShareButton = false,
-                    isPlayed = isCompleted,
-                    showMarkPlayedButton = showMarkPlayedButton,
-                    onMarkPlayedClick = onMarkPlayedClick,
-                    controlSize = 40.dp,
-                )
-
-                // Play Button
-                cx.aswin.boxlore.core.designsystem.components.ExpressivePlayButton(
-                    onClick = onPlayClick,
-                    state =
-                        cx.aswin.boxlore.core.designsystem.components.ExpressivePlayButtonState(
-                            isPlaying = isPlaying,
-                            isResume = isResume,
-                            progress = progress,
-                            timeText = timeLeft,
-                        ),
-                    accentColor = accentColor,
+                // 2. Control Row
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
                     modifier =
                         Modifier
-                            .height(44.dp)
-                            .padding(start = 16.dp)
-                            .weight(1f),
-                )
+                            .fillMaxWidth()
+                            .animateContentSize(),
+                ) {
+                    cx.aswin.boxlore.core.designsystem.components.AdvancedPlayerControls(
+                        isLiked = isLiked,
+                        isDownloaded = isDownloaded,
+                        isDownloading = isDownloading,
+                        colorScheme = MaterialTheme.colorScheme,
+                        onLikeClick = onToggleLike,
+                        onDownloadClick = onDownloadClick,
+                        onQueueClick = onQueueClick,
+                        style = cx.aswin.boxlore.core.designsystem.components.ControlStyle.TonalSquircle,
+                        overrideColor = accentColor,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        showAddQueueIcon = true,
+                        isQueued = isQueued,
+                        showShareButton = false,
+                        isPlayed = isCompleted,
+                        showMarkPlayedButton = showMarkPlayedButton,
+                        onMarkPlayedClick = onMarkPlayedClick,
+                        controlSize = 40.dp,
+                    )
+
+                    cx.aswin.boxlore.core.designsystem.components.ExpressivePlayButton(
+                        onClick = onPlayClick,
+                        state =
+                            cx.aswin.boxlore.core.designsystem.components.ExpressivePlayButtonState(
+                                isPlaying = isPlaying,
+                                isResume = isResume,
+                                progress = progress,
+                                timeText = timeLeft,
+                            ),
+                        accentColor = accentColor,
+                        modifier =
+                            Modifier
+                                .height(44.dp)
+                                .padding(start = 16.dp)
+                                .weight(1f),
+                    )
+                }
             }
         }
     }

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeSelectionToolbar.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeSelectionToolbar.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.rounded.DoneAll
 import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.RadioButtonUnchecked
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -37,7 +38,7 @@ import cx.aswin.boxlore.feature.info.R
 internal data class EpisodeSelectionToolbarState(
     val selectedCount: Int,
     val canDownload: Boolean,
-    val canMarkCompleted: Boolean,
+    val markAsUnplayed: Boolean,
     val canAddToQueue: Boolean,
     val hasRangeAnchor: Boolean,
     val isLoadingFullSelection: Boolean,
@@ -46,7 +47,7 @@ internal data class EpisodeSelectionToolbarState(
 internal data class EpisodeSelectionToolbarActions(
     val onClear: () -> Unit,
     val onDownload: () -> Unit,
-    val onMarkCompleted: () -> Unit,
+    val onToggleCompletion: () -> Unit,
     val onPlay: () -> Unit,
     val onAddToQueue: () -> Unit,
     val onSelectVisible: () -> Unit,
@@ -91,12 +92,23 @@ internal fun EpisodeSelectionToolbar(
                 )
             }
             IconButton(
-                onClick = actions.onMarkCompleted,
-                enabled = state.canMarkCompleted,
+                onClick = actions.onToggleCompletion,
             ) {
                 Icon(
-                    imageVector = Icons.Rounded.DoneAll,
-                    contentDescription = stringResource(R.string.episode_selection_mark_completed),
+                    imageVector =
+                        if (state.markAsUnplayed) {
+                            Icons.Rounded.RadioButtonUnchecked
+                        } else {
+                            Icons.Rounded.DoneAll
+                        },
+                    contentDescription =
+                        stringResource(
+                            if (state.markAsUnplayed) {
+                                R.string.episode_selection_mark_unplayed
+                            } else {
+                                R.string.episode_selection_mark_completed
+                            },
+                        ),
                 )
             }
             FilledIconButton(onClick = actions.onPlay) {

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeSelectionToolbar.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/EpisodeSelectionToolbar.kt
@@ -1,0 +1,205 @@
+package cx.aswin.boxlore.feature.info.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.rounded.DoneAll
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilledIconButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import cx.aswin.boxlore.core.designsystem.theme.ExpressiveShapes
+import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
+import cx.aswin.boxlore.feature.info.R
+
+internal data class EpisodeSelectionToolbarState(
+    val selectedCount: Int,
+    val canDownload: Boolean,
+    val canMarkCompleted: Boolean,
+    val canAddToQueue: Boolean,
+    val hasRangeAnchor: Boolean,
+    val isLoadingFullSelection: Boolean,
+)
+
+internal data class EpisodeSelectionToolbarActions(
+    val onClear: () -> Unit,
+    val onDownload: () -> Unit,
+    val onMarkCompleted: () -> Unit,
+    val onPlay: () -> Unit,
+    val onAddToQueue: () -> Unit,
+    val onSelectVisible: () -> Unit,
+    val onSelectAll: () -> Unit,
+    val onSelectOlder: () -> Unit,
+    val onSelectNewer: () -> Unit,
+)
+
+@Composable
+internal fun EpisodeSelectionToolbar(
+    state: EpisodeSelectionToolbarState,
+    actions: EpisodeSelectionToolbarActions,
+    modifier: Modifier = Modifier,
+) {
+    var rangeMenuExpanded by remember { mutableStateOf(false) }
+    Surface(
+        modifier = modifier,
+        shape = ExpressiveShapes.Pill,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        tonalElevation = 8.dp,
+        shadowElevation = 8.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = state.selectedCount.toString(),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = GoogleSansWeight.bold,
+                modifier = Modifier.padding(horizontal = 6.dp),
+            )
+            IconButton(
+                onClick = actions.onDownload,
+                enabled = state.canDownload,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Download,
+                    contentDescription = stringResource(R.string.episode_selection_download),
+                )
+            }
+            IconButton(
+                onClick = actions.onMarkCompleted,
+                enabled = state.canMarkCompleted,
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.DoneAll,
+                    contentDescription = stringResource(R.string.episode_selection_mark_completed),
+                )
+            }
+            FilledIconButton(onClick = actions.onPlay) {
+                Icon(
+                    imageVector = Icons.Rounded.PlayArrow,
+                    contentDescription = stringResource(R.string.episode_selection_play),
+                )
+            }
+            IconButton(
+                onClick = actions.onAddToQueue,
+                enabled = state.canAddToQueue,
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Rounded.PlaylistAdd,
+                    contentDescription = stringResource(R.string.episode_selection_add_queue),
+                )
+            }
+            EpisodeSelectionRangeMenu(
+                state = state,
+                actions = actions,
+                expanded = rangeMenuExpanded,
+                onExpandedChange = { rangeMenuExpanded = it },
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpisodeSelectionRangeMenu(
+    state: EpisodeSelectionToolbarState,
+    actions: EpisodeSelectionToolbarActions,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+) {
+    Box {
+        IconButton(
+            onClick = { onExpandedChange(true) },
+            enabled = !state.isLoadingFullSelection,
+        ) {
+            if (state.isLoadingFullSelection) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+            } else {
+                Icon(
+                    imageVector = Icons.Rounded.MoreVert,
+                    contentDescription = stringResource(R.string.episode_selection_more),
+                )
+            }
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { onExpandedChange(false) },
+        ) {
+            RangeMenuItem(
+                text = stringResource(R.string.episode_selection_select_visible),
+                onClick = {
+                    onExpandedChange(false)
+                    actions.onSelectVisible()
+                },
+            )
+            RangeMenuItem(
+                text = stringResource(R.string.episode_selection_select_all),
+                onClick = {
+                    onExpandedChange(false)
+                    actions.onSelectAll()
+                },
+            )
+            RangeMenuItem(
+                text = stringResource(R.string.episode_selection_select_older),
+                enabled = state.hasRangeAnchor,
+                onClick = {
+                    onExpandedChange(false)
+                    actions.onSelectOlder()
+                },
+            )
+            RangeMenuItem(
+                text = stringResource(R.string.episode_selection_select_newer),
+                enabled = state.hasRangeAnchor,
+                onClick = {
+                    onExpandedChange(false)
+                    actions.onSelectNewer()
+                },
+            )
+            HorizontalDivider()
+            RangeMenuItem(
+                text = stringResource(R.string.episode_selection_clear),
+                onClick = {
+                    onExpandedChange(false)
+                    actions.onClear()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun RangeMenuItem(
+    text: String,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    DropdownMenuItem(
+        text = { Text(text) },
+        enabled = enabled,
+        onClick = onClick,
+    )
+}

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/PodcastInfoChrome.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/PodcastInfoChrome.kt
@@ -256,15 +256,27 @@ internal data class EpisodeListIndicators(
     val completedEpisodeIds: Set<String> = emptySet(),
 )
 
+internal data class EpisodeSelectionUi(
+    val selectedEpisodeIds: Set<String> = emptySet(),
+    val isActive: Boolean = false,
+    val onToggle: (Episode) -> Unit = {},
+    val onLongPress: (Episode) -> Unit = {},
+)
+
+internal data class EpisodeFeedRowUi(
+    val accentColor: Color,
+    val indicators: EpisodeListIndicators,
+    val autoScrolledEpisodeId: String?,
+    val podcastImageUrl: String?,
+)
+
 @Composable
 internal fun EpisodeFeedItemRow(
     feedItem: FeedItem,
     viewModel: PodcastInfoViewModel,
-    accentColor: Color,
-    indicators: EpisodeListIndicators,
-    autoScrolledEpisodeId: String?,
+    ui: EpisodeFeedRowUi,
     onEpisodeClick: (Episode, String, Int?) -> Unit,
-    podcastImageUrl: String? = null,
+    selection: EpisodeSelectionUi = EpisodeSelectionUi(),
 ) {
     when (feedItem) {
         is FeedItem.NormalEpisode -> {
@@ -277,24 +289,31 @@ internal fun EpisodeFeedItemRow(
             ) { playState ->
                 EpisodeListItem(
                     episode = episode,
-                    isLiked = indicators.likedEpisodeIds.contains(episode.id),
-                    accentColor = accentColor,
-                    podcastImageUrl = podcastImageUrl,
+                    isLiked = ui.indicators.likedEpisodeIds.contains(episode.id),
+                    accentColor = ui.accentColor,
+                    podcastImageUrl = ui.podcastImageUrl,
                     // Playback State
                     isPlaying = playState?.isPlaying == true,
                     isResume = playState?.isResume == true,
                     progress = playState?.progress ?: 0f,
                     timeLeft = playState?.timeLeft,
                     // Download State
-                    isDownloaded = indicators.downloadedEpisodeIds.contains(episode.id),
-                    isDownloading = indicators.downloadingEpisodeIds.contains(episode.id),
-                    isQueued = indicators.queuedEpisodeIds.contains(episode.id),
-                    isCompleted = indicators.completedEpisodeIds.contains(episode.id),
-                    isUpNext = episode.id == autoScrolledEpisodeId,
+                    isDownloaded = ui.indicators.downloadedEpisodeIds.contains(episode.id),
+                    isDownloading = ui.indicators.downloadingEpisodeIds.contains(episode.id),
+                    isQueued = ui.indicators.queuedEpisodeIds.contains(episode.id),
+                    isCompleted = ui.indicators.completedEpisodeIds.contains(episode.id),
+                    isUpNext = episode.id == ui.autoScrolledEpisodeId,
+                    selectionActive = selection.isActive,
+                    isSelected = episode.id in selection.selectedEpisodeIds,
                     onClick = {
-                        viewModel.recordEpisodeClick(episode.id)
-                        onEpisodeClick(episode, "podcast_info_episodes_list", index)
+                        if (selection.isActive) {
+                            selection.onToggle(episode)
+                        } else {
+                            viewModel.recordEpisodeClick(episode.id)
+                            onEpisodeClick(episode, "podcast_info_episodes_list", index)
+                        }
                     },
+                    onLongClick = { selection.onLongPress(episode) },
                     onPlayClick = { viewModel.onPlayClick(episode) },
                     onToggleLike = { viewModel.onToggleLike(episode) },
                     onQueueClick = { viewModel.toggleQueue(episode) },
@@ -315,6 +334,7 @@ internal fun EpisodeFeedItemRow(
                     onEpisodeClick(ep, "podcast_info_episodes_list", globalIndex)
                 },
                 onPlayClick = { ep -> viewModel.onPlayClick(ep) },
+                selection = selection,
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
         }
@@ -327,6 +347,7 @@ internal fun EpisodeFeedItemRow(
                     onEpisodeClick(ep, "podcast_info_episodes_list", globalIndex)
                 },
                 onPlayClick = { ep -> viewModel.onPlayClick(ep) },
+                selection = selection,
                 modifier = Modifier.padding(horizontal = 16.dp),
             )
         }
@@ -510,7 +531,7 @@ private fun PodcastInfoOverflowMenuItems(
     )
     if (actions.isSubscribed) {
         DropdownMenuItem(
-            text = { Text(if (actions.isPinnedToHome) "Unpin" else "Pin") },
+            text = { Text(if (actions.isPinnedToHome) "Unpin from Home screen" else "Pin to Home screen") },
             onClick = {
                 onDismiss()
                 actions.onToggleHomePin()

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/PodcastTrailerCards.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/components/PodcastTrailerCards.kt
@@ -1,7 +1,5 @@
 package cx.aswin.boxlore.feature.info.components
 
-import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
-
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -18,11 +16,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Movie
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -36,10 +37,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import cx.aswin.boxlore.core.designsystem.theme.ExpressiveShapes
+import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
 import cx.aswin.boxlore.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxlore.core.model.Episode
 import cx.aswin.boxlore.feature.info.PodcastInfoViewModel
@@ -48,128 +52,111 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
+private typealias EpisodePlaybackStates = Map<String, PodcastInfoViewModel.EpisodePlaybackState>
+
+private data class TrailerPlaybackUi(
+    val isPlaying: Boolean,
+    val isResume: Boolean,
+)
+
+private data class TrailerLeadVisuals(
+    val containerColor: Color,
+    val icon: ImageVector?,
+    val contentDescription: String?,
+    val iconTint: Color,
+)
+
 @Composable
-fun SingleTrailerCard(
+internal fun SingleTrailerCard(
     episode: Episode,
     globalIndex: Int,
-    playbackStateFlow: kotlinx.coroutines.flow.Flow<Map<String, PodcastInfoViewModel.EpisodePlaybackState>>,
+    playbackStateFlow: Flow<EpisodePlaybackStates>,
     onEpisodeClick: (Episode, Int) -> Unit,
     onPlayClick: (Episode) -> Unit,
+    selection: EpisodeSelectionUi = EpisodeSelectionUi(),
     modifier: Modifier = Modifier,
 ) {
-    EpisodePlayStateWrapper(episodeId = episode.id, playbackStateFlow = playbackStateFlow) { playState ->
-        val isPlaying = playState?.isPlaying == true
-        val isResume = playState?.isResume == true
+    EpisodePlayStateWrapper(episode.id, playbackStateFlow) { playState ->
+        SingleTrailerContent(
+            episode = episode,
+            globalIndex = globalIndex,
+            playback = TrailerPlaybackUi(playState?.isPlaying == true, playState?.isResume == true),
+            onEpisodeClick = onEpisodeClick,
+            onPlayClick = onPlayClick,
+            selection = selection,
+            modifier = modifier,
+        )
+    }
+}
 
-        OutlinedCard(
-            modifier =
-                modifier
-                    .fillMaxWidth()
-                    .expressiveClickable { onEpisodeClick(episode, globalIndex) },
-            shape = MaterialTheme.shapes.large,
-            colors =
-                androidx.compose.material3.CardDefaults.outlinedCardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+@Composable
+private fun SingleTrailerContent(
+    episode: Episode,
+    globalIndex: Int,
+    playback: TrailerPlaybackUi,
+    onEpisodeClick: (Episode, Int) -> Unit,
+    onPlayClick: (Episode) -> Unit,
+    selection: EpisodeSelectionUi,
+    modifier: Modifier,
+) {
+    val isSelected = episode.id in selection.selectedEpisodeIds
+    OutlinedCard(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .expressiveClickable(
+                    onLongClickLabel = "Select episode",
+                    onLongClick = { selection.onLongPress(episode) },
+                    onClick = {
+                        if (selection.isActive) selection.onToggle(episode) else onEpisodeClick(episode, globalIndex)
+                    },
                 ),
-            border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-            elevation =
-                androidx.compose.material3.CardDefaults
-                    .outlinedCardElevation(defaultElevation = 1.dp),
+        shape = MaterialTheme.shapes.large,
+        colors =
+            CardDefaults.outlinedCardColors(
+                containerColor =
+                    if (isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLow
+                    },
+            ),
+        border = trailerBorder(isSelected),
+        elevation = CardDefaults.outlinedCardElevation(defaultElevation = 1.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                // Play Button
-                Surface(
-                    shape = CircleShape,
-                    color = if (isPlaying || isResume) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant,
-                    modifier =
-                        Modifier
-                            .size(40.dp) // Slightly larger play button for a better hit target
-                            .expressiveClickable(isolate = true) { onPlayClick(episode) },
-                ) {
-                    Icon(
-                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                        contentDescription = if (isPlaying) "Pause" else "Play",
-                        tint =
-                            if (isPlaying ||
-                                isResume
-                            ) {
-                                MaterialTheme.colorScheme.onPrimary
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            },
-                        modifier = Modifier.padding(10.dp),
-                    )
-                }
-
-                Spacer(modifier = Modifier.width(14.dp))
-
-                // Text
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = episode.title,
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = GoogleSansWeight.bold,
-                        color = MaterialTheme.colorScheme.onSurface,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-
-                    Spacer(modifier = Modifier.height(4.dp))
-
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Surface(
-                            shape = ExpressiveShapes.Pill,
-                            color = MaterialTheme.colorScheme.tertiaryContainer,
-                        ) {
-                            Text(
-                                text = "Trailer",
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = GoogleSansWeight.bold,
-                                color = MaterialTheme.colorScheme.onTertiaryContainer,
-                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                            )
-                        }
-
-                        val durationText =
-                            if (episode.duration > 0) {
-                                val h = episode.duration / 3600
-                                val m = (episode.duration % 3600) / 60
-                                if (h > 0) "${h}hr ${m}min" else "${m}min"
-                            } else {
-                                ""
-                            }
-
-                        if (durationText.isNotEmpty()) {
-                            Spacer(modifier = Modifier.width(6.dp))
-                            Text(
-                                text = durationText,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                }
-            }
+            TrailerLeadButton(
+                episode = episode,
+                playback = playback,
+                selection = selection,
+                size = 40.dp,
+                iconPadding = 10.dp,
+                onPlayClick = onPlayClick,
+            )
+            Spacer(modifier = Modifier.width(14.dp))
+            TrailerSummary(
+                episode = episode,
+                showBadge = true,
+                modifier = Modifier.weight(1f),
+            )
         }
     }
 }
 
 @Composable
-fun TrailerStackCard(
+internal fun TrailerStackCard(
     group: FeedItem.TrailerGroup,
-    playbackStateFlow: kotlinx.coroutines.flow.Flow<Map<String, PodcastInfoViewModel.EpisodePlaybackState>>,
+    playbackStateFlow: Flow<EpisodePlaybackStates>,
     onEpisodeClick: (Episode, Int) -> Unit,
     onPlayClick: (Episode) -> Unit,
+    selection: EpisodeSelectionUi = EpisodeSelectionUi(),
     modifier: Modifier = Modifier,
 ) {
     var isExpanded by remember { mutableStateOf(false) }
-
+    val selectedCount = group.trailers.count { (episode, _) -> episode.id in selection.selectedEpisodeIds }
     OutlinedCard(
         modifier =
             modifier
@@ -177,158 +164,312 @@ fun TrailerStackCard(
                 .animateContentSize(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)),
         shape = MaterialTheme.shapes.large,
         colors =
-            androidx.compose.material3.CardDefaults.outlinedCardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            CardDefaults.outlinedCardColors(
+                containerColor =
+                    if (selectedCount > 0) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLow
+                    },
             ),
-        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-        elevation =
-            androidx.compose.material3.CardDefaults
-                .outlinedCardElevation(defaultElevation = 1.dp),
+        border = trailerBorder(selectedCount > 0),
+        elevation = CardDefaults.outlinedCardElevation(defaultElevation = 1.dp),
     ) {
         Column {
-            // Header Row (Always visible)
-            Row(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .expressiveClickable { isExpanded = !isExpanded }
-                        .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Surface(
-                        shape = CircleShape,
-                        color = MaterialTheme.colorScheme.secondaryContainer,
-                        modifier = Modifier.size(32.dp),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Rounded.Movie,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                            modifier = Modifier.padding(6.dp),
-                        )
-                    }
-                    Column {
-                        Text(
-                            text = "Promotional Trailers",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = GoogleSansWeight.bold,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Text(
-                            text = "${group.trailers.size} trailers",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-                Icon(
-                    imageVector = if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
-                    contentDescription = if (isExpanded) "Collapse" else "Expand",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            // Expanded Content (Mini-Trailers)
+            TrailerStackHeader(
+                trailerCount = group.trailers.size,
+                selectedCount = selectedCount,
+                isExpanded = isExpanded,
+                onToggle = { isExpanded = !isExpanded },
+            )
             if (isExpanded) {
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .background(MaterialTheme.colorScheme.surfaceContainerHigh),
-                ) {
-                    group.trailers.forEachIndexed { index, (episode, globalIndex) ->
-                        EpisodePlayStateWrapper(episodeId = episode.id, playbackStateFlow = playbackStateFlow) { playState ->
-                            val isPlaying = playState?.isPlaying == true
-                            val isResume = playState?.isResume == true
-
-                            Row(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .expressiveClickable { onEpisodeClick(episode, globalIndex) }
-                                        .padding(horizontal = 16.dp, vertical = 12.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                // Play Button
-                                Surface(
-                                    shape = CircleShape,
-                                    color =
-                                        if (isPlaying ||
-                                            isResume
-                                        ) {
-                                            MaterialTheme.colorScheme.primary
-                                        } else {
-                                            MaterialTheme.colorScheme.surfaceVariant
-                                        },
-                                    modifier =
-                                        Modifier
-                                            .size(36.dp)
-                                            .expressiveClickable(isolate = true) { onPlayClick(episode) },
-                                ) {
-                                    Icon(
-                                        imageVector = if (isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
-                                        contentDescription = if (isPlaying) "Pause" else "Play",
-                                        tint =
-                                            if (isPlaying ||
-                                                isResume
-                                            ) {
-                                                MaterialTheme.colorScheme.onPrimary
-                                            } else {
-                                                MaterialTheme.colorScheme.onSurfaceVariant
-                                            },
-                                        modifier = Modifier.padding(8.dp),
-                                    )
-                                }
-
-                                Spacer(modifier = Modifier.width(12.dp))
-
-                                // Text
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = episode.title,
-                                        style = MaterialTheme.typography.labelLarge,
-                                        color = MaterialTheme.colorScheme.onSurface,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
-                                    val durationText =
-                                        if (episode.duration > 0) {
-                                            val h = episode.duration / 3600
-                                            val m = (episode.duration % 3600) / 60
-                                            if (h > 0) "${h}hr ${m}min" else "${m}min"
-                                        } else {
-                                            "Trailer"
-                                        }
-
-                                    Text(
-                                        text = durationText,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                }
-                            }
-                        }
-
-                        if (index < group.trailers.lastIndex) {
-                            androidx.compose.material3.HorizontalDivider(
-                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
-                                modifier = Modifier.padding(start = 64.dp),
-                            )
-                        }
-                    }
-                }
+                TrailerStackContent(
+                    group = group,
+                    playbackStateFlow = playbackStateFlow,
+                    onEpisodeClick = onEpisodeClick,
+                    onPlayClick = onPlayClick,
+                    selection = selection,
+                )
             }
         }
     }
 }
 
+@Composable
+private fun TrailerStackHeader(
+    trailerCount: Int,
+    selectedCount: Int,
+    isExpanded: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().expressiveClickable(onClick = onToggle).padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.secondaryContainer,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Movie,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier.padding(6.dp),
+                )
+            }
+            Column {
+                Text(
+                    text = "Promotional Trailers",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = GoogleSansWeight.bold,
+                )
+                Text(
+                    text =
+                        if (selectedCount > 0) {
+                            "$selectedCount of $trailerCount selected"
+                        } else {
+                            "$trailerCount trailers"
+                        },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        Icon(
+            imageVector = if (isExpanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+            contentDescription = if (isExpanded) "Collapse" else "Expand",
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun TrailerStackContent(
+    group: FeedItem.TrailerGroup,
+    playbackStateFlow: Flow<EpisodePlaybackStates>,
+    onEpisodeClick: (Episode, Int) -> Unit,
+    onPlayClick: (Episode) -> Unit,
+    selection: EpisodeSelectionUi,
+) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+    ) {
+        group.trailers.forEachIndexed { index, (episode, globalIndex) ->
+            TrailerStackRow(
+                episode = episode,
+                globalIndex = globalIndex,
+                playbackStateFlow = playbackStateFlow,
+                onEpisodeClick = onEpisodeClick,
+                onPlayClick = onPlayClick,
+                selection = selection,
+            )
+            if (index < group.trailers.lastIndex) {
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f),
+                    modifier = Modifier.padding(start = 64.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TrailerStackRow(
+    episode: Episode,
+    globalIndex: Int,
+    playbackStateFlow: Flow<EpisodePlaybackStates>,
+    onEpisodeClick: (Episode, Int) -> Unit,
+    onPlayClick: (Episode) -> Unit,
+    selection: EpisodeSelectionUi,
+) {
+    EpisodePlayStateWrapper(episode.id, playbackStateFlow) { playState ->
+        val isSelected = episode.id in selection.selectedEpisodeIds
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(if (isSelected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent)
+                    .expressiveClickable(
+                        onLongClickLabel = "Select episode",
+                        onLongClick = { selection.onLongPress(episode) },
+                        onClick = {
+                            if (selection.isActive) selection.onToggle(episode) else onEpisodeClick(episode, globalIndex)
+                        },
+                    ).padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            TrailerLeadButton(
+                episode = episode,
+                playback = TrailerPlaybackUi(playState?.isPlaying == true, playState?.isResume == true),
+                selection = selection,
+                size = 36.dp,
+                iconPadding = 8.dp,
+                onPlayClick = onPlayClick,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            TrailerSummary(
+                episode = episode,
+                showBadge = false,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TrailerLeadButton(
+    episode: Episode,
+    playback: TrailerPlaybackUi,
+    selection: EpisodeSelectionUi,
+    size: Dp,
+    iconPadding: Dp,
+    onPlayClick: (Episode) -> Unit,
+) {
+    val isSelected = episode.id in selection.selectedEpisodeIds
+    val visuals =
+        trailerLeadVisuals(
+            isSelected = isSelected,
+            selectionActive = selection.isActive,
+            playback = playback,
+        )
+    Surface(
+        shape = CircleShape,
+        color = visuals.containerColor,
+        modifier =
+            Modifier
+                .size(size)
+                .then(
+                    if (selection.isActive) {
+                        Modifier
+                    } else {
+                        Modifier.expressiveClickable(isolate = true) { onPlayClick(episode) }
+                    },
+                ),
+    ) {
+        visuals.icon?.let { icon ->
+            Icon(
+                imageVector = icon,
+                contentDescription = visuals.contentDescription,
+                tint = visuals.iconTint,
+                modifier = Modifier.padding(iconPadding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun trailerLeadVisuals(
+    isSelected: Boolean,
+    selectionActive: Boolean,
+    playback: TrailerPlaybackUi,
+): TrailerLeadVisuals =
+    when {
+        isSelected ->
+            TrailerLeadVisuals(
+                containerColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Rounded.Check,
+                contentDescription = "Selected",
+                iconTint = MaterialTheme.colorScheme.onPrimary,
+            )
+        selectionActive ->
+            TrailerLeadVisuals(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                icon = null,
+                contentDescription = null,
+                iconTint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        playback.isPlaying ->
+            TrailerLeadVisuals(
+                containerColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Rounded.Pause,
+                contentDescription = "Pause",
+                iconTint = MaterialTheme.colorScheme.onPrimary,
+            )
+        playback.isResume ->
+            TrailerLeadVisuals(
+                containerColor = MaterialTheme.colorScheme.primary,
+                icon = Icons.Rounded.PlayArrow,
+                contentDescription = "Play",
+                iconTint = MaterialTheme.colorScheme.onPrimary,
+            )
+        else ->
+            TrailerLeadVisuals(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                icon = Icons.Rounded.PlayArrow,
+                contentDescription = "Play",
+                iconTint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+    }
+
+@Composable
+private fun TrailerSummary(
+    episode: Episode,
+    showBadge: Boolean,
+    modifier: Modifier,
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = episode.title,
+            style = if (showBadge) MaterialTheme.typography.titleSmall else MaterialTheme.typography.labelLarge,
+            fontWeight = if (showBadge) GoogleSansWeight.bold else null,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            if (showBadge) {
+                Surface(
+                    shape = ExpressiveShapes.Pill,
+                    color = MaterialTheme.colorScheme.tertiaryContainer,
+                ) {
+                    Text(
+                        text = "Trailer",
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = GoogleSansWeight.bold,
+                        color = MaterialTheme.colorScheme.onTertiaryContainer,
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                    )
+                }
+                Spacer(modifier = Modifier.width(6.dp))
+            }
+            if (!showBadge || episode.duration > 0) {
+                Text(
+                    text = trailerDurationText(episode),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun trailerBorder(isSelected: Boolean): BorderStroke =
+    BorderStroke(
+        width = if (isSelected) 2.dp else 0.5.dp,
+        color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant,
+    )
+
+private fun trailerDurationText(episode: Episode): String {
+    if (episode.duration <= 0) return "Trailer"
+    val hours = episode.duration / 3600
+    val minutes = (episode.duration % 3600) / 60
+    return if (hours > 0) "${hours}hr ${minutes}min" else "${minutes}min"
+}
 
 @Composable
 fun EpisodePlayStateWrapper(
     episodeId: String,
-    playbackStateFlow: kotlinx.coroutines.flow.Flow<Map<String, PodcastInfoViewModel.EpisodePlaybackState>>,
+    playbackStateFlow: Flow<EpisodePlaybackStates>,
     content: @Composable (PodcastInfoViewModel.EpisodePlaybackState?) -> Unit,
 ) {
     val playStateFlow =

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/logic/PodcastEpisodeSelectionLogic.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/logic/PodcastEpisodeSelectionLogic.kt
@@ -75,4 +75,9 @@ internal object PodcastEpisodeSelectionLogic {
         episodes: List<Episode>,
         selectedIds: Set<String>,
     ): List<Episode> = episodes.filter { it.id in selectedIds }.distinctBy(Episode::id)
+
+    fun shouldMarkUnplayed(
+        selectedEpisodes: List<Episode>,
+        completedEpisodeIds: Set<String>,
+    ): Boolean = selectedEpisodes.isNotEmpty() && selectedEpisodes.all { it.id in completedEpisodeIds }
 }

--- a/feature/info/src/main/java/cx/aswin/boxlore/feature/info/logic/PodcastEpisodeSelectionLogic.kt
+++ b/feature/info/src/main/java/cx/aswin/boxlore/feature/info/logic/PodcastEpisodeSelectionLogic.kt
@@ -1,0 +1,78 @@
+package cx.aswin.boxlore.feature.info.logic
+
+import cx.aswin.boxlore.core.model.Episode
+
+internal enum class EpisodeSelectionRange {
+    ALL,
+    OLDER,
+    NEWER,
+}
+
+internal object PodcastEpisodeSelectionLogic {
+    fun toggle(
+        selectedIds: Set<String>,
+        episodeId: String,
+    ): Set<String> =
+        if (episodeId in selectedIds) {
+            selectedIds - episodeId
+        } else {
+            selectedIds + episodeId
+        }
+
+    /**
+     * Adds a chronological range from a complete fetched episode window.
+     * OLDER and NEWER include the anchor, which is already selected in normal use.
+     */
+    fun addRange(
+        selectedIds: Set<String>,
+        episodes: List<Episode>,
+        anchorEpisodeId: String?,
+        range: EpisodeSelectionRange,
+        newestFirst: Boolean,
+    ): Set<String> {
+        val orderedIds = episodes.map(Episode::id)
+        if (orderedIds.isEmpty()) return selectedIds
+        if (range == EpisodeSelectionRange.ALL) return orderedIds.toSet()
+
+        val anchorIndex = orderedIds.indexOf(anchorEpisodeId)
+        if (anchorIndex < 0) return selectedIds
+        val rangeIds =
+            when (range) {
+                EpisodeSelectionRange.ALL -> orderedIds
+                EpisodeSelectionRange.OLDER ->
+                    if (newestFirst) {
+                        orderedIds.drop(anchorIndex)
+                    } else {
+                        orderedIds.take(anchorIndex + 1)
+                    }
+                EpisodeSelectionRange.NEWER ->
+                    if (newestFirst) {
+                        orderedIds.take(anchorIndex + 1)
+                    } else {
+                        orderedIds.drop(anchorIndex)
+                    }
+            }
+        return selectedIds + rangeIds
+    }
+
+    fun visibleEpisodes(
+        feedItems: List<FeedItem>,
+        visibleItemKeys: Set<String>,
+    ): List<Episode> =
+        feedItems
+            .asSequence()
+            .filter { it.id in visibleItemKeys }
+            .flatMap { feedItem ->
+                when (feedItem) {
+                    is FeedItem.NormalEpisode -> sequenceOf(feedItem.episode)
+                    is FeedItem.SingleTrailer -> sequenceOf(feedItem.episode)
+                    is FeedItem.TrailerGroup -> feedItem.trailers.asSequence().map { it.first }
+                }
+            }.distinctBy(Episode::id)
+            .toList()
+
+    fun selectedEpisodes(
+        episodes: List<Episode>,
+        selectedIds: Set<String>,
+    ): List<Episode> = episodes.filter { it.id in selectedIds }.distinctBy(Episode::id)
+}

--- a/feature/info/src/main/res/values/strings.xml
+++ b/feature/info/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="episode_selection_clear">Clear selection</string>
     <string name="episode_selection_download">Download selected episodes</string>
     <string name="episode_selection_mark_completed">Mark selected episodes completed</string>
+    <string name="episode_selection_mark_unplayed">Mark selected episodes unplayed</string>
     <string name="episode_selection_play">Play selected episodes</string>
     <string name="episode_selection_add_queue">Add selected episodes to queue</string>
     <string name="episode_selection_more">More selection options</string>

--- a/feature/info/src/main/res/values/strings.xml
+++ b/feature/info/src/main/res/values/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="episode_selection_clear">Clear selection</string>
+    <string name="episode_selection_download">Download selected episodes</string>
+    <string name="episode_selection_mark_completed">Mark selected episodes completed</string>
+    <string name="episode_selection_play">Play selected episodes</string>
+    <string name="episode_selection_add_queue">Add selected episodes to queue</string>
+    <string name="episode_selection_more">More selection options</string>
+    <string name="episode_selection_select_visible">Select visible episodes</string>
+    <string name="episode_selection_select_all">Select all episodes</string>
+    <string name="episode_selection_select_older">Select all older episodes</string>
+    <string name="episode_selection_select_newer">Select all newer episodes</string>
+    <string name="episode_selection_limit">Selection is limited to 1,000 episodes</string>
+</resources>

--- a/feature/info/src/test/java/cx/aswin/boxlore/feature/info/logic/PodcastEpisodeSelectionLogicTest.kt
+++ b/feature/info/src/test/java/cx/aswin/boxlore/feature/info/logic/PodcastEpisodeSelectionLogicTest.kt
@@ -93,6 +93,24 @@ class PodcastEpisodeSelectionLogicTest {
         assertEquals(listOf("b", "a"), selected.map(Episode::id))
     }
 
+    @Test
+    fun `completion action becomes unplayed only when every selection is completed`() {
+        val selected = listOf(episode("a"), episode("b"))
+
+        assertEquals(
+            true,
+            PodcastEpisodeSelectionLogic.shouldMarkUnplayed(selected, setOf("a", "b", "other")),
+        )
+        assertEquals(
+            false,
+            PodcastEpisodeSelectionLogic.shouldMarkUnplayed(selected, setOf("a")),
+        )
+        assertEquals(
+            false,
+            PodcastEpisodeSelectionLogic.shouldMarkUnplayed(emptyList(), setOf("a")),
+        )
+    }
+
     private fun episode(id: String): Episode =
         Episode(
             id = id,

--- a/feature/info/src/test/java/cx/aswin/boxlore/feature/info/logic/PodcastEpisodeSelectionLogicTest.kt
+++ b/feature/info/src/test/java/cx/aswin/boxlore/feature/info/logic/PodcastEpisodeSelectionLogicTest.kt
@@ -1,0 +1,103 @@
+package cx.aswin.boxlore.feature.info.logic
+
+import cx.aswin.boxlore.core.model.Episode
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PodcastEpisodeSelectionLogicTest {
+    @Test
+    fun `toggle enters extends and leaves selection`() {
+        assertEquals(setOf("b"), PodcastEpisodeSelectionLogic.toggle(emptySet(), "b"))
+        assertEquals(setOf("a", "b"), PodcastEpisodeSelectionLogic.toggle(setOf("a"), "b"))
+        assertEquals(setOf("a"), PodcastEpisodeSelectionLogic.toggle(setOf("a", "b"), "b"))
+    }
+
+    @Test
+    fun `older and newer follow newest-first fetched order`() {
+        val episodes = listOf(episode("new"), episode("middle"), episode("old"))
+
+        assertEquals(
+            setOf("middle", "old"),
+            PodcastEpisodeSelectionLogic.addRange(
+                selectedIds = setOf("middle"),
+                episodes = episodes,
+                anchorEpisodeId = "middle",
+                range = EpisodeSelectionRange.OLDER,
+                newestFirst = true,
+            ),
+        )
+        assertEquals(
+            setOf("new", "middle"),
+            PodcastEpisodeSelectionLogic.addRange(
+                selectedIds = setOf("middle"),
+                episodes = episodes,
+                anchorEpisodeId = "middle",
+                range = EpisodeSelectionRange.NEWER,
+                newestFirst = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `older follows oldest-first fetched order`() {
+        assertEquals(
+            setOf("old", "middle"),
+            PodcastEpisodeSelectionLogic.addRange(
+                selectedIds = setOf("middle"),
+                episodes = listOf(episode("old"), episode("middle"), episode("new")),
+                anchorEpisodeId = "middle",
+                range = EpisodeSelectionRange.OLDER,
+                newestFirst = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `select all replaces prior ids with complete fetched window`() {
+        val selected =
+            PodcastEpisodeSelectionLogic.addRange(
+                selectedIds = setOf("hidden"),
+                episodes = listOf(episode("a"), episode("b")),
+                anchorEpisodeId = "a",
+                range = EpisodeSelectionRange.ALL,
+                newestFirst = true,
+            )
+
+        assertEquals(setOf("a", "b"), selected)
+    }
+
+    @Test
+    fun `visible selection includes only feed cards on screen`() {
+        val visible =
+            PodcastEpisodeSelectionLogic.visibleEpisodes(
+                feedItems =
+                    listOf(
+                        FeedItem.NormalEpisode(episode("a"), 0),
+                        FeedItem.TrailerGroup(listOf(episode("trailer-1") to 1, episode("trailer-2") to 2)),
+                        FeedItem.NormalEpisode(episode("hidden"), 3),
+                    ),
+                visibleItemKeys = setOf("a", "trailer_group_trailer-1"),
+            )
+
+        assertEquals(listOf("a", "trailer-1", "trailer-2"), visible.map(Episode::id))
+    }
+
+    @Test
+    fun `bulk actions preserve visible sorted order and remove duplicates`() {
+        val selected =
+            PodcastEpisodeSelectionLogic.selectedEpisodes(
+                episodes = listOf(episode("b"), episode("a"), episode("b")),
+                selectedIds = setOf("a", "b"),
+            )
+
+        assertEquals(listOf("b", "a"), selected.map(Episode::id))
+    }
+
+    private fun episode(id: String): Episode =
+        Episode(
+            id = id,
+            title = id,
+            description = "",
+            audioUrl = "https://example.com/$id.mp3",
+        )
+}


### PR DESCRIPTION
## Summary

- Add long-press multi-selection to Podcast Info episode cards.
- Provide a floating bulk-action toolbar and explicit full-feed range selection.

## Motivation

- Listeners with imported or long-running shows need to process many already-heard episodes without acting on each episode individually.

## What changed

- Added bulk download, contextual played/unplayed, play, and append-to-queue actions.
- The completion action uses a distinct empty-circle icon and marks episodes unplayed when every selected episode is already complete.
- Added Select visible, Select all, Select older, and Select newer options; full-feed selections fetch up to 1,000 episodes without expanding the rendered list.
- Kept episode sorting available during selection and prevented the jump pill or snackbar from overlapping the contextual toolbar.
- Added selection handling for regular and trailer episode cards, focused JVM tests, and module documentation.
- Clarified the Podcast Info pin action as “Pin to Home screen.”

## Behavior & compatibility

- Existing single-episode actions and sorting behavior remain unchanged outside selection mode.
- Full-feed selection retains fetched episode metadata only while selection is active and reports when the 1,000-episode safety limit truncates the result.
- No storage identity, navigation route, backend, or cross-feature dependency changes.

Closes #995

Related discussion: https://github.com/boxcreate/boxlore/discussions/992

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-critical`
- [x] `user-impact-high`
- [ ] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact

**What changes in the user’s life:**

- Listeners can long-press an episode and manage many episodes together instead of repeating the same action one episode at a time.
- Long feeds can be selected by visible cards, the entire show, or episodes older/newer than the selection anchor.
- A completed selection can be reset to unplayed with one clearly distinguished action.

### Backend — optional

- [ ] `backend-change`

## Release copy (verbatim — highest priority)

### CHANGELOG.md (developer copy)

<!-- release-copy:changelog:start -->

### Added
- Added Podcast Info episode multi-selection with bulk download, played/unplayed, playback, queue, and full-feed range actions.

<!-- release-copy:changelog:end -->

### README What's New / Upcoming (listener copy)

<!-- release-copy:readme:start -->

### Added
- Long-press an episode to select and manage many episodes together, including older or newer episodes across long shows.

<!-- release-copy:readme:end -->

## Test plan

- [x] `./gradlew :feature:info:testDebugUnitTest`
- [x] `./gradlew :feature:info:ktlintCheck`
- [x] `./gradlew detekt`
- [x] Built and installed with `./gradlew installDebug`
- [ ] Manually verify selection and each bulk action on the installed build
- [ ] Required PR checks are green before merge