### PR TITLE
feat(widgets): improve playback and episode widgets

### DIFF
--- a/feature/widgets/README.md
+++ b/feature/widgets/README.md
@@ -4,19 +4,21 @@
 
 Owns home-screen widgets built with `AppWidgetProvider` + `RemoteViews` (no Glance):
 
-- **Now playing** — 4×2 compact card (`wrap_content` height, centered in the host cell) with a 48dp artwork tile, two-line bounded episode metadata, and previous / seek-back / play-pause / seek-forward / next. Its 100dp content height matches the provider minimum, so long titles cannot displace or clip transport controls.
-- **Now playing bar** — compact 4×1 card (`wrap_content` height, centered in the host cell). Fixed 40dp art / 36dp square seek controls; titles fill the middle. Playing and empty states both fit the provider's 48dp minimum instead of stretching or clipping.
-- **Playback controls** — centered square 2×2 artwork / play-pause / seek-back / seek-forward tile grid.
+- **Now playing** — 4×2 compact card (`wrap_content` height, centered in the host cell) with a 48dp artwork tile, one-line episode and show labels, and previous / seek-back / play-pause / seek-forward / next. Its 100dp content height matches the provider minimum, so long titles ellipsize without displacing or clipping the 38dp transport controls.
+- **Now playing bar** — compact 4×1 card (`wrap_content` height, centered in the host cell). Fixed 40dp art / 36dp square seek controls; one-line episode and show labels fill the middle. Playing and empty states both fit the provider's 48dp minimum instead of stretching or clipping.
+- **Playback controls** — centered square 2×2 tile grids with artwork and play-pause. The original uses seek-back / seek-forward; the alternate uses next episode / seek-forward.
 - **Subscriptions** — 4×3 scrollable `ListView` of subscribed shows (cap 50); same sort prefs as Library → Subscriptions → Shows. Its 180dp resize floor preserves the header, one complete row, and footer. Row tap opens `boxlore://podcast/{id}`.
-- **New episodes** — 4×3 scrollable `ListView` of latest episodes from subscriptions (cap 50); same filters as Library → Subscriptions → Latest (`hideCompletedInSubs`, smart/recency sort). It uses the same 180dp safe resize floor. Row tap opens the episode deep link.
+- **New episodes** — 4×3 scrollable `ListView` of latest episodes from subscriptions (cap 50); same filters as Library → Subscriptions → Latest (`hideCompletedInSubs`, smart/recency sort). Its dedicated 68dp rows allow two episode-title lines above a one-line show name while retaining the 180dp safe resize floor. Row tap opens the episode deep link.
 
-Compact playback surfaces expose seek only; the wider 4×2 adds previous/next around seek. There is no shuffle or repeat on widgets. Library list widgets do not play audio from the home screen.
+The compact bar exposes seek only; the alternate 2×2 controls grid replaces seek-back with next episode. The wider 4×2 adds previous/next around seek. There is no shuffle or repeat on widgets. Library list widgets do not play audio from the home screen.
+
+When playback is dismissed, every playback widget becomes a clean branded launch surface instead of showing disabled transport: the boxlore icon sits beside centered “Ready when you are” copy in the 4×2 and bar, while both 2×2 grids stack the same identity treatment to fit their square footprint. There are no decorative shapes or separate CTA buttons; the whole themed surface opens boxlore.
 
 Does **not** construct `PlaybackRepository` or talk to Media3 / Room directly — `:app` installs narrow ports via `configureNowPlayingWidget` and `configureLibraryWidgets`.
 
 ## Public API
 
-- `NowPlayingWidgetReceiver`, `NowPlayingBarWidgetReceiver`, `PlaybackControlsWidgetReceiver` — picker-visible playback providers.
+- `NowPlayingWidgetReceiver`, `NowPlayingBarWidgetReceiver`, `PlaybackControlsWidgetReceiver`, `PlaybackNextControlsWidgetReceiver` — picker-visible playback providers.
 - `SubscriptionsWidgetReceiver`, `NewEpisodesWidgetReceiver` — picker-visible library list providers.
 - `WidgetControlReceiver` — one explicit, non-exported action endpoint shared by playback providers.
 - `NowPlayingWidgetDependencies` + `configureNowPlayingWidget(...)` / `WidgetPlaybackSource`.
@@ -24,6 +26,7 @@ Does **not** construct `PlaybackRepository` or talk to Media3 / Room directly �
 - `NowPlayingWidgetSnapshotStore` — SharedPreferences file `boxlore_now_playing_widget`.
 - `LibraryWidgetSnapshotStore` — SharedPreferences file `boxlore_library_widget`.
 - Coordinators collect Flows, persist snapshots, render RemoteViews, and load artwork without blocking metadata.
+- Picker labels are grouped as Now Playing, Playback Controls, New Episodes, and Your Shows; preview layouts mirror each live variant.
 
 ## Internal structure
 
@@ -37,7 +40,7 @@ src/main/java/cx/aswin/boxlore/feature/widgets/
   actions/WidgetActionHandler.kt
   actions/WidgetControlReceiver.kt
 src/main/res/
-  layout/now_playing_*.xml / playback_controls_widget.xml / library_widget_list*.xml
+  layout/now_playing_*.xml / playback_controls_widget.xml / library_widget_*list*.xml
   layout/widget_preview_*.xml — picker previews use themed surfaces (not white tint bases),
     rounded clipped mock covers, and mock episode/show titles matching live chrome.
   xml/*_widget_info.xml
@@ -68,7 +71,7 @@ src/main/res/
 | SharedPreferences files | `boxlore_now_playing_widget`, `boxlore_library_widget` |
 | Snapshot keys | `snapshot` (JSON) |
 | Artwork cache dir | `{cacheDir}/widget_artwork/` |
-| Receiver FQCNs | Now Playing / bar / controls / Subscriptions / New Episodes under `cx.aswin.boxlore.feature.widgets` |
+| Receiver FQCNs | Now Playing / bar / seek controls / next controls / Subscriptions / New Episodes under `cx.aswin.boxlore.feature.widgets` |
 | RemoteViewsService | `LibraryWidgetRemoteViewsService` (not exported; `BIND_REMOTEVIEWS`) |
 | Widget info | All providers use `updatePeriodMillis=0` |
 

--- a/feature/widgets/src/main/AndroidManifest.xml
+++ b/feature/widgets/src/main/AndroidManifest.xml
@@ -50,6 +50,19 @@
         </receiver>
 
         <receiver
+            android:name=".PlaybackNextControlsWidgetReceiver"
+            android:exported="true"
+            android:label="@string/playback_next_controls_widget_label"
+            android:permission="android.permission.BIND_APPWIDGET">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/playback_next_controls_widget_info" />
+        </receiver>
+
+        <receiver
             android:name=".SubscriptionsWidgetReceiver"
             android:exported="true"
             android:label="@string/subscriptions_widget_label"

--- a/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/LibraryWidgetRemoteViewsService.kt
+++ b/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/LibraryWidgetRemoteViewsService.kt
@@ -72,7 +72,12 @@ internal class LibraryWidgetRemoteViewsFactory(
         }
 
     override fun getViewAt(position: Int): RemoteViews {
-        val views = RemoteViews(context.packageName, R.layout.library_widget_list_item)
+        val layoutId =
+            when (kind) {
+                LibraryWidgetKind.SUBSCRIPTIONS -> R.layout.library_widget_list_item
+                LibraryWidgetKind.NEW_EPISODES -> R.layout.library_widget_episode_list_item
+            }
+        val views = RemoteViews(context.packageName, layoutId)
         WidgetRemoteViewsColors.setColorFilter(
             views,
             R.id.widget_row_bg,

--- a/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetModels.kt
+++ b/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetModels.kt
@@ -46,6 +46,7 @@ enum class WidgetVariant {
     NOW_PLAYING,
     BAR,
     CONTROLS,
+    CONTROLS_NEXT,
 }
 
 enum class WidgetControl {

--- a/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetReceiver.kt
+++ b/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetReceiver.kt
@@ -90,6 +90,10 @@ class PlaybackControlsWidgetReceiver : BaseNowPlayingWidgetReceiver() {
     override val variant = WidgetVariant.CONTROLS
 }
 
+class PlaybackNextControlsWidgetReceiver : BaseNowPlayingWidgetReceiver() {
+    override val variant = WidgetVariant.CONTROLS_NEXT
+}
+
 object WidgetProviders {
     data class Provider(
         val receiverClass: Class<out AppWidgetProvider>,
@@ -101,5 +105,6 @@ object WidgetProviders {
             Provider(NowPlayingWidgetReceiver::class.java, WidgetVariant.NOW_PLAYING),
             Provider(NowPlayingBarWidgetReceiver::class.java, WidgetVariant.BAR),
             Provider(PlaybackControlsWidgetReceiver::class.java, WidgetVariant.CONTROLS),
+            Provider(PlaybackNextControlsWidgetReceiver::class.java, WidgetVariant.CONTROLS_NEXT),
         )
 }

--- a/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetRenderer.kt
+++ b/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetRenderer.kt
@@ -92,6 +92,7 @@ object NowPlayingWidgetRenderer {
                 WidgetVariant.NOW_PLAYING -> R.layout.now_playing_widget_standard
                 WidgetVariant.BAR -> R.layout.now_playing_widget_bar
                 WidgetVariant.CONTROLS -> R.layout.playback_controls_widget
+                WidgetVariant.CONTROLS_NEXT -> R.layout.playback_controls_widget
             }
         return RemoteViews(context.packageName, layoutId).also { views ->
             bind(
@@ -144,7 +145,7 @@ object NowPlayingWidgetRenderer {
             views.setImageViewBitmap(R.id.widget_artwork, artwork)
         }
 
-        if (variant != WidgetVariant.CONTROLS) {
+        if (!variant.isControlsGrid()) {
             bindMetadata(views, snapshot, chrome)
         }
         bindTransport(context, views, appWidgetId, snapshot, variant, chrome)
@@ -158,12 +159,9 @@ object NowPlayingWidgetRenderer {
         variant: WidgetVariant,
         chrome: WidgetChrome,
     ) {
-        val compactBar = variant == WidgetVariant.BAR
-        val titleHeightDp = if (compactBar) 24 else 40
-        val ctaHeightDp = if (compactBar) 16 else 28
         views.setViewVisibility(R.id.widget_playing_container, View.GONE)
         views.setViewVisibility(R.id.widget_empty_container, View.VISIBLE)
-        if (variant != WidgetVariant.CONTROLS) {
+        if (!variant.isControlsGrid()) {
             WidgetRemoteViewsColors.setColorFilter(
                 views,
                 R.id.widget_empty_surface_background,
@@ -171,8 +169,102 @@ object NowPlayingWidgetRenderer {
                 chrome,
             )
         }
+        val appIcon = context.applicationInfo.icon
+        if (appIcon != 0) {
+            views.setImageViewResource(R.id.widget_empty_icon, appIcon)
+        }
         views.setOnClickPendingIntent(R.id.widget_empty_container, WidgetActionIntents.openApp(context))
-        val textWidth = (widthDp - EMPTY_HORIZONTAL_PADDING_DP).coerceAtLeast(MIN_TEXT_WIDTH_DP)
+
+        when (variant) {
+            WidgetVariant.NOW_PLAYING -> bindStandardEmptyState(context, views, widthDp, chrome)
+            WidgetVariant.BAR -> bindBarEmptyState(context, views, widthDp, chrome)
+            WidgetVariant.CONTROLS,
+            WidgetVariant.CONTROLS_NEXT,
+            -> bindControlsEmptyState(context, views, widthDp, chrome)
+        }
+    }
+
+    private fun bindStandardEmptyState(
+        context: Context,
+        views: RemoteViews,
+        widthDp: Int,
+        chrome: WidgetChrome,
+    ) {
+        val metadataWidth = (widthDp - STANDARD_EMPTY_METADATA_INSETS_DP).coerceAtLeast(MIN_TEXT_WIDTH_DP)
+        views.setImageViewBitmap(
+            R.id.widget_empty_title,
+            WidgetTextBitmapRenderer.renderColor(
+                context = context,
+                spec =
+                    WidgetTextBitmapRenderer.Spec(
+                        text = context.getString(R.string.widget_empty_title),
+                        widthDp = metadataWidth,
+                        heightDp = 40,
+                        preferredSizeSp = 17f,
+                        minSizeSp = 13f,
+                        weight = TITLE_WEIGHT,
+                        maxLines = 2,
+                        alignment = Layout.Alignment.ALIGN_CENTER,
+                    ),
+                color = chrome.argb(WidgetPalette.onSurface),
+            ),
+        )
+        views.setImageViewBitmap(
+            R.id.widget_empty_subtitle,
+            WidgetTextBitmapRenderer.renderColor(
+                context = context,
+                spec =
+                    WidgetTextBitmapRenderer.Spec(
+                        text = context.getString(R.string.widget_empty_subtitle),
+                        widthDp = metadataWidth,
+                        heightDp = 18,
+                        preferredSizeSp = 11f,
+                        minSizeSp = 9f,
+                        weight = BODY_WEIGHT,
+                        maxLines = 1,
+                        alignment = Layout.Alignment.ALIGN_CENTER,
+                    ),
+                color = chrome.argb(WidgetPalette.onSurfaceVariant),
+            ),
+        )
+    }
+
+    private fun bindBarEmptyState(
+        context: Context,
+        views: RemoteViews,
+        widthDp: Int,
+        chrome: WidgetChrome,
+    ) {
+        val textWidth = (widthDp - BAR_EMPTY_CONTENT_INSETS_DP).coerceAtLeast(MIN_TEXT_WIDTH_DP)
+        views.setImageViewBitmap(
+            R.id.widget_empty_title,
+            WidgetTextBitmapRenderer.renderColor(
+                context = context,
+                spec =
+                    WidgetTextBitmapRenderer.Spec(
+                        text = context.getString(R.string.widget_empty_bar_title),
+                        widthDp = textWidth,
+                        heightDp = 24,
+                        preferredSizeSp = 14f,
+                        minSizeSp = 11f,
+                        weight = TITLE_WEIGHT,
+                        maxLines = 1,
+                        alignment = Layout.Alignment.ALIGN_CENTER,
+                    ),
+                color = chrome.argb(WidgetPalette.onSurface),
+            ),
+        )
+    }
+
+    private fun bindControlsEmptyState(
+        context: Context,
+        views: RemoteViews,
+        widthDp: Int,
+        chrome: WidgetChrome,
+    ) {
+        val textWidth =
+            (widthDp - GRID_EMPTY_HORIZONTAL_PADDING_DP)
+                .coerceAtLeast(GRID_MIN_TEXT_WIDTH_DP)
         views.setImageViewBitmap(
             R.id.widget_empty_title,
             WidgetTextBitmapRenderer.renderColor(
@@ -181,32 +273,14 @@ object NowPlayingWidgetRenderer {
                     WidgetTextBitmapRenderer.Spec(
                         text = context.getString(R.string.widget_empty_title),
                         widthDp = textWidth,
-                        heightDp = titleHeightDp,
-                        preferredSizeSp = if (compactBar) 15f else 22f,
-                        minSizeSp = if (compactBar) 11f else 16f,
+                        heightDp = 28,
+                        preferredSizeSp = 11f,
+                        minSizeSp = 9f,
                         weight = TITLE_WEIGHT,
-                        maxLines = 1,
+                        maxLines = 2,
                         alignment = Layout.Alignment.ALIGN_CENTER,
                     ),
                 color = chrome.argb(WidgetPalette.onSurface),
-            ),
-        )
-        views.setImageViewBitmap(
-            R.id.widget_empty_cta,
-            WidgetTextBitmapRenderer.renderColor(
-                context = context,
-                spec =
-                    WidgetTextBitmapRenderer.Spec(
-                        text = context.getString(R.string.widget_empty_cta),
-                        widthDp = textWidth,
-                        heightDp = ctaHeightDp,
-                        preferredSizeSp = if (compactBar) 12f else 17f,
-                        minSizeSp = if (compactBar) 9f else 14f,
-                        weight = BODY_WEIGHT,
-                        maxLines = 1,
-                        alignment = Layout.Alignment.ALIGN_CENTER,
-                    ),
-                color = chrome.argb(WidgetPalette.primary),
             ),
         )
     }
@@ -241,7 +315,7 @@ object NowPlayingWidgetRenderer {
         chrome: WidgetChrome,
     ) {
         val playBackground =
-            if (variant == WidgetVariant.CONTROLS || snapshot.isPlaying) {
+            if (variant.isControlsGrid() || snapshot.isPlaying) {
                 R.drawable.widget_button_pause
             } else {
                 R.drawable.widget_button_play
@@ -272,7 +346,32 @@ object NowPlayingWidgetRenderer {
             WidgetActionIntents.broadcast(context, appWidgetId, WidgetControl.TOGGLE),
         )
 
-        // Compact surfaces: seek only. 4×2 adds previous/next around seek.
+        val leadingControl =
+            if (variant == WidgetVariant.CONTROLS_NEXT) {
+                WidgetControl.NEXT
+            } else {
+                WidgetControl.SKIP_BACK
+            }
+        views.setImageViewResource(
+            R.id.widget_skip_back_icon,
+            if (leadingControl == WidgetControl.NEXT) {
+                R.drawable.ic_widget_next
+            } else {
+                R.drawable.ic_widget_skip_back
+            },
+        )
+        views.setContentDescription(
+            R.id.widget_skip_back_icon,
+            context.getString(
+                if (leadingControl == WidgetControl.NEXT) {
+                    R.string.widget_next
+                } else {
+                    R.string.widget_skip_back
+                },
+            ),
+        )
+
+        // Compact surfaces use seek-back by default; the alternate grid uses next.
         bindSecondaryButton(
             context = context,
             views = views,
@@ -280,7 +379,7 @@ object NowPlayingWidgetRenderer {
             containerId = R.id.widget_skip_back,
             backgroundId = R.id.widget_skip_back_background,
             iconId = R.id.widget_skip_back_icon,
-            control = WidgetControl.SKIP_BACK,
+            control = leadingControl,
             chrome = chrome,
         )
         bindSecondaryButton(
@@ -352,7 +451,7 @@ object NowPlayingWidgetRenderer {
         widthDp: Int,
         heightDp: Int,
     ) {
-        if (variant != WidgetVariant.CONTROLS) return
+        if (!variant.isControlsGrid()) return
         val sideDp = minOf(widthDp, heightDp).coerceAtLeast(GRID_MIN_SIDE_DP)
         views.setViewLayoutWidth(R.id.widget_grid_card, sideDp.toFloat(), TypedValue.COMPLEX_UNIT_DIP)
         views.setViewLayoutHeight(R.id.widget_grid_card, sideDp.toFloat(), TypedValue.COMPLEX_UNIT_DIP)
@@ -371,11 +470,13 @@ object NowPlayingWidgetRenderer {
     ) {
         val heightDp =
             when (variant) {
-                // 48 art + 4 gap + 38 controls + 10 vertical padding
+                // 48 metadata + 4 gap + 38 controls + 10 vertical padding
                 WidgetVariant.NOW_PLAYING -> STANDARD_CARD_HEIGHT_DP
                 // 40 art + 8 vertical padding
                 WidgetVariant.BAR -> BAR_CARD_HEIGHT_DP
-                WidgetVariant.CONTROLS -> return
+                WidgetVariant.CONTROLS,
+                WidgetVariant.CONTROLS_NEXT,
+                -> return
             }
         views.setViewLayoutHeight(
             R.id.widget_playing_container,
@@ -405,7 +506,9 @@ object NowPlayingWidgetRenderer {
             when (variant) {
                 WidgetVariant.NOW_PLAYING -> 48
                 WidgetVariant.BAR -> 40
-                WidgetVariant.CONTROLS ->
+                WidgetVariant.CONTROLS,
+                WidgetVariant.CONTROLS_NEXT,
+                ->
                     ((minOf(widthDp, heightDp) - GRID_INSETS_DP) / 2)
                         .coerceAtLeast(GRID_MIN_ART_DP)
             }
@@ -449,8 +552,11 @@ object NowPlayingWidgetRenderer {
 
     private const val TITLE_WEIGHT = 600
     private const val BODY_WEIGHT = 400
-    private const val EMPTY_HORIZONTAL_PADDING_DP = 32
     private const val MIN_TEXT_WIDTH_DP = 72
+    private const val GRID_MIN_TEXT_WIDTH_DP = 48
+    private const val STANDARD_EMPTY_METADATA_INSETS_DP = 104
+    private const val BAR_EMPTY_CONTENT_INSETS_DP = 70
+    private const val GRID_EMPTY_HORIZONTAL_PADDING_DP = 20
     private const val GRID_MIN_SIDE_DP = 110
     private const val GRID_INSETS_DP = 38
     private const val GRID_MIN_ART_DP = 36
@@ -458,4 +564,7 @@ object NowPlayingWidgetRenderer {
     private const val GRID_PLAY_ICON_RATIO = 0.16f
     private const val STANDARD_CARD_HEIGHT_DP = 100
     private const val BAR_CARD_HEIGHT_DP = 48
+
+    private fun WidgetVariant.isControlsGrid(): Boolean =
+        this == WidgetVariant.CONTROLS || this == WidgetVariant.CONTROLS_NEXT
 }

--- a/feature/widgets/src/main/res/layout/library_widget_episode_list_item.xml
+++ b/feature/widgets/src/main/res/layout/library_widget_episode_list_item.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_row_root"
+    android:layout_width="match_parent"
+    android:layout_height="68dp"
+    android:paddingBottom="6dp">
+
+    <ImageView
+        android:id="@+id/widget_row_bg"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@null"
+        android:scaleType="fitXY"
+        android:src="@drawable/widget_list_row_chip" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingHorizontal="8dp">
+
+        <FrameLayout
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="@drawable/widget_list_art_frame"
+            android:clipToOutline="true">
+
+            <ImageView
+                android:id="@+id/widget_row_art"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:contentDescription="@null"
+                android:scaleType="centerCrop"
+                android:src="@drawable/widget_art_placeholder" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:id="@+id/widget_row_metadata"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/widget_row_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif-medium"
+                android:includeFontPadding="false"
+                android:maxLines="2"
+                android:textColor="@color/widget_on_secondary_container"
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/widget_row_subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif"
+                android:includeFontPadding="false"
+                android:maxLines="1"
+                android:textColor="@color/widget_on_surface_variant"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/widget_row_new_dot"
+            android:layout_width="8dp"
+            android:layout_height="8dp"
+            android:layout_marginStart="8dp"
+            android:contentDescription="@null"
+            android:src="@drawable/widget_new_dot"
+            android:visibility="gone" />
+    </LinearLayout>
+</FrameLayout>

--- a/feature/widgets/src/main/res/layout/now_playing_widget_bar.xml
+++ b/feature/widgets/src/main/res/layout/now_playing_widget_bar.xml
@@ -189,22 +189,33 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="4dp">
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingHorizontal="10dp"
+            android:paddingVertical="4dp">
 
             <ImageView
-                android:id="@+id/widget_empty_title"
-                android:layout_width="match_parent"
-                android:layout_height="24dp"
+                android:id="@+id/widget_empty_icon"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
                 android:contentDescription="@null"
-                android:scaleType="fitCenter" />
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_widget_play" />
 
-            <ImageView
-                android:id="@+id/widget_empty_cta"
-                android:layout_width="match_parent"
-                android:layout_height="16dp"
-                android:contentDescription="@null"
-                android:scaleType="fitCenter" />
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="40dp"
+                android:layout_marginStart="10dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/widget_empty_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="24dp"
+                    android:layout_gravity="center_vertical"
+                    android:contentDescription="@null"
+                    android:scaleType="fitCenter" />
+            </FrameLayout>
         </LinearLayout>
     </FrameLayout>
 </FrameLayout>

--- a/feature/widgets/src/main/res/layout/now_playing_widget_standard.xml
+++ b/feature/widgets/src/main/res/layout/now_playing_widget_standard.xml
@@ -69,7 +69,7 @@
                         android:ellipsize="end"
                         android:fontFamily="sans-serif-medium"
                         android:includeFontPadding="false"
-                        android:maxLines="2"
+                        android:maxLines="1"
                         android:textColor="@color/widget_on_surface"
                         android:textSize="14sp" />
 
@@ -239,24 +239,48 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="vertical"
-            android:padding="14dp">
+            android:layout_height="100dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="10dp">
 
             <ImageView
-                android:id="@+id/widget_empty_title"
-                android:layout_width="match_parent"
-                android:layout_height="40dp"
+                android:id="@+id/widget_empty_icon"
+                android:layout_width="68dp"
+                android:layout_height="68dp"
                 android:contentDescription="@null"
-                android:scaleType="fitCenter" />
+                android:scaleType="fitCenter"
+                android:src="@drawable/ic_widget_play" />
 
-            <ImageView
-                android:id="@+id/widget_empty_cta"
-                android:layout_width="match_parent"
-                android:layout_height="28dp"
-                android:contentDescription="@null"
-                android:scaleType="fitCenter" />
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_marginStart="12dp"
+                android:layout_weight="1">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:orientation="vertical">
+
+                    <ImageView
+                        android:id="@+id/widget_empty_title"
+                        android:layout_width="match_parent"
+                        android:layout_height="40dp"
+                        android:contentDescription="@null"
+                        android:scaleType="fitCenter" />
+
+                    <ImageView
+                        android:id="@+id/widget_empty_subtitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="18dp"
+                        android:layout_marginTop="2dp"
+                        android:contentDescription="@null"
+                        android:scaleType="fitCenter" />
+                </LinearLayout>
+            </FrameLayout>
         </LinearLayout>
     </FrameLayout>
 </FrameLayout>

--- a/feature/widgets/src/main/res/layout/playback_controls_widget.xml
+++ b/feature/widgets/src/main/res/layout/playback_controls_widget.xml
@@ -133,28 +133,42 @@
             </LinearLayout>
         </LinearLayout>
 
-        <LinearLayout
+        <FrameLayout
             android:id="@+id/widget_empty_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:gravity="center"
-            android:orientation="vertical"
-            android:padding="16dp"
             android:visibility="visible">
 
-            <ImageView
-                android:id="@+id/widget_empty_title"
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="40dp"
-                android:contentDescription="@null"
-                android:scaleType="fitCenter" />
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:paddingHorizontal="10dp">
 
-            <ImageView
-                android:id="@+id/widget_empty_cta"
-                android:layout_width="match_parent"
-                android:layout_height="28dp"
-                android:contentDescription="@null"
-                android:scaleType="fitCenter" />
-        </LinearLayout>
+                <ImageView
+                    android:id="@+id/widget_empty_icon"
+                    android:layout_width="56dp"
+                    android:layout_height="56dp"
+                    android:contentDescription="@null"
+                    android:scaleType="fitCenter"
+                    android:src="@drawable/ic_widget_play" />
+
+                <FrameLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="28dp"
+                    android:layout_marginTop="4dp">
+
+                    <ImageView
+                        android:id="@+id/widget_empty_title"
+                        android:layout_width="match_parent"
+                        android:layout_height="28dp"
+                        android:layout_gravity="center"
+                        android:contentDescription="@null"
+                        android:scaleType="fitCenter" />
+                </FrameLayout>
+            </LinearLayout>
+        </FrameLayout>
     </FrameLayout>
 </FrameLayout>

--- a/feature/widgets/src/main/res/layout/widget_preview_control_4x2.xml
+++ b/feature/widgets/src/main/res/layout/widget_preview_control_4x2.xml
@@ -49,7 +49,7 @@
                     android:ellipsize="end"
                     android:fontFamily="sans-serif-medium"
                     android:includeFontPadding="false"
-                    android:maxLines="2"
+                    android:maxLines="1"
                     android:text="@string/widget_preview_episode"
                     android:textColor="@color/widget_on_surface"
                     android:textSize="14sp" />

--- a/feature/widgets/src/main/res/layout/widget_preview_grid_next_2x2.xml
+++ b/feature/widgets/src/main/res/layout/widget_preview_grid_next_2x2.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Picker preview for 2×2 next controls — mirrors live grid + rounded art. -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@android:style/Theme.DeviceDefault.DayNight">
+
+    <LinearLayout
+        android:layout_width="126dp"
+        android:layout_height="126dp"
+        android:layout_gravity="center"
+        android:background="@drawable/widget_preview_surface"
+        android:clipToOutline="true"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:orientation="horizontal">
+
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:background="@drawable/widget_art_tile_shape"
+                android:clipToOutline="true">
+
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@null"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/widget_preview_cover_a" />
+            </FrameLayout>
+
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_marginStart="6dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@null"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/widget_preview_button_primary" />
+
+                <ImageView
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_widget_pause" />
+            </FrameLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="6dp"
+            android:layout_weight="1"
+            android:orientation="horizontal">
+
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@null"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/widget_preview_button_secondary" />
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_widget_next" />
+            </FrameLayout>
+
+            <FrameLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_marginStart="6dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@null"
+                    android:scaleType="fitXY"
+                    android:src="@drawable/widget_preview_button_secondary" />
+
+                <ImageView
+                    android:layout_width="20dp"
+                    android:layout_height="20dp"
+                    android:layout_gravity="center"
+                    android:contentDescription="@null"
+                    android:src="@drawable/ic_widget_skip_fwd" />
+            </FrameLayout>
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/feature/widgets/src/main/res/layout/widget_preview_new_episodes.xml
+++ b/feature/widgets/src/main/res/layout/widget_preview_new_episodes.xml
@@ -47,7 +47,7 @@
     <!-- Episode 1 -->
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="68dp"
         android:paddingBottom="6dp">
 
         <ImageView
@@ -65,8 +65,8 @@
             android:paddingHorizontal="8dp">
 
             <FrameLayout
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:background="@drawable/widget_list_art_frame"
                 android:clipToOutline="true">
 
@@ -91,7 +91,7 @@
                     android:ellipsize="end"
                     android:fontFamily="sans-serif-medium"
                     android:includeFontPadding="false"
-                    android:maxLines="1"
+                    android:maxLines="2"
                     android:text="@string/widget_preview_episode"
                     android:textColor="@color/widget_on_secondary_container"
                     android:textSize="14sp" />
@@ -114,7 +114,7 @@
     <!-- Episode 2 -->
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="68dp"
         android:paddingBottom="6dp">
 
         <ImageView
@@ -132,8 +132,8 @@
             android:paddingHorizontal="8dp">
 
             <FrameLayout
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:background="@drawable/widget_list_art_frame"
                 android:clipToOutline="true">
 
@@ -158,7 +158,7 @@
                     android:ellipsize="end"
                     android:fontFamily="sans-serif-medium"
                     android:includeFontPadding="false"
-                    android:maxLines="1"
+                    android:maxLines="2"
                     android:text="@string/widget_preview_episode_2"
                     android:textColor="@color/widget_on_secondary_container"
                     android:textSize="14sp" />
@@ -172,72 +172,6 @@
                     android:includeFontPadding="false"
                     android:maxLines="1"
                     android:text="@string/widget_preview_episode_2_show"
-                    android:textColor="@color/widget_on_surface_variant"
-                    android:textSize="12sp" />
-            </LinearLayout>
-        </LinearLayout>
-    </FrameLayout>
-
-    <!-- Episode 3 -->
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="50dp">
-
-        <ImageView
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:contentDescription="@null"
-            android:scaleType="fitXY"
-            android:src="@drawable/widget_preview_row_chip" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:gravity="center_vertical"
-            android:orientation="horizontal"
-            android:paddingHorizontal="8dp">
-
-            <FrameLayout
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:background="@drawable/widget_list_art_frame"
-                android:clipToOutline="true">
-
-                <ImageView
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:contentDescription="@null"
-                    android:scaleType="centerCrop"
-                    android:src="@drawable/widget_preview_cover_c" />
-            </FrameLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"
-                android:layout_weight="1"
-                android:orientation="vertical">
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:ellipsize="end"
-                    android:fontFamily="sans-serif-medium"
-                    android:includeFontPadding="false"
-                    android:maxLines="1"
-                    android:text="@string/widget_preview_episode_3"
-                    android:textColor="@color/widget_on_secondary_container"
-                    android:textSize="14sp" />
-
-                <TextView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
-                    android:ellipsize="end"
-                    android:fontFamily="sans-serif"
-                    android:includeFontPadding="false"
-                    android:maxLines="1"
-                    android:text="@string/widget_preview_episode_3_show"
                     android:textColor="@color/widget_on_surface_variant"
                     android:textSize="12sp" />
             </LinearLayout>

--- a/feature/widgets/src/main/res/values/strings.xml
+++ b/feature/widgets/src/main/res/values/strings.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="now_playing_widget_label">boxlore now playing</string>
-    <string name="now_playing_bar_widget_label">boxlore now playing bar</string>
-    <string name="playback_controls_widget_label">boxlore playback controls</string>
-    <string name="now_playing_bar_widget_description">Compact artwork, episode, and seek controls</string>
-    <string name="playback_controls_widget_description">Artwork, play, and seek controls</string>
+    <string name="now_playing_widget_label">Now Playing · Full Controls</string>
+    <string name="now_playing_bar_widget_label">Now Playing · Compact</string>
+    <string name="playback_controls_widget_label">Playback Controls · Seek</string>
+    <string name="playback_next_controls_widget_label">Playback Controls · Next</string>
+    <string name="now_playing_bar_widget_description">A slim now-playing bar with quick seek controls</string>
+    <string name="playback_controls_widget_description">Artwork with play and seek controls</string>
+    <string name="playback_next_controls_widget_description">Artwork with play, next episode, and seek-forward controls</string>
     <string name="widget_empty_title">Ready when you are</string>
-    <string name="widget_empty_cta">Open boxlore</string>
+    <string name="widget_empty_subtitle">Tap to open boxlore</string>
+    <string name="widget_empty_bar_title">Ready when you are</string>
     <string name="widget_previous">Previous episode</string>
     <string name="widget_next">Next episode</string>
     <string name="widget_skip_back">Seek backward</string>
@@ -24,12 +27,12 @@
     <string name="widget_preview_episode_3">How maps shape memory</string>
     <string name="widget_preview_episode_3_show">Soft Power</string>
     <string name="widget_preview_count">12</string>
-    <string name="subscriptions_widget_label">boxlore subscriptions</string>
+    <string name="subscriptions_widget_label">Your Shows</string>
     <string name="subscriptions_widget_description">Your subscribed shows</string>
     <string name="subscriptions_widget_header">Subscriptions</string>
     <string name="subscriptions_widget_empty_title">No subscriptions yet</string>
     <string name="subscriptions_widget_empty_cta">Open boxlore</string>
-    <string name="new_episodes_widget_label">boxlore new episodes</string>
+    <string name="new_episodes_widget_label">New Episodes</string>
     <string name="new_episodes_widget_description">Latest episodes from your shows</string>
     <string name="new_episodes_widget_header">New episodes</string>
     <string name="new_episodes_widget_empty_title">No new episodes</string>

--- a/feature/widgets/src/main/res/xml/playback_next_controls_widget_info.xml
+++ b/feature/widgets/src/main/res/xml/playback_next_controls_widget_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/playback_next_controls_widget_description"
+    android:initialLayout="@layout/playback_controls_widget"
+    android:minWidth="110dp"
+    android:minHeight="110dp"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="110dp"
+    android:previewLayout="@layout/widget_preview_grid_next_2x2"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="2"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen"
+    android:widgetFeatures="reconfigurable|configuration_optional" />

--- a/feature/widgets/src/test/java/cx/aswin/boxlore/feature/widgets/LibraryWidgetRemoteViewsTest.kt
+++ b/feature/widgets/src/test/java/cx/aswin/boxlore/feature/widgets/LibraryWidgetRemoteViewsTest.kt
@@ -3,6 +3,7 @@ package cx.aswin.boxlore.feature.widgets
 import android.content.Context
 import android.view.View
 import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -151,5 +152,69 @@ class LibraryWidgetRemoteViewsTest {
             "list content was ${listHeight}px; expected at least ${minimumRowHeight}px",
             listHeight >= minimumRowHeight,
         )
+    }
+
+    @Test
+    fun newEpisodeRowsAllowTwoTitleLinesWithoutChangingSubscriptionRows() {
+        val store = LibraryWidgetSnapshotStore(context)
+        store.write(
+            LibraryWidgetSnapshot(
+                subscriptions =
+                    listOf(
+                        WidgetShowRow(
+                            podcastId = "p1",
+                            title = "A subscription title that remains on one line",
+                            subtitle = "Publisher",
+                            deepLinkUri = "boxlore://podcast/p1",
+                        ),
+                    ),
+                newEpisodes =
+                    listOf(
+                        WidgetEpisodeRow(
+                            episodeId = "e1",
+                            episodeTitle =
+                                "An exceptionally long episode title that needs a second line " +
+                                    "before it is truncated",
+                            podcastId = "p1",
+                            podcastTitle = "A show name",
+                            deepLinkUri = "boxlore://episode/e1",
+                        ),
+                    ),
+            ),
+        )
+
+        val episodeFactory =
+            LibraryWidgetRemoteViewsFactory(context, LibraryWidgetKind.NEW_EPISODES).apply {
+                onDataSetChanged()
+            }
+        val episodeViews = episodeFactory.getViewAt(0)
+        val episodeRoot = episodeViews.apply(context, FrameLayout(context))
+        val density = context.resources.displayMetrics.density
+        episodeRoot.measure(
+            View.MeasureSpec.makeMeasureSpec((245 * density).toInt(), View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec((68 * density).toInt(), View.MeasureSpec.EXACTLY),
+        )
+        episodeRoot.layout(0, 0, episodeRoot.measuredWidth, episodeRoot.measuredHeight)
+
+        val episodeTitle = episodeRoot.findViewById<TextView>(R.id.widget_row_title)
+        val episodeSubtitle = episodeRoot.findViewById<TextView>(R.id.widget_row_subtitle)
+        val episodeMetadata = episodeRoot.findViewById<View>(R.id.widget_row_metadata)
+        assertEquals(R.layout.library_widget_episode_list_item, episodeViews.layoutId)
+        assertEquals(2, episodeTitle.maxLines)
+        assertTrue(episodeTitle.top >= 0)
+        assertTrue(episodeSubtitle.bottom <= episodeMetadata.height)
+
+        val subscriptionFactory =
+            LibraryWidgetRemoteViewsFactory(context, LibraryWidgetKind.SUBSCRIPTIONS).apply {
+                onDataSetChanged()
+            }
+        val subscriptionViews = subscriptionFactory.getViewAt(0)
+        val subscriptionRoot = subscriptionViews.apply(context, FrameLayout(context))
+        assertEquals(R.layout.library_widget_list_item, subscriptionViews.layoutId)
+        assertEquals(1, subscriptionRoot.findViewById<TextView>(R.id.widget_row_title).maxLines)
+
+        episodeFactory.onDestroy()
+        subscriptionFactory.onDestroy()
+        store.clear()
     }
 }

--- a/feature/widgets/src/test/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetRemoteViewsTest.kt
+++ b/feature/widgets/src/test/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetRemoteViewsTest.kt
@@ -34,6 +34,21 @@ class NowPlayingWidgetRemoteViewsTest {
     }
 
     @Test
+    fun standardEmptyStateUsesThemedBoxloreIdentity() {
+        val root =
+            renderAtMinimumSize(
+                variant = WidgetVariant.NOW_PLAYING,
+                widthDp = 245,
+                heightDp = 100,
+                snapshot = NowPlayingWidgetSnapshot(),
+            )
+
+        assertFullyInside(root, R.id.widget_empty_icon)
+        assertFullyInside(root, R.id.widget_empty_title)
+        assertFullyInside(root, R.id.widget_empty_subtitle)
+    }
+
+    @Test
     fun playingSnapshotUsesStandardLayoutForDefaultOptions() {
         val views =
             NowPlayingWidgetRenderer.buildRemoteViews(
@@ -66,7 +81,7 @@ class NowPlayingWidgetRemoteViewsTest {
     }
 
     @Test
-    fun longEpisodeTitleKeepsStandardControlsInsideMinimumHeight() {
+    fun longEpisodeTitleEllipsizesWithoutDisplacingStandardControls() {
         val root =
             renderAtMinimumSize(
                 variant = WidgetVariant.NOW_PLAYING,
@@ -80,7 +95,11 @@ class NowPlayingWidgetRemoteViewsTest {
                     ),
             )
 
-        assertEquals(2, root.findViewById<TextView>(R.id.widget_episode_title).maxLines)
+        assertEquals(1, root.findViewById<TextView>(R.id.widget_episode_title).maxLines)
+        val metadata = root.findViewById<View>(R.id.widget_metadata_container)
+        assertEquals(1, root.findViewById<TextView>(R.id.widget_episode_title).lineCount)
+        assertFullyInside(metadata, R.id.widget_episode_title)
+        assertFullyInside(metadata, R.id.widget_podcast_title)
         assertFullyInside(root, R.id.widget_previous)
         assertFullyInside(root, R.id.widget_skip_back)
         assertFullyInside(root, R.id.widget_play_pause)
@@ -95,9 +114,16 @@ class NowPlayingWidgetRemoteViewsTest {
                 variant = WidgetVariant.BAR,
                 widthDp = 245,
                 heightDp = 48,
-                snapshot = playingSnapshot(),
+                snapshot =
+                    playingSnapshot().copy(
+                        episodeTitle = "A long episode title that must truncate cleanly",
+                        podcastTitle = "A long publisher name that must also truncate cleanly",
+                    ),
             )
 
+        val metadata = root.findViewById<View>(R.id.widget_metadata_container)
+        assertFullyInside(metadata, R.id.widget_episode_title)
+        assertFullyInside(metadata, R.id.widget_podcast_title)
         assertFullyInside(root, R.id.widget_skip_back)
         assertFullyInside(root, R.id.widget_play_pause)
         assertFullyInside(root, R.id.widget_skip_forward)
@@ -113,8 +139,8 @@ class NowPlayingWidgetRemoteViewsTest {
                 snapshot = NowPlayingWidgetSnapshot(),
             )
 
+        assertFullyInside(root, R.id.widget_empty_icon)
         assertFullyInside(root, R.id.widget_empty_title)
-        assertFullyInside(root, R.id.widget_empty_cta)
     }
 
     @Test
@@ -184,6 +210,49 @@ class NowPlayingWidgetRemoteViewsTest {
             )
 
         assertEquals(R.layout.playback_controls_widget, views.layoutId)
+    }
+
+    @Test
+    fun emptyControlsGridUsesCompactBoxloreIdentity() {
+        val root =
+            renderAtMinimumSize(
+                variant = WidgetVariant.CONTROLS,
+                widthDp = 110,
+                heightDp = 110,
+                snapshot = NowPlayingWidgetSnapshot(),
+            )
+
+        assertFullyInside(root, R.id.widget_empty_icon)
+        assertFullyInside(root, R.id.widget_empty_title)
+    }
+
+    @Test
+    fun nextControlsVariantBindsNextAndSeekForwardGrid() {
+        val views =
+            NowPlayingWidgetRenderer.buildRemoteViews(
+                context = context,
+                appWidgetId = 7,
+                snapshot = playingSnapshot(),
+                options = defaultOptions(),
+                variant = WidgetVariant.CONTROLS_NEXT,
+            )
+        val root = views.apply(context, FrameLayout(context))
+
+        assertEquals(R.layout.playback_controls_widget, views.layoutId)
+        assertEquals(
+            context.getString(R.string.widget_next),
+            root.findViewById<View>(R.id.widget_skip_back_icon).contentDescription,
+        )
+        assertEquals(
+            context.getString(R.string.widget_skip_forward),
+            root.findViewById<View>(R.id.widget_skip_forward_icon).contentDescription,
+        )
+        assertTrue(
+            WidgetProviders.all.any {
+                it.receiverClass == PlaybackNextControlsWidgetReceiver::class.java &&
+                    it.variant == WidgetVariant.CONTROLS_NEXT
+            },
+        )
     }
 
     private fun playingSnapshot() =


### PR DESCRIPTION
## Summary

- Prevent full-control playback metadata from clipping in compact widget bounds.
- Add an alternate 2×2 playback widget with Next and seek-forward controls.
- Improve New Episodes rows, widget picker naming/previews, and idle states.

## Motivation

Long playback metadata could clip vertically, and the existing compact controls and episode list did not provide enough choice or readable context.

## What changed

- Keep the full-controls episode title to one ellipsized line while preserving the show name and control spacing.
- Add a compact Next + seek-forward widget beside the existing compact control widget in the picker.
- Allow New Episodes rows to use two title lines without changing subscription rows.
- Use clearer picker labels and dedicated previews.
- Replace cramped idle controls with a simple themed boxlore icon and centered “Ready when you are” copy, with no decorative shapes.
- Extend RemoteViews regression coverage and update the widgets module documentation.

## Behavior & compatibility

Existing widget receiver identities remain unchanged. The additional compact widget uses a new receiver, while existing widgets retain their saved configuration and actions.

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-critical`
- [ ] `user-impact-high`
- [x] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact

**What changes in the user’s life:**

- Playback widgets remain readable with long episode names, New Episodes shows more title context, and listeners can choose a compact control layout with either back or next navigation.

### Backend — optional

- [ ] `backend-change`

## Release copy (verbatim — highest priority)

### CHANGELOG.md (developer copy)

<!-- release-copy:changelog:start -->

### Added
- Added an alternate compact playback widget with Next and seek-forward controls.

### Changed
- Improved playback metadata sizing, New Episodes title wrapping, widget picker previews, and idle states.

<!-- release-copy:changelog:end -->

### README What's New / Upcoming (listener copy)

<!-- release-copy:readme:start -->

- Playback widgets now handle long episode names more cleanly, show more context for new episodes, and offer a new compact Next-control layout.

<!-- release-copy:readme:end -->

## Test plan

- [x] Ran `./gradlew testDebugUnitTest --continue`
- [x] Built and installed locally with `./gradlew installDebug`
- [ ] Manually verify the final widget layouts and picker previews
- [ ] Required checks are green before merge completes