### PR TITLE
feat(share): polish artwork sharing

### DIFF
--- a/core/designsystem/README.md
+++ b/core/designsystem/README.md
@@ -11,8 +11,8 @@ Owns shared Compose visual primitives: theme, typography, shapes, motion, loader
 - `PredictiveBackWrapper` peeks the NavHost (scale 1.0 → 0.9) during system Back. Progress always returns to rest after commit or cancel so a Back that replaces the start destination (cold-start Subscriptions → Home) does not leave Home scaled down.
 - Shared discovery poster cards: `FeedMediaCard`, `CuratedEpisodeCard`, `EqualHeightPosterGrid`, and `FeedPosterSpacing` (Home “Based on Your Taste” and Explore For You).
 - `ProgressiveSearchScrollLogic` decides when a progressive Find-a-show list should pin to the top (query change, new top hit, or Matches header). Used by onboarding search and Explore Find-a-show; Ask anything does not use it.
-- `share.ShareManager` for composite share cards and the system share sheet; emits glossary `share_content` via `:core:analytics`.
-- `share.ShareCardRenderer` builds the share-card bitmaps used by `ShareManager` (stories / message formats).
+- `share.ShareManager` for composite share cards and the system share sheet; emits glossary `share_content` via `:core:analytics`. `ShareBottomSheet` presents a clear content preview, a switch-style timestamp option, a primary artwork share action, and separate link/story actions.
+- `share.ShareCardRenderer` builds the share-card bitmaps used by `ShareManager`. Stories separate episode/show details from a reduced branding block and retain the “listen now” prompt; square message artwork uses smaller branding without that prompt.
 
 ## Internal structure
 

--- a/core/designsystem/src/main/java/cx/aswin/boxlore/core/designsystem/components/ShareBottomSheet.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxlore/core/designsystem/components/ShareBottomSheet.kt
@@ -1,29 +1,30 @@
 package cx.aswin.boxlore.core.designsystem.components
 
-import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
-
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.ChatBubble
 import androidx.compose.material.icons.rounded.ContentCopy
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material.icons.rounded.Schedule
+import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -35,15 +36,17 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
 import cx.aswin.boxlore.core.designsystem.theme.expressiveClickable
 import cx.aswin.boxlore.core.model.ShareLinkBuilder
 import cx.aswin.boxlore.core.model.ShareTarget
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
+@Suppress("FunctionName")
 fun ShareBottomSheet(
     id: String,
     type: String, // "podcast" or "episode"
@@ -58,224 +61,367 @@ fun ShareBottomSheet(
         id: String,
         type: String,
         timestampMs: Long?,
-        target: ShareTarget
-    ) -> Unit
+        target: ShareTarget,
+    ) -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val context = LocalContext.current
 
     var includeTimestamp by remember { mutableStateOf(false) }
-    val primaryColor = MaterialTheme.colorScheme.primary
+    val contentLabel = if (type == "podcast") "podcast" else "episode"
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
         sheetState = sheetState,
-        shape = RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp),
-        containerColor = MaterialTheme.colorScheme.surfaceContainer
+        shape = RoundedCornerShape(topStart = 32.dp, topEnd = 32.dp),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp)
-                .padding(bottom = 32.dp),
-            horizontalAlignment = Alignment.Start
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .padding(bottom = 28.dp),
+            horizontalAlignment = Alignment.Start,
         ) {
-            Text(
-                text = "Share the good stuff",
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = GoogleSansWeight.bold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Text(
-                text = "A polished boxlore card is ready to send.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(modifier = Modifier.height(18.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ) {
+                    Icon(
+                        imageVector = Icons.Rounded.Share,
+                        contentDescription = null,
+                        modifier = Modifier.padding(12.dp).size(24.dp),
+                    )
+                }
+                Spacer(modifier = Modifier.width(14.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Share this $contentLabel",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = GoogleSansWeight.bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Text(
+                        text = "Share an artwork card by message or story, or copy its link.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(20.dp))
 
             Surface(
                 modifier = Modifier.fillMaxWidth(),
                 shape = MaterialTheme.shapes.extraLarge,
-                color = MaterialTheme.colorScheme.surfaceContainerHigh
+                color = MaterialTheme.colorScheme.surfaceContainerHigh,
             ) {
                 Row(
-                    modifier = Modifier.padding(14.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    modifier = Modifier.padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     if (!imageUrl.isNullOrBlank()) {
                         OptimizedImage(
                             url = imageUrl,
                             proxyWidth = 160,
                             contentDescription = null,
-                            modifier = Modifier
-                                .size(72.dp)
-                                .clip(RoundedCornerShape(18.dp))
+                            modifier =
+                                Modifier
+                                    .size(76.dp)
+                                    .clip(MaterialTheme.shapes.large),
                         )
                         Spacer(modifier = Modifier.width(14.dp))
                     }
                     Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = if (type == "podcast") "PODCAST" else "EPISODE",
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = GoogleSansWeight.bold,
-                            color = primaryColor
-                        )
+                        Surface(
+                            shape = MaterialTheme.shapes.small,
+                            color = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        ) {
+                            Text(
+                                text = contentLabel.uppercase(),
+                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = GoogleSansWeight.bold,
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(7.dp))
                         Text(
                             text = title,
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = GoogleSansWeight.bold,
                             color = MaterialTheme.colorScheme.onSurface,
                             maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis,
                         )
-                        Spacer(modifier = Modifier.height(2.dp))
-                        Text(
-                            text = subtitle,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
+                        if (subtitle.isNotBlank()) {
+                            Spacer(modifier = Modifier.height(2.dp))
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     }
                 }
             }
 
             if (type == "episode" && showTimestampOption && currentPositionMs > 1000L) {
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(14.dp))
                 Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = MaterialTheme.shapes.large,
-                    color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.52f)
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .expressiveClickable(
+                                shape = MaterialTheme.shapes.extraLarge,
+                                onClick = { includeTimestamp = !includeTimestamp },
+                            ),
+                    shape = MaterialTheme.shapes.extraLarge,
+                    color =
+                        if (includeTimestamp) {
+                            MaterialTheme.colorScheme.secondaryContainer
+                        } else {
+                            MaterialTheme.colorScheme.surfaceContainerHigh
+                        },
                 ) {
                     Row(
-                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                        modifier = Modifier.padding(14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        Checkbox(
+                        Surface(
+                            shape = MaterialTheme.shapes.large,
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Schedule,
+                                contentDescription = null,
+                                modifier = Modifier.padding(9.dp).size(20.dp),
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Start at ${formatTime(currentPositionMs)}",
+                                style = MaterialTheme.typography.titleSmall,
+                                fontWeight = GoogleSansWeight.bold,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                            Text(
+                                text = "Include your current position",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Switch(
                             checked = includeTimestamp,
                             onCheckedChange = { includeTimestamp = it },
-                            colors = CheckboxDefaults.colors(checkedColor = primaryColor)
-                        )
-                        Text(
-                            text = "Start at ${formatTime(currentPositionMs)}",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = GoogleSansWeight.medium,
-                            color = MaterialTheme.colorScheme.onSecondaryContainer
+                            colors =
+                                SwitchDefaults.colors(
+                                    checkedTrackColor = MaterialTheme.colorScheme.primary,
+                                    checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                                ),
                         )
                     }
                 }
             }
 
-            Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(22.dp))
+            Text(
+                text = "CHOOSE HOW TO SHARE",
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = GoogleSansWeight.bold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            SharePrimaryAction(
+                icon = Icons.Rounded.ChatBubble,
+                title = "Send artwork card",
+                subtitle = "Artwork and link",
+                onClick = {
+                    val tMs =
+                        if (includeTimestamp && showTimestampOption) {
+                            currentPositionMs
+                        } else {
+                            null
+                        }
+                    onShare(id, type, tMs, ShareTarget.MESSAGE)
+                    onDismissRequest()
+                },
+            )
+            Spacer(modifier = Modifier.height(10.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                ShareActionTile(
+                ShareSecondaryAction(
                     icon = Icons.Rounded.ContentCopy,
-                    label = "Copy",
+                    title = "Copy link",
+                    subtitle = "Link only",
                     onClick = {
-                        val finalLink = ShareLinkBuilder.build(
-                            id = id,
-                            type = type,
-                            timestampMs = currentPositionMs.takeIf {
-                                includeTimestamp && showTimestampOption
-                            }
-                        )
-                        val clipboard = context.getSystemService(
-                            android.content.Context.CLIPBOARD_SERVICE
-                        ) as android.content.ClipboardManager
+                        val finalLink =
+                            ShareLinkBuilder.build(
+                                id = id,
+                                type = type,
+                                timestampMs =
+                                    currentPositionMs.takeIf {
+                                        includeTimestamp && showTimestampOption
+                                    },
+                            )
+                        val clipboard =
+                            context.getSystemService(
+                                android.content.Context.CLIPBOARD_SERVICE,
+                            ) as android.content.ClipboardManager
                         clipboard.setPrimaryClip(
-                            android.content.ClipData.newPlainText("boxlore link", finalLink)
+                            android.content.ClipData.newPlainText("boxlore link", finalLink),
                         )
-                        android.widget.Toast.makeText(
-                            context,
-                            "Link copied",
-                            android.widget.Toast.LENGTH_SHORT
-                        ).show()
-                        onDismissRequest()
-                    },
-                    modifier = Modifier.weight(1f)
-                )
-                ShareActionTile(
-                    icon = Icons.Rounded.ChatBubble,
-                    label = "Send",
-                    onClick = {
-                        val tMs = if (includeTimestamp && showTimestampOption) currentPositionMs else null
-                        onShare(id, type, tMs, ShareTarget.MESSAGE)
+                        val toast =
+                            android.widget.Toast.makeText(
+                                context,
+                                "Link copied",
+                                android.widget.Toast.LENGTH_SHORT,
+                            )
+                        toast.show()
                         onDismissRequest()
                     },
                     modifier = Modifier.weight(1f),
-                    emphasized = true
                 )
-                ShareActionTile(
+                ShareSecondaryAction(
                     icon = Icons.Rounded.AutoAwesome,
-                    label = "Story",
+                    title = "Instagram Story",
+                    subtitle = "Artwork + copied link",
                     onClick = {
-                        val tMs = if (includeTimestamp && showTimestampOption) currentPositionMs else null
+                        val tMs =
+                            if (includeTimestamp && showTimestampOption) {
+                                currentPositionMs
+                            } else {
+                                null
+                            }
                         onShare(id, type, tMs, ShareTarget.INSTAGRAM_STORY)
                         onDismissRequest()
                     },
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f),
                 )
             }
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = "Story copies the link so you can add it with Instagram’s Link sticker.",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+        }
+    }
+}
+
+@Composable
+@Suppress("FunctionName")
+private fun SharePrimaryAction(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .expressiveClickable(
+                    shape = MaterialTheme.shapes.extraLarge,
+                    onClick = onClick,
+                ),
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.primary,
+        contentColor = MaterialTheme.colorScheme.onPrimary,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Surface(
+                shape = MaterialTheme.shapes.large,
+                color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.14f),
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.padding(10.dp).size(22.dp),
+                )
+            }
+            Spacer(modifier = Modifier.width(13.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = GoogleSansWeight.bold,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.78f),
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.ArrowForward,
+                contentDescription = null,
+                modifier = Modifier.size(22.dp),
             )
         }
     }
 }
 
 @Composable
-private fun ShareActionTile(
+@Suppress("FunctionName")
+private fun ShareSecondaryAction(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
-    label: String,
+    title: String,
+    subtitle: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    emphasized: Boolean = false
 ) {
-    val containerColor = if (emphasized) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.surfaceContainerHighest
-    }
-    val contentColor = if (emphasized) {
-        MaterialTheme.colorScheme.onPrimary
-    } else {
-        MaterialTheme.colorScheme.onSurface
-    }
     Surface(
-        modifier = modifier.expressiveClickable(
-            shape = MaterialTheme.shapes.extraLarge,
-            onClick = onClick
-        ),
+        modifier =
+            modifier
+                .defaultMinSize(minHeight = 108.dp)
+                .expressiveClickable(
+                    shape = MaterialTheme.shapes.extraLarge,
+                    onClick = onClick,
+                ),
         shape = MaterialTheme.shapes.extraLarge,
-        color = containerColor
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        contentColor = MaterialTheme.colorScheme.onSurface,
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 14.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            modifier = Modifier.fillMaxWidth().padding(14.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
             Surface(
-                shape = CircleShape,
-                color = contentColor.copy(alpha = 0.12f)
+                shape = MaterialTheme.shapes.large,
+                color = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
             ) {
                 Icon(
                     imageVector = icon,
                     contentDescription = null,
-                    tint = contentColor,
-                    modifier = Modifier.padding(8.dp).size(20.dp)
+                    modifier = Modifier.padding(8.dp).size(19.dp),
                 )
             }
-            Spacer(modifier = Modifier.height(7.dp))
+            Spacer(modifier = Modifier.height(10.dp))
             Text(
-                text = label,
-                style = MaterialTheme.typography.labelLarge,
+                text = title,
+                modifier = Modifier.fillMaxWidth(),
+                style = MaterialTheme.typography.titleSmall,
                 fontWeight = GoogleSansWeight.bold,
-                color = contentColor
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = subtitle,
+                modifier = Modifier.fillMaxWidth(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }

--- a/core/designsystem/src/main/java/cx/aswin/boxlore/core/designsystem/components/ShareBottomSheet.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxlore/core/designsystem/components/ShareBottomSheet.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:function-naming")
+
 package cx.aswin.boxlore.core.designsystem.components
 
 import androidx.compose.foundation.layout.Arrangement
@@ -36,8 +38,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
 import cx.aswin.boxlore.core.designsystem.theme.expressiveClickable
@@ -46,7 +48,7 @@ import cx.aswin.boxlore.core.model.ShareTarget
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-@Suppress("FunctionName")
+@Suppress("LongMethod", "LongParameterList")
 fun ShareBottomSheet(
     id: String,
     type: String, // "podcast" or "episode"
@@ -312,7 +314,6 @@ fun ShareBottomSheet(
 }
 
 @Composable
-@Suppress("FunctionName")
 private fun SharePrimaryAction(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     title: String,
@@ -370,7 +371,6 @@ private fun SharePrimaryAction(
 }
 
 @Composable
-@Suppress("FunctionName")
 private fun ShareSecondaryAction(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     title: String,

--- a/core/designsystem/src/main/java/cx/aswin/boxlore/core/designsystem/share/ShareCardRenderer.kt
+++ b/core/designsystem/src/main/java/cx/aswin/boxlore/core/designsystem/share/ShareCardRenderer.kt
@@ -5,6 +5,36 @@ package cx.aswin.boxlore.core.designsystem.share
 import android.content.Context
 import cx.aswin.boxlore.core.model.ShareTarget
 
+internal data class ShareBrandingLayout(
+    val contentGap: Float,
+    val labelSize: Float,
+    val logoWidth: Int,
+    val listenNowGap: Float,
+    val listenNowSize: Float,
+    val showListenNow: Boolean,
+)
+
+internal fun shareBrandingLayout(isStory: Boolean): ShareBrandingLayout =
+    if (isStory) {
+        ShareBrandingLayout(
+            contentGap = 112f,
+            labelSize = 28f,
+            logoWidth = 400,
+            listenNowGap = 18f,
+            listenNowSize = 28f,
+            showListenNow = true,
+        )
+    } else {
+        ShareBrandingLayout(
+            contentGap = 64f,
+            labelSize = 24f,
+            logoWidth = 340,
+            listenNowGap = 0f,
+            listenNowSize = 0f,
+            showListenNow = false,
+        )
+    }
+
 /** Bitmap card composition for [ShareManager] share sheets / Instagram stories. */
 internal object ShareCardRenderer {
     fun createShareCard(
@@ -48,6 +78,7 @@ internal object ShareCardRenderer {
             cornerRadius = 72f,
         )
 
+        val brandingLayout = shareBrandingLayout(isStory)
         if (isStory) {
             val textBottom =
                 drawShareText(
@@ -66,11 +97,12 @@ internal object ShareCardRenderer {
                 context = context,
                 canvas = canvas,
                 canvasWidth = width,
-                brandingTop = textBottom + 44f,
-                brandingLabelSize = 34f,
-                logoWidth = 480,
-                listenNowGap = 22f,
-                listenNowSize = 32f,
+                brandingTop = textBottom + brandingLayout.contentGap,
+                brandingLabelSize = brandingLayout.labelSize,
+                logoWidth = brandingLayout.logoWidth,
+                listenNowGap = brandingLayout.listenNowGap,
+                listenNowSize = brandingLayout.listenNowSize,
+                showListenNow = brandingLayout.showListenNow,
             )
         } else {
             val textBottom =
@@ -90,11 +122,12 @@ internal object ShareCardRenderer {
                 context = context,
                 canvas = canvas,
                 canvasWidth = width,
-                brandingTop = textBottom + 30f,
-                brandingLabelSize = 28f,
-                logoWidth = 400,
-                listenNowGap = 17f,
-                listenNowSize = 28f,
+                brandingTop = textBottom + brandingLayout.contentGap,
+                brandingLabelSize = brandingLayout.labelSize,
+                logoWidth = brandingLayout.logoWidth,
+                listenNowGap = brandingLayout.listenNowGap,
+                listenNowSize = brandingLayout.listenNowSize,
+                showListenNow = brandingLayout.showListenNow,
             )
         }
 
@@ -184,6 +217,7 @@ internal object ShareCardRenderer {
         logoWidth: Int,
         listenNowGap: Float,
         listenNowSize: Float,
+        showListenNow: Boolean,
     ) {
         val brandingLeft = (canvasWidth - logoWidth) / 2f
         val brandingRight = brandingLeft + logoWidth
@@ -248,6 +282,8 @@ internal object ShareCardRenderer {
                 )
                 draw(canvas)
             }
+        if (!showListenNow) return
+
         val listenNowTop = logoTop + logoHeight + listenNowGap
         drawCenteredTextBlock(
             canvas = canvas,
@@ -366,7 +402,9 @@ internal object ShareCardRenderer {
         cx.aswin.boxlore.core.designsystem.theme.GoogleSansTypefaces.create(
             context = context,
             style = style,
-            roundness = cx.aswin.boxlore.core.designsystem.theme.GoogleSansTypefaces.cachedRoundness(context),
+            roundness =
+                cx.aswin.boxlore.core.designsystem.theme.GoogleSansTypefaces
+                    .cachedRoundness(context),
         )
 
     private fun drawRoundedArtwork(

--- a/core/designsystem/src/test/java/cx/aswin/boxlore/core/designsystem/share/ShareCardLayoutTest.kt
+++ b/core/designsystem/src/test/java/cx/aswin/boxlore/core/designsystem/share/ShareCardLayoutTest.kt
@@ -1,0 +1,27 @@
+package cx.aswin.boxlore.core.designsystem.share
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ShareCardLayoutTest {
+    @Test
+    fun storyBrandingIsSeparatedAndKeepsListenPrompt() {
+        val layout = shareBrandingLayout(isStory = true)
+
+        assertTrue(layout.contentGap >= 110f)
+        assertTrue(layout.labelSize < 34f)
+        assertTrue(layout.logoWidth < 480)
+        assertTrue(layout.showListenNow)
+    }
+
+    @Test
+    fun messageBrandingIsCompactAndOmitsListenPrompt() {
+        val layout = shareBrandingLayout(isStory = false)
+
+        assertTrue(layout.contentGap >= 60f)
+        assertTrue(layout.labelSize < 28f)
+        assertTrue(layout.logoWidth < 400)
+        assertFalse(layout.showListenNow)
+    }
+}

--- a/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetRenderer.kt
+++ b/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetRenderer.kt
@@ -15,6 +15,7 @@ import android.widget.RemoteViews
 import cx.aswin.boxlore.feature.widgets.actions.WidgetActionIntents
 import cx.aswin.boxlore.feature.widgets.logic.WidgetSemantics
 
+@Suppress("TooManyFunctions")
 object NowPlayingWidgetRenderer {
     fun updateAll(
         context: Context,

--- a/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetRenderer.kt
+++ b/feature/widgets/src/main/java/cx/aswin/boxlore/feature/widgets/NowPlayingWidgetRenderer.kt
@@ -565,6 +565,5 @@ object NowPlayingWidgetRenderer {
     private const val STANDARD_CARD_HEIGHT_DP = 100
     private const val BAR_CARD_HEIGHT_DP = 48
 
-    private fun WidgetVariant.isControlsGrid(): Boolean =
-        this == WidgetVariant.CONTROLS || this == WidgetVariant.CONTROLS_NEXT
+    private fun WidgetVariant.isControlsGrid(): Boolean = this == WidgetVariant.CONTROLS || this == WidgetVariant.CONTROLS_NEXT
 }


### PR DESCRIPTION
## Summary

- Redesign the share sheet with clearer hierarchy, content preview, and aligned actions.
- Clarify that both message and Instagram Story sharing include artwork.
- Refine generated share-card spacing and branding for Story and square formats.

## Motivation

The previous share sheet felt visually flat, its timestamp checkbox looked awkward, and its copy made the Story behavior unclear. Generated cards also placed too much visual weight on branding.

## What changed

- Added a themed header and stronger podcast/episode preview.
- Replaced the timestamp checkbox with a labeled switch row.
- Made artwork sharing the primary action, with aligned Copy Link and Instagram Story actions below.
- Explicitly describes Story output as artwork plus a copied link.
- Reduced and lowered branding on both generated formats.
- Removed “listen now” from square message artwork while retaining it on Story artwork.
- Added unit coverage for format-specific branding layout.

## Behavior & compatibility

Share links, targets, analytics, and Instagram intent behavior remain unchanged. This only changes share-sheet presentation and generated-card composition.

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-critical`
- [ ] `user-impact-high`
- [x] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact

**What changes in the user’s life:**

- Sharing a podcast or episode is easier to understand, and the resulting artwork cards are less crowded and better balanced.

### Backend — optional

- [ ] `backend-change`

## Release copy (verbatim — highest priority)

### CHANGELOG.md (developer copy)

<!-- release-copy:changelog:start -->

### Changed
- Redesigned the artwork sharing sheet and refined Story and square share-card composition.

<!-- release-copy:changelog:end -->

### README What's New / Upcoming (listener copy)

<!-- release-copy:readme:start -->

- Sharing podcasts and episodes is now clearer, with cleaner artwork cards for messages and Instagram Stories.

<!-- release-copy:readme:end -->

## Test plan

- [x] Ran `./gradlew :core:designsystem:testDebugUnitTest`
- [x] Ran relevant ktlint checks
- [x] Built and installed locally with `./gradlew installDebug`
- [ ] Manually verify final message and Story share flows
- [ ] Required checks are green before merge completes