### PR TITLE
fix(briefing): preserve global market selection

### DIFF
--- a/app/src/main/java/cx/aswin/boxlore/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxlore/BoxLoreApplication.kt
@@ -6,6 +6,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import androidx.media3.cast.Cast
+import androidx.media3.common.util.UnstableApi
 import androidx.work.Configuration
 import com.google.android.gms.cast.SessionState
 import com.google.android.gms.cast.framework.CastContext
@@ -159,6 +160,7 @@ class BoxLoreApplication :
                 .setWorkerFactory(LegacyWorkerFactory())
                 .build()
 
+    @OptIn(UnstableApi::class)
     override fun onCreate() {
         super.onCreate()
 

--- a/app/src/main/java/cx/aswin/boxlore/BoxLoreApplication.kt
+++ b/app/src/main/java/cx/aswin/boxlore/BoxLoreApplication.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
+import androidx.annotation.OptIn
 import androidx.media3.cast.Cast
 import androidx.media3.common.util.UnstableApi
 import androidx.work.Configuration

--- a/core/model/README.md
+++ b/core/model/README.md
@@ -8,7 +8,7 @@ Owns shared domain models, enums, and pure value helpers used across network, da
 
 - Podcast, episode, briefing, chapter, person, transcript, and playback-adjacent model types.
 - `EpisodeMediaCacheKey`: Media3 `customCacheKey` helper — briefing keys append audio URL `v=` so same-day regenerations bust the local audio cache.
-- `ContentRegion` / `ContentRegions`: 11 chart storefronts, language allowlist/normalize/expand (`id`→`id,in`), off-market soft-warn helpers, and briefing market mapping.
+- `ContentRegion` / `ContentRegions`: 11 chart storefronts, language allowlist/normalize/expand (`id`→`id,in`), off-market soft-warn helpers, and briefing market mapping that preserves the explicit `global` briefing tab.
 - `ContentLanguageSelection`: pure language-chip toggle rules (English lock, max languages, BCP47 normalization) for settings/onboarding pickers.
 - `PlaybackEntryPoint`, `ShareTarget`, and `ShareLinkBuilder`.
 - `PlaybackEntryPoint` coarse values: `GENERIC`, `HOME_MIXTAPE`, `LEARN`, `BRIEFING`

--- a/core/model/src/main/java/cx/aswin/boxlore/core/model/ContentRegion.kt
+++ b/core/model/src/main/java/cx/aswin/boxlore/core/model/ContentRegion.kt
@@ -153,11 +153,15 @@ object ContentRegions {
         }
     }
 
-    fun briefingMarket(region: String): String =
-        when (canonicalize(region)) {
+    fun briefingMarket(region: String): String {
+        val normalized = region.trim().lowercase()
+        if (normalized == "global") return "global"
+
+        return when (canonicalize(normalized)) {
             "us" -> "us"
             "in" -> "in"
             "gb" -> "gb"
             else -> "global"
         }
+    }
 }

--- a/core/model/src/test/java/cx/aswin/boxlore/core/model/ContentRegionsTest.kt
+++ b/core/model/src/test/java/cx/aswin/boxlore/core/model/ContentRegionsTest.kt
@@ -46,6 +46,8 @@ class ContentRegionsTest {
     @Test
     fun briefingMarket_mapsNonCoreToGlobal() {
         assertEquals("global", ContentRegions.briefingMarket("de"))
+        assertEquals("global", ContentRegions.briefingMarket("global"))
+        assertEquals("global", ContentRegions.briefingMarket(" GLOBAL "))
         assertEquals("gb", ContentRegions.briefingMarket("uk"))
     }
 }


### PR DESCRIPTION
## Summary

- Preserve the explicit Global briefing market instead of normalizing it to US.
- Add regression coverage and document the briefing-market behavior.

## Motivation

The Global chip could immediately switch back to US because the briefing helper reused chart-storefront fallback rules.

## What changed

- Handle the explicit `global` briefing market before storefront canonicalization.
- Cover normalized and whitespace/case variants in the model tests.
- Update the core model module documentation.

## Behavior & compatibility

The Global briefing chip now remains selected and requests Global content. Chart countries, language defaults, and unknown-storefront fallback behavior are unchanged.

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-critical`
- [ ] `user-impact-high`
- [x] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact

**What changes in the user’s life:**

- Listeners can open and stay on the Global briefing instead of being redirected to the US briefing.

### Backend — optional

- [ ] `backend-change`

## Release copy (verbatim — highest priority)

### CHANGELOG.md (developer copy)

<!-- release-copy:changelog:start -->
-
<!-- release-copy:changelog:end -->

### README What's New / Upcoming (listener copy)

<!-- release-copy:readme:start -->
-
<!-- release-copy:readme:end -->

## Test plan

- [x] Built and installed locally with `./gradlew installDebug` on a connected device.
- [ ] Manually switch the briefing page to Global and confirm it remains selected.
- [ ] Required checks are green before merge completes.