### PR TITLE
fix(catalog): report real-time show restore progress and streamline notification permission banner

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -62,6 +62,7 @@ src/main/java/cx/aswin/boxlore/
     libraryimport/
       OpmlImportDialog.kt
       ImportDialogSystemBars.kt
+      ImportNotificationPermissionCard.kt
       OpmlImportEffects.kt
       OpmlImportProgressContent.kt
   updates/

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportNotificationPermissionCard.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportNotificationPermissionCard.kt
@@ -10,9 +10,7 @@ import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -28,6 +26,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -84,19 +86,24 @@ internal fun ImportNotificationPermissionCard(
     onOpenSettings: () -> Unit = {},
 ) {
     val context = LocalContext.current
+    var promptAttempted by rememberSaveable { mutableStateOf(false) }
+
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = { granted ->
+            promptAttempted = true
             AnalyticsHelper.trackNotificationPermissionDecided(granted)
             onPermissionChanged(areAppNotificationsEnabled(context))
         },
     )
 
-    val needsRuntimePermission = Build.VERSION.SDK_INT >= 33 &&
+    val canRequestRuntimePermission = Build.VERSION.SDK_INT >= 33 &&
+        !promptAttempted &&
         ContextCompat.checkSelfPermission(
             context,
             Manifest.permission.POST_NOTIFICATIONS,
-        ) != PackageManager.PERMISSION_GRANTED
+        ) != PackageManager.PERMISSION_GRANTED &&
+        NotificationManagerCompat.from(context).areNotificationsEnabled()
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -131,52 +138,29 @@ internal fun ImportNotificationPermissionCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )
-            Spacer(modifier = Modifier.height(12.dp))
-            NotificationCardButtons(
-                needsRuntimePermission = needsRuntimePermission,
-                onGrant = { launcher.launch(Manifest.permission.POST_NOTIFICATIONS) },
-                onSettings = onOpenSettings,
-            )
-        }
-    }
-}
-
-@Composable
-private fun NotificationCardButtons(
-    needsRuntimePermission: Boolean,
-    onGrant: () -> Unit,
-    onSettings: () -> Unit,
-) {
-    Row(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (needsRuntimePermission) {
+            Spacer(modifier = Modifier.height(14.dp))
             Button(
-                onClick = onGrant,
+                onClick = {
+                    if (canRequestRuntimePermission) {
+                        launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    } else {
+                        onOpenSettings()
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
                 colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
                 shape = RoundedCornerShape(12.dp),
             ) {
-                Text("Grant permission", color = MaterialTheme.colorScheme.onError)
+                Text(
+                    text = if (canRequestRuntimePermission) {
+                        "Enable notifications"
+                    } else {
+                        "Enable in settings"
+                    },
+                    color = MaterialTheme.colorScheme.onError,
+                    fontWeight = GoogleSansWeight.semiBold,
+                )
             }
-        }
-        Button(
-            onClick = onSettings,
-            colors = if (needsRuntimePermission) {
-                ButtonDefaults.filledTonalButtonColors()
-            } else {
-                ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
-            },
-            shape = RoundedCornerShape(12.dp),
-        ) {
-            Text(
-                "Settings",
-                color = if (needsRuntimePermission) {
-                    MaterialTheme.colorScheme.onSurface
-                } else {
-                    MaterialTheme.colorScheme.onError
-                },
-            )
         }
     }
 }

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportNotificationPermissionCard.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportNotificationPermissionCard.kt
@@ -102,8 +102,7 @@ internal fun ImportNotificationPermissionCard(
         ContextCompat.checkSelfPermission(
             context,
             Manifest.permission.POST_NOTIFICATIONS,
-        ) != PackageManager.PERMISSION_GRANTED &&
-        NotificationManagerCompat.from(context).areNotificationsEnabled()
+        ) != PackageManager.PERMISSION_GRANTED
 
     Surface(
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportNotificationPermissionCard.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportNotificationPermissionCard.kt
@@ -107,7 +107,7 @@ internal fun ImportNotificationPermissionCard(
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = ImportCorner,
-        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.35f),
+        color = MaterialTheme.colorScheme.errorContainer,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.28f)),
     ) {
         Column(
@@ -127,14 +127,14 @@ internal fun ImportNotificationPermissionCard(
                 text = "Enable notifications",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = GoogleSansWeight.bold,
-                color = MaterialTheme.colorScheme.error,
+                color = MaterialTheme.colorScheme.onErrorContainer,
             )
             Spacer(modifier = Modifier.height(6.dp))
             Text(
                 text = "This backup includes shows with alerts or auto-downloads. " +
                     "Allow notifications so they can keep working in the background.",
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = MaterialTheme.colorScheme.onErrorContainer,
                 textAlign = TextAlign.Center,
             )
             Spacer(modifier = Modifier.height(14.dp))

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportNotificationPermissionCard.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/ImportNotificationPermissionCard.kt
@@ -1,0 +1,182 @@
+package cx.aswin.boxlore.ui.libraryimport
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.NotificationsActive
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import cx.aswin.boxlore.core.analytics.AnalyticsHelper
+import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
+
+internal fun areAppNotificationsEnabled(context: Context): Boolean {
+    if (Build.VERSION.SDK_INT >= 33) {
+        val granted = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) return false
+    }
+    return NotificationManagerCompat.from(context).areNotificationsEnabled()
+}
+
+internal fun hasPostNotificationPermission(context: Context): Boolean =
+    areAppNotificationsEnabled(context)
+
+internal fun openAppNotificationSettings(context: Context) {
+    val intent = Intent().apply {
+        when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
+                action = Settings.ACTION_APP_NOTIFICATION_SETTINGS
+                putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+            }
+            else -> {
+                action = "android.settings.APP_NOTIFICATION_SETTINGS"
+                putExtra("app_package", context.packageName)
+                putExtra("app_uid", context.applicationInfo.uid)
+            }
+        }
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+    }
+    try {
+        context.startActivity(intent)
+    } catch (_: Exception) {
+        val fallback = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", context.packageName, null)
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        context.startActivity(fallback)
+    }
+}
+
+@Composable
+internal fun ImportNotificationPermissionCard(
+    onPermissionChanged: (Boolean) -> Unit = {},
+    onOpenSettings: () -> Unit = {},
+) {
+    val context = LocalContext.current
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { granted ->
+            AnalyticsHelper.trackNotificationPermissionDecided(granted)
+            onPermissionChanged(areAppNotificationsEnabled(context))
+        },
+    )
+
+    val needsRuntimePermission = Build.VERSION.SDK_INT >= 33 &&
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) != PackageManager.PERMISSION_GRANTED
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = ImportCorner,
+        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.35f),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.28f)),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.NotificationsActive,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(26.dp),
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Enable notifications",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = GoogleSansWeight.bold,
+                color = MaterialTheme.colorScheme.error,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = "This backup includes shows with alerts or auto-downloads. " +
+                    "Allow notifications so they can keep working in the background.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            NotificationCardButtons(
+                needsRuntimePermission = needsRuntimePermission,
+                onGrant = { launcher.launch(Manifest.permission.POST_NOTIFICATIONS) },
+                onSettings = onOpenSettings,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NotificationCardButtons(
+    needsRuntimePermission: Boolean,
+    onGrant: () -> Unit,
+    onSettings: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (needsRuntimePermission) {
+            Button(
+                onClick = onGrant,
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                shape = RoundedCornerShape(12.dp),
+            ) {
+                Text("Grant permission", color = MaterialTheme.colorScheme.onError)
+            }
+        }
+        Button(
+            onClick = onSettings,
+            colors = if (needsRuntimePermission) {
+                ButtonDefaults.filledTonalButtonColors()
+            } else {
+                ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error)
+            },
+            shape = RoundedCornerShape(12.dp),
+        ) {
+            Text(
+                "Settings",
+                color = if (needsRuntimePermission) {
+                    MaterialTheme.colorScheme.onSurface
+                } else {
+                    MaterialTheme.colorScheme.onError
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportDialog.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportDialog.kt
@@ -45,23 +45,28 @@ sealed interface OpmlImportState {
 
     data object ShowSelector : OpmlImportState
 
+    sealed interface ActiveImportState : OpmlImportState {
+        val progress: Float
+        val totalCount: Int
+    }
+
     data class ImportingJson(
         val currentTitle: String = "",
-        val progress: Float = 0f,
+        override val progress: Float = 0f,
         val currentCount: Int = 0,
-        val totalCount: Int = 0,
+        override val totalCount: Int = 0,
         val phase: JsonBackupPhase = JsonBackupPhase.PREPARING,
-    ) : OpmlImportState
+    ) : ActiveImportState
 
     data class Parsing(val uri: android.net.Uri,) : OpmlImportState
 
     data class Importing(
         val currentFeedTitle: String,
-        val progress: Float,
+        override val progress: Float,
         val currentCount: Int,
-        val totalCount: Int,
+        override val totalCount: Int,
         val importedPodcasts: List<Podcast>,
-    ) : OpmlImportState
+    ) : ActiveImportState
 
     data class AskCompleted(val importedPodcasts: List<Podcast>, val selectedIds: Set<String>,) : OpmlImportState
 

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportDialog.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportDialog.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import cx.aswin.boxlore.core.catalog.backup.JsonBackupPhase
 import cx.aswin.boxlore.core.designsystem.theme.LocalEffectiveDarkTheme
 import cx.aswin.boxlore.core.model.Podcast
 
@@ -44,7 +45,13 @@ sealed interface OpmlImportState {
 
     data object ShowSelector : OpmlImportState
 
-    data object ImportingJson : OpmlImportState
+    data class ImportingJson(
+        val currentTitle: String = "",
+        val progress: Float = 0f,
+        val currentCount: Int = 0,
+        val totalCount: Int = 0,
+        val phase: JsonBackupPhase = JsonBackupPhase.PREPARING,
+    ) : OpmlImportState
 
     data class Parsing(val uri: android.net.Uri,) : OpmlImportState
 

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportEffects.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportEffects.kt
@@ -199,7 +199,7 @@ suspend fun performJsonLibraryImport(
     userPrefs: UserPreferencesRepository,
     onStateChange: (OpmlImportState) -> Unit,
 ) {
-    onStateChange(OpmlImportState.ImportingJson)
+    onStateChange(OpmlImportState.ImportingJson())
     withContext(Dispatchers.IO) {
         try {
             val jsonStr =
@@ -223,7 +223,19 @@ suspend fun performJsonLibraryImport(
                     podcastRepository,
                     userPrefs,
                     context,
-                ).importLibraryFromJson(jsonStr)
+                ).importLibraryFromJson(jsonStr) { progress ->
+                    withContext(Dispatchers.Main) {
+                        onStateChange(
+                            OpmlImportState.ImportingJson(
+                                currentTitle = progress.currentTitle,
+                                progress = progress.progressRatio,
+                                currentCount = progress.current,
+                                totalCount = progress.total,
+                                phase = progress.phase,
+                            ),
+                        )
+                    }
+                }
             AnalyticsHelper.trackBackupRestoreResult(
                 action = "import",
                 success = true,

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContent.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContent.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import cx.aswin.boxlore.core.catalog.backup.JsonBackupPhase
 import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
 
 internal val ImportCorner = RoundedCornerShape(24.dp)
@@ -67,13 +66,18 @@ internal fun contentKeyFor(state: OpmlImportState): String = when (state) {
 
 internal fun heroVisualFor(state: OpmlImportState): ImportHeroVisual? = when (state) {
     is OpmlImportState.ImportingJson ->
-        if (state.totalCount > 0) {
+        if (state.totalCount > 0 && state.progress > 0f) {
             ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
         } else {
             ImportHeroVisual.Indeterminate
         }
     is OpmlImportState.Parsing -> ImportHeroVisual.Indeterminate
-    is OpmlImportState.Importing -> ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
+    is OpmlImportState.Importing ->
+        if (state.totalCount > 0 && state.progress > 0f) {
+            ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
+        } else {
+            ImportHeroVisual.Indeterminate
+        }
     is OpmlImportState.Completing -> ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
     is OpmlImportState.Success -> ImportHeroVisual.Complete
     else -> null
@@ -104,31 +108,17 @@ internal fun ProgressFlowScaffold(hero: ImportHeroVisual, state: OpmlImportState
             when (current) {
                 is OpmlImportState.ImportingJson -> {
                     when {
-                        current.phase == JsonBackupPhase.SUBSCRIBING && current.totalCount > 0 ->
+                        current.totalCount > 0 ->
                             ProgressCopy(
                                 title = "Restoring podcasts",
                                 subtitle = "Subscribing ${minOf(current.currentCount + 1, current.totalCount)} of ${current.totalCount}",
                                 detail = current.currentTitle.ifBlank { null },
                             )
 
-                        current.phase == JsonBackupPhase.RESTORING_HISTORY ->
-                            ProgressCopy(
-                                title = "Restoring history",
-                                subtitle = "Bringing in playback progress and history",
-                                detail = current.currentTitle.ifBlank { null },
-                            )
-
-                        current.phase == JsonBackupPhase.REFRESHING_FEEDS ->
-                            ProgressCopy(
-                                title = "Updating feeds",
-                                subtitle = "Fetching latest episodes for restored shows",
-                                detail = current.currentTitle.ifBlank { null },
-                            )
-
                         else ->
                             ProgressCopy(
-                                title = "Restoring backup",
-                                subtitle = "Bringing in shows and playback history",
+                                title = "Restoring podcasts",
+                                subtitle = "Preparing your library",
                                 detail = current.currentTitle.ifBlank { null },
                             )
                     }

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContent.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContent.kt
@@ -65,19 +65,13 @@ internal fun contentKeyFor(state: OpmlImportState): String = when (state) {
 }
 
 internal fun heroVisualFor(state: OpmlImportState): ImportHeroVisual? = when (state) {
-    is OpmlImportState.ImportingJson ->
+    is OpmlImportState.ActiveImportState ->
         if (state.totalCount > 0 && state.progress > 0f) {
             ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
         } else {
             ImportHeroVisual.Indeterminate
         }
     is OpmlImportState.Parsing -> ImportHeroVisual.Indeterminate
-    is OpmlImportState.Importing ->
-        if (state.totalCount > 0 && state.progress > 0f) {
-            ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
-        } else {
-            ImportHeroVisual.Indeterminate
-        }
     is OpmlImportState.Completing -> ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
     is OpmlImportState.Success -> ImportHeroVisual.Complete
     else -> null

--- a/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContent.kt
+++ b/app/src/main/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContent.kt
@@ -1,10 +1,5 @@
 package cx.aswin.boxlore.ui.libraryimport
 
-import android.Manifest
-import android.content.pm.PackageManager
-import android.os.Build
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -28,7 +23,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.LibraryBooks
 import androidx.compose.material.icons.rounded.ImportExport
-import androidx.compose.material.icons.rounded.NotificationsActive
 import androidx.compose.material.icons.rounded.SettingsBackupRestore
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -39,6 +33,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -46,16 +45,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat
-import cx.aswin.boxlore.core.analytics.AnalyticsHelper
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import cx.aswin.boxlore.core.catalog.backup.JsonBackupPhase
 import cx.aswin.boxlore.core.designsystem.theme.GoogleSansWeight
 
-private val ImportCorner = RoundedCornerShape(24.dp)
+internal val ImportCorner = RoundedCornerShape(24.dp)
 
 internal fun contentKeyFor(state: OpmlImportState): String = when (state) {
     OpmlImportState.Idle -> "idle"
     OpmlImportState.ShowSelector -> "selector"
-    OpmlImportState.ImportingJson -> "importing_json"
+    is OpmlImportState.ImportingJson -> "importing_json"
     is OpmlImportState.Parsing -> "parsing"
     is OpmlImportState.Importing -> "importing"
     is OpmlImportState.AskCompleted -> "ask"
@@ -65,9 +66,13 @@ internal fun contentKeyFor(state: OpmlImportState): String = when (state) {
 }
 
 internal fun heroVisualFor(state: OpmlImportState): ImportHeroVisual? = when (state) {
-    OpmlImportState.ImportingJson,
-    is OpmlImportState.Parsing,
-    -> ImportHeroVisual.Indeterminate
+    is OpmlImportState.ImportingJson ->
+        if (state.totalCount > 0) {
+            ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
+        } else {
+            ImportHeroVisual.Indeterminate
+        }
+    is OpmlImportState.Parsing -> ImportHeroVisual.Indeterminate
     is OpmlImportState.Importing -> ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
     is OpmlImportState.Completing -> ImportHeroVisual.Progress(state.progress.coerceIn(0f, 1f))
     is OpmlImportState.Success -> ImportHeroVisual.Complete
@@ -97,11 +102,37 @@ internal fun ProgressFlowScaffold(hero: ImportHeroVisual, state: OpmlImportState
             label = "import_progress_copy",
         ) { current ->
             when (current) {
-                OpmlImportState.ImportingJson ->
-                    ProgressCopy(
-                        title = "Restoring backup",
-                        subtitle = "Bringing in shows and playback history",
-                    )
+                is OpmlImportState.ImportingJson -> {
+                    when {
+                        current.phase == JsonBackupPhase.SUBSCRIBING && current.totalCount > 0 ->
+                            ProgressCopy(
+                                title = "Restoring podcasts",
+                                subtitle = "Subscribing ${minOf(current.currentCount + 1, current.totalCount)} of ${current.totalCount}",
+                                detail = current.currentTitle.ifBlank { null },
+                            )
+
+                        current.phase == JsonBackupPhase.RESTORING_HISTORY ->
+                            ProgressCopy(
+                                title = "Restoring history",
+                                subtitle = "Bringing in playback progress and history",
+                                detail = current.currentTitle.ifBlank { null },
+                            )
+
+                        current.phase == JsonBackupPhase.REFRESHING_FEEDS ->
+                            ProgressCopy(
+                                title = "Updating feeds",
+                                subtitle = "Fetching latest episodes for restored shows",
+                                detail = current.currentTitle.ifBlank { null },
+                            )
+
+                        else ->
+                            ProgressCopy(
+                                title = "Restoring backup",
+                                subtitle = "Bringing in shows and playback history",
+                                detail = current.currentTitle.ifBlank { null },
+                            )
+                    }
+                }
 
                 is OpmlImportState.Parsing ->
                     ProgressCopy(
@@ -313,21 +344,30 @@ internal fun ImportOptionCard(icon: ImageVector, title: String, subtitle: String
     }
 }
 
-internal fun hasPostNotificationPermission(context: android.content.Context): Boolean {
-    if (Build.VERSION.SDK_INT < 33) return true
-    return ContextCompat.checkSelfPermission(
-        context,
-        Manifest.permission.POST_NOTIFICATIONS,
-    ) == PackageManager.PERMISSION_GRANTED
-}
-
 @Composable
 internal fun SuccessCopy(state: OpmlImportState.Success, onDone: () -> Unit,) {
     val context = LocalContext.current
+    var hasNotificationPermission by remember {
+        mutableStateOf(areAppNotificationsEnabled(context))
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, context) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                hasNotificationPermission = areAppNotificationsEnabled(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
     val showNotificationPrompt =
         state.isJson &&
             state.hasNotificationsEnabled &&
-            !hasPostNotificationPermission(context)
+            !hasNotificationPermission
 
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
@@ -351,7 +391,10 @@ internal fun SuccessCopy(state: OpmlImportState.Success, onDone: () -> Unit,) {
 
         if (showNotificationPrompt) {
             Spacer(modifier = Modifier.height(16.dp))
-            ImportNotificationPermissionCard()
+            ImportNotificationPermissionCard(
+                onPermissionChanged = { hasNotificationPermission = it },
+                onOpenSettings = { openAppNotificationSettings(context) },
+            )
         }
 
         Spacer(modifier = Modifier.height(28.dp))
@@ -401,74 +444,6 @@ internal fun ImportSuccessSummary(state: OpmlImportState.Success) {
             SummaryRow(label = "Imported shows", value = "${state.importedCount}")
             if (!state.isJson && state.completedCount > 0) {
                 SummaryRow(label = "Marked played", value = "${state.completedCount}")
-            }
-        }
-    }
-}
-
-@Composable
-internal fun ImportNotificationPermissionCard() {
-    val requestPermissionLauncher =
-        rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.RequestPermission(),
-            onResult = { granted ->
-                AnalyticsHelper.trackNotificationPermissionDecided(granted)
-            },
-        )
-
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = ImportCorner,
-        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.35f),
-        border =
-        androidx.compose.foundation.BorderStroke(
-            1.dp,
-            MaterialTheme.colorScheme.error.copy(alpha = 0.28f),
-        ),
-    ) {
-        Column(
-            modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(18.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Icon(
-                imageVector = Icons.Rounded.NotificationsActive,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(26.dp),
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = "Enable notifications",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = GoogleSansWeight.bold,
-                color = MaterialTheme.colorScheme.error,
-            )
-            Spacer(modifier = Modifier.height(6.dp))
-            Text(
-                text =
-                "This backup includes shows with alerts or auto-downloads. " +
-                    "Allow notifications so they can keep working in the background.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Button(
-                onClick = {
-                    if (Build.VERSION.SDK_INT >= 33) {
-                        requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                    }
-                },
-                colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.error,
-                ),
-                shape = RoundedCornerShape(12.dp),
-            ) {
-                Text("Grant permission", color = MaterialTheme.colorScheme.onError)
             }
         }
     }

--- a/app/src/test/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContentTest.kt
+++ b/app/src/test/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContentTest.kt
@@ -58,6 +58,20 @@ class OpmlImportProgressContentTest {
     }
 
     @Test
+    fun heroVisualFor_importingOpmlWithPositiveTotal_isProgress() {
+        val state = OpmlImportState.Importing(
+            currentFeedTitle = "Show B",
+            progress = 0.75f,
+            currentCount = 15,
+            totalCount = 20,
+            importedPodcasts = emptyList(),
+        )
+        val hero = heroVisualFor(state)
+        assertTrue(hero is ImportHeroVisual.Progress)
+        assertEquals(0.75f, (hero as ImportHeroVisual.Progress).value, 0.001f)
+    }
+
+    @Test
     fun heroVisualFor_zeroOrNegativeProgress_isIndeterminate() {
         val zeroState = OpmlImportState.ImportingJson(
             totalCount = 10,

--- a/app/src/test/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContentTest.kt
+++ b/app/src/test/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContentTest.kt
@@ -58,14 +58,22 @@ class OpmlImportProgressContentTest {
     }
 
     @Test
-    fun heroVisualFor_clampsProgressBetweenZeroAndOne() {
+    fun heroVisualFor_zeroOrNegativeProgress_isIndeterminate() {
+        val zeroState = OpmlImportState.ImportingJson(
+            totalCount = 10,
+            progress = 0f,
+        )
+        assertEquals(ImportHeroVisual.Indeterminate, heroVisualFor(zeroState))
+
         val negativeState = OpmlImportState.ImportingJson(
             totalCount = 10,
             progress = -0.2f,
         )
-        val negativeHero = heroVisualFor(negativeState) as ImportHeroVisual.Progress
-        assertEquals(0f, negativeHero.value, 0.001f)
+        assertEquals(ImportHeroVisual.Indeterminate, heroVisualFor(negativeState))
+    }
 
+    @Test
+    fun heroVisualFor_clampsProgressAtOne() {
         val overflowState = OpmlImportState.ImportingJson(
             totalCount = 10,
             progress = 1.8f,

--- a/app/src/test/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContentTest.kt
+++ b/app/src/test/java/cx/aswin/boxlore/ui/libraryimport/OpmlImportProgressContentTest.kt
@@ -1,0 +1,106 @@
+package cx.aswin.boxlore.ui.libraryimport
+
+import android.app.Application
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import cx.aswin.boxlore.core.catalog.backup.JsonBackupPhase
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class OpmlImportProgressContentTest {
+    private lateinit var activity: ComponentActivity
+
+    @Before
+    fun setUp() {
+        activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+    }
+
+    @Test
+    fun contentKeyFor_returnsImportingJsonForJsonImportState() {
+        val state = OpmlImportState.ImportingJson(
+            currentTitle = "Show A",
+            progress = 0.5f,
+            currentCount = 5,
+            totalCount = 10,
+            phase = JsonBackupPhase.SUBSCRIBING,
+        )
+        assertEquals("importing_json", contentKeyFor(state))
+    }
+
+    @Test
+    fun heroVisualFor_importingJsonWithZeroTotal_isIndeterminate() {
+        val state = OpmlImportState.ImportingJson(totalCount = 0)
+        assertEquals(ImportHeroVisual.Indeterminate, heroVisualFor(state))
+    }
+
+    @Test
+    fun heroVisualFor_importingJsonWithPositiveTotal_isProgress() {
+        val state = OpmlImportState.ImportingJson(
+            totalCount = 20,
+            progress = 0.45f,
+            phase = JsonBackupPhase.SUBSCRIBING,
+        )
+        val hero = heroVisualFor(state)
+        assertTrue(hero is ImportHeroVisual.Progress)
+        assertEquals(0.45f, (hero as ImportHeroVisual.Progress).value, 0.001f)
+    }
+
+    @Test
+    fun heroVisualFor_clampsProgressBetweenZeroAndOne() {
+        val negativeState = OpmlImportState.ImportingJson(
+            totalCount = 10,
+            progress = -0.2f,
+        )
+        val negativeHero = heroVisualFor(negativeState) as ImportHeroVisual.Progress
+        assertEquals(0f, negativeHero.value, 0.001f)
+
+        val overflowState = OpmlImportState.ImportingJson(
+            totalCount = 10,
+            progress = 1.8f,
+        )
+        val overflowHero = heroVisualFor(overflowState) as ImportHeroVisual.Progress
+        assertEquals(1f, overflowHero.value, 0.001f)
+    }
+
+    @Test
+    fun heroVisualFor_success_isComplete() {
+        val state = OpmlImportState.Success(
+            importedCount = 5,
+            completedCount = 0,
+            isJson = true,
+        )
+        assertEquals(ImportHeroVisual.Complete, heroVisualFor(state))
+    }
+
+    @Test
+    fun areAppNotificationsEnabled_and_hasPostNotificationPermission_executeSuccessfully() {
+        val enabled = areAppNotificationsEnabled(activity)
+        val permissionResult = hasPostNotificationPermission(activity)
+        assertEquals(enabled, permissionResult)
+    }
+
+    @Test
+    fun openAppNotificationSettings_startsExpectedSettingsIntent() {
+        openAppNotificationSettings(activity)
+        val shadowActivity = shadowOf(activity)
+        val nextIntent = shadowActivity.nextStartedActivity
+        assertNotNull(nextIntent)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            assertEquals(Settings.ACTION_APP_NOTIFICATION_SETTINGS, nextIntent.action)
+            assertEquals(activity.packageName, nextIntent.getStringExtra(Settings.EXTRA_APP_PACKAGE))
+        }
+        assertTrue(nextIntent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+}

--- a/core/catalog/README.md
+++ b/core/catalog/README.md
@@ -54,6 +54,7 @@ src/main/java/cx/aswin/boxlore/core/catalog/
   logic/
   backup/
     LibraryBackupManager.kt
+    LibraryBackupProgress.kt
     LibraryBackupDirectFeed.kt
     LibraryBackupDirectFeedRestore.kt
     LibraryBackupImportLogic.kt

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupDirectFeedRestore.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupDirectFeedRestore.kt
@@ -32,13 +32,23 @@ internal object LibraryBackupDirectFeedRestore {
         targets: List<DirectFeedOptInBackup>,
         actions: DirectFeedRestoreActions,
         concurrency: Int = DEFAULT_CONCURRENCY,
+        onTargetStarted: (suspend (podcastId: String) -> Unit)? = null,
+        onTargetCompleted: (suspend (podcastId: String) -> Unit)? = null,
     ) {
         if (targets.isEmpty()) return
         val gate = Semaphore(concurrency.coerceAtLeast(1))
         coroutineScope {
             targets.map { optIn ->
                 async {
-                    gate.withPermit { restoreOne(optIn, actions) }
+                    gate.withPermit {
+                        val id = optIn.podcastId?.trim().orEmpty()
+                        if (id.isNotEmpty()) onTargetStarted?.invoke(id)
+                        try {
+                            restoreOne(optIn, actions)
+                        } finally {
+                            if (id.isNotEmpty()) onTargetCompleted?.invoke(id)
+                        }
+                    }
                 }
             }.awaitAll()
         }

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManager.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManager.kt
@@ -199,18 +199,62 @@ class LibraryBackupManager(
             .replace("'", "&apos;")
     }
 
-    suspend fun importLibraryFromJson(jsonString: String): Pair<Int, Boolean> = try {
+    suspend fun importLibraryFromJson(
+        jsonString: String,
+        onProgress: suspend (JsonBackupProgress) -> Unit = {},
+    ): Pair<Int, Boolean> = try {
+        onProgress(JsonBackupProgress(phase = JsonBackupPhase.PREPARING))
         val backup = gson.fromJson(jsonString, BoxLoreBackup::class.java)
         restoreImportedGlobalPreferences(backup.globalPreferences)
+        val totalSubs = backup.subscriptions.size
         val importedIds = mutableListOf<String>()
-        for (entity in backup.subscriptions) {
+        for ((index, entity) in backup.subscriptions.withIndex()) {
+            onProgress(
+                JsonBackupProgress(
+                    phase = JsonBackupPhase.SUBSCRIBING,
+                    current = index,
+                    total = totalSubs,
+                    currentTitle = entity.title,
+                ),
+            )
             importBackupSubscription(entity, backup)?.let { importedIds += it }
         }
+        if (totalSubs > 0) {
+            onProgress(
+                JsonBackupProgress(
+                    phase = JsonBackupPhase.SUBSCRIBING,
+                    current = totalSubs,
+                    total = totalSubs,
+                    currentTitle = "",
+                ),
+            )
+        }
+        onProgress(
+            JsonBackupProgress(
+                phase = JsonBackupPhase.RESTORING_HISTORY,
+                current = 0,
+                total = backup.history.size,
+            ),
+        )
         restoreImportedHistory(backup.history, importedIds)
         backup.adaptiveRanking?.let { rankingBackup ->
             adaptiveRankingRepository.restoreBackup(rankingBackup)
         }
+        onProgress(
+            JsonBackupProgress(
+                phase = JsonBackupPhase.REFRESHING_FEEDS,
+                current = 0,
+                total = importedIds.size,
+            ),
+        )
         refreshImportedLatestEpisodes(importedIds, backup.directFeedOptIns)
+        onProgress(
+            JsonBackupProgress(
+                phase = JsonBackupPhase.COMPLETED,
+                current = importedIds.size,
+                total = importedIds.size,
+            ),
+        )
         Pair(
             importedIds.size,
             backup.subscriptions.any { it.notificationsEnabled || it.autoDownloadEnabled },

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManager.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManager.kt
@@ -555,6 +555,8 @@ class LibraryBackupManager(
             )
             try {
                 rssPodcastRepository.refreshCatalogIfNeeded(id)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Log.e("JSON_IMPORT", "RSS catalog refresh failed for $id", e)
             }

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManager.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManager.kt
@@ -206,48 +206,21 @@ class LibraryBackupManager(
         onProgress(JsonBackupProgress(phase = JsonBackupPhase.PREPARING))
         val backup = gson.fromJson(jsonString, BoxLoreBackup::class.java)
         restoreImportedGlobalPreferences(backup.globalPreferences)
-        val totalSubs = backup.subscriptions.size
+        val titleMap = backup.subscriptions.associate { it.podcastId to it.title }
         val importedIds = mutableListOf<String>()
-        for ((index, entity) in backup.subscriptions.withIndex()) {
-            onProgress(
-                JsonBackupProgress(
-                    phase = JsonBackupPhase.SUBSCRIBING,
-                    current = index,
-                    total = totalSubs,
-                    currentTitle = entity.title,
-                ),
-            )
+        for (entity in backup.subscriptions) {
             importBackupSubscription(entity, backup)?.let { importedIds += it }
         }
-        if (totalSubs > 0) {
-            onProgress(
-                JsonBackupProgress(
-                    phase = JsonBackupPhase.SUBSCRIBING,
-                    current = totalSubs,
-                    total = totalSubs,
-                    currentTitle = "",
-                ),
-            )
-        }
-        onProgress(
-            JsonBackupProgress(
-                phase = JsonBackupPhase.RESTORING_HISTORY,
-                current = 0,
-                total = backup.history.size,
-            ),
-        )
         restoreImportedHistory(backup.history, importedIds)
         backup.adaptiveRanking?.let { rankingBackup ->
             adaptiveRankingRepository.restoreBackup(rankingBackup)
         }
-        onProgress(
-            JsonBackupProgress(
-                phase = JsonBackupPhase.REFRESHING_FEEDS,
-                current = 0,
-                total = importedIds.size,
-            ),
+        refreshImportedLatestEpisodes(
+            importedIds = importedIds,
+            backupOptIns = backup.directFeedOptIns,
+            titleMap = titleMap,
+            onProgress = onProgress,
         )
-        refreshImportedLatestEpisodes(importedIds, backup.directFeedOptIns)
         onProgress(
             JsonBackupProgress(
                 phase = JsonBackupPhase.COMPLETED,
@@ -447,7 +420,12 @@ class LibraryBackupManager(
         }
     }
 
-    private suspend fun refreshImportedLatestEpisodes(importedIds: List<String>, backupOptIns: List<DirectFeedOptInBackup>?,) {
+    private suspend fun refreshImportedLatestEpisodes(
+        importedIds: List<String>,
+        backupOptIns: List<DirectFeedOptInBackup>?,
+        titleMap: Map<String, String> = emptyMap(),
+        onProgress: suspend (JsonBackupProgress) -> Unit = {},
+    ) {
         val subscriptionFeedUrls =
             importedIds.associateWith { id ->
                 subscriptionRepository.getPodcastEntity(id)?.feedUrl
@@ -458,23 +436,138 @@ class LibraryBackupManager(
                 backupOptIns = backupOptIns,
                 subscriptionFeedUrls = subscriptionFeedUrls,
             )
+        val total = refreshPlan.directFeedTargets.size + refreshPlan.piSyncIds.size + refreshPlan.rssIds.size
+        if (total == 0) return
+
+        val completedCount = java.util.concurrent.atomic.AtomicInteger(0)
+
+        suspend fun resolveTitle(id: String): String =
+            titleMap[id]?.ifBlank { null } ?: subscriptionRepository.getPodcastEntity(id)?.title.orEmpty()
+
+        val initialTargetId = refreshPlan.directFeedTargets.firstOrNull()?.podcastId.orEmpty().ifBlank {
+            refreshPlan.rssIds.firstOrNull() ?: refreshPlan.piSyncIds.firstOrNull().orEmpty()
+        }
+        val initialTitle = if (initialTargetId.isNotBlank()) resolveTitle(initialTargetId) else ""
+
+        onProgress(
+            JsonBackupProgress(
+                phase = JsonBackupPhase.REFRESHING_FEEDS,
+                current = 0,
+                total = total,
+                currentTitle = initialTitle,
+            ),
+        )
+
         LibraryBackupDirectFeedLogic.runPostSubscribeRefresh(
             plan = refreshPlan,
-            restoreDirectFeeds = { restoreImportedDirectFeeds(it) },
-            syncPi = { ids ->
-                try {
-                    val syncedMap = podcastRepository.syncSubscriptions(ids)
-                    for ((id, ep) in syncedMap) {
-                        subscriptionRepository.updateLatestEpisode(id, ep)
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Log.e("JSON_IMPORT", "Failed to sync episodes", e)
-                }
+            restoreDirectFeeds = { targets ->
+                restoreImportedDirectFeeds(
+                    targets = targets,
+                    onTargetStarted = { id ->
+                        val title = resolveTitle(id)
+                        onProgress(
+                            JsonBackupProgress(
+                                phase = JsonBackupPhase.REFRESHING_FEEDS,
+                                current = completedCount.get(),
+                                total = total,
+                                currentTitle = title,
+                            ),
+                        )
+                    },
+                    onTargetCompleted = { id ->
+                        val done = completedCount.incrementAndGet()
+                        val title = resolveTitle(id)
+                        onProgress(
+                            JsonBackupProgress(
+                                phase = JsonBackupPhase.REFRESHING_FEEDS,
+                                current = done,
+                                total = total,
+                                currentTitle = title,
+                            ),
+                        )
+                    },
+                )
             },
-            refreshRss = { refreshImportedRssCatalogs(it) },
+            syncPi = { ids ->
+                syncPiSubscriptionsWithProgress(ids, total, completedCount, ::resolveTitle, onProgress)
+            },
+            refreshRss = { ids ->
+                refreshRssCatalogsWithProgress(ids, total, completedCount, ::resolveTitle, onProgress)
+            },
         )
+    }
+
+    private suspend fun syncPiSubscriptionsWithProgress(
+        ids: List<String>,
+        total: Int,
+        completedCount: java.util.concurrent.atomic.AtomicInteger,
+        resolveTitle: suspend (String) -> String,
+        onProgress: suspend (JsonBackupProgress) -> Unit,
+    ) {
+        for (id in ids) {
+            val title = resolveTitle(id)
+            onProgress(
+                JsonBackupProgress(
+                    phase = JsonBackupPhase.REFRESHING_FEEDS,
+                    current = completedCount.get(),
+                    total = total,
+                    currentTitle = title,
+                ),
+            )
+        }
+        try {
+            val syncedMap = podcastRepository.syncSubscriptions(ids)
+            for ((id, ep) in syncedMap) {
+                subscriptionRepository.updateLatestEpisode(id, ep)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e("JSON_IMPORT", "Failed to sync episodes", e)
+        }
+        val done = completedCount.addAndGet(ids.size)
+        onProgress(
+            JsonBackupProgress(
+                phase = JsonBackupPhase.REFRESHING_FEEDS,
+                current = done,
+                total = total,
+                currentTitle = "",
+            ),
+        )
+    }
+
+    private suspend fun refreshRssCatalogsWithProgress(
+        rssIds: List<String>,
+        total: Int,
+        completedCount: java.util.concurrent.atomic.AtomicInteger,
+        resolveTitle: suspend (String) -> String,
+        onProgress: suspend (JsonBackupProgress) -> Unit,
+    ) {
+        for (id in rssIds) {
+            val title = resolveTitle(id)
+            onProgress(
+                JsonBackupProgress(
+                    phase = JsonBackupPhase.REFRESHING_FEEDS,
+                    current = completedCount.get(),
+                    total = total,
+                    currentTitle = title,
+                ),
+            )
+            try {
+                rssPodcastRepository.refreshCatalogIfNeeded(id)
+            } catch (e: Exception) {
+                Log.e("JSON_IMPORT", "RSS catalog refresh failed for $id", e)
+            }
+            val done = completedCount.incrementAndGet()
+            onProgress(
+                JsonBackupProgress(
+                    phase = JsonBackupPhase.REFRESHING_FEEDS,
+                    current = done,
+                    total = total,
+                    currentTitle = title,
+                ),
+            )
+        }
     }
 
     suspend fun importFromOpml(inputStream: InputStream): Int = LibraryBackupImportLogic.opmlImportCount(
@@ -622,7 +715,12 @@ class LibraryBackupManager(
 
     private fun supplementPort(): EpisodeSupplementPort? = episodeSupplementPort ?: podcastRepository.episodeSupplementRepository
 
-    private suspend fun restoreImportedLocalCatalogs(targets: List<DirectFeedOptInBackup>, catalog: LocalEpisodeCatalogPort,) {
+    private suspend fun restoreImportedLocalCatalogs(
+        targets: List<DirectFeedOptInBackup>,
+        catalog: LocalEpisodeCatalogPort,
+        onTargetStarted: (suspend (podcastId: String) -> Unit)? = null,
+        onTargetCompleted: (suspend (podcastId: String) -> Unit)? = null,
+    ) {
         LibraryBackupDirectFeedRestore.restoreAndRefresh(
             targets = targets,
             actions =
@@ -688,13 +786,24 @@ class LibraryBackupManager(
                     Log.e("JSON_IMPORT", "Local catalog restore failed for $id", error)
                 },
             ),
+            onTargetStarted = onTargetStarted,
+            onTargetCompleted = onTargetCompleted,
         )
     }
 
-    private suspend fun restoreImportedDirectFeeds(targets: List<DirectFeedOptInBackup>) {
+    private suspend fun restoreImportedDirectFeeds(
+        targets: List<DirectFeedOptInBackup>,
+        onTargetStarted: (suspend (podcastId: String) -> Unit)? = null,
+        onTargetCompleted: (suspend (podcastId: String) -> Unit)? = null,
+    ) {
         val catalog = podcastRepository.localEpisodeCatalog
         if (catalog != null) {
-            restoreImportedLocalCatalogs(targets, catalog)
+            restoreImportedLocalCatalogs(
+                targets = targets,
+                catalog = catalog,
+                onTargetStarted = onTargetStarted,
+                onTargetCompleted = onTargetCompleted,
+            )
             return
         }
         val port = supplementPort() ?: return
@@ -741,17 +850,9 @@ class LibraryBackupManager(
                     Log.e("JSON_IMPORT", "Direct-feed restore failed for $id", error)
                 },
             ),
+            onTargetStarted = onTargetStarted,
+            onTargetCompleted = onTargetCompleted,
         )
-    }
-
-    private suspend fun refreshImportedRssCatalogs(rssIds: Collection<String>) {
-        for (id in rssIds) {
-            try {
-                rssPodcastRepository.refreshCatalogIfNeeded(id)
-            } catch (e: Exception) {
-                Log.e("JSON_IMPORT", "RSS catalog refresh failed for $id", e)
-            }
-        }
     }
 
     suspend fun markAllEpisodesCompleted(podcast: cx.aswin.boxlore.core.model.Podcast) {

--- a/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupProgress.kt
+++ b/core/catalog/src/main/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupProgress.kt
@@ -1,0 +1,19 @@
+package cx.aswin.boxlore.core.catalog.backup
+
+enum class JsonBackupPhase {
+    PREPARING,
+    SUBSCRIBING,
+    RESTORING_HISTORY,
+    REFRESHING_FEEDS,
+    COMPLETED,
+}
+
+data class JsonBackupProgress(
+    val phase: JsonBackupPhase = JsonBackupPhase.PREPARING,
+    val current: Int = 0,
+    val total: Int = 0,
+    val currentTitle: String = "",
+) {
+    val progressRatio: Float
+        get() = if (total > 0) (current.toFloat() / total).coerceIn(0f, 1f) else 0f
+}

--- a/core/catalog/src/test/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupDirectFeedRestoreTest.kt
+++ b/core/catalog/src/test/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupDirectFeedRestoreTest.kt
@@ -103,4 +103,28 @@ class LibraryBackupDirectFeedRestoreTest {
         )
         assertFalse(called)
     }
+
+    @Test
+    fun `restoreAndRefresh invokes progress callbacks per target`() = runTest {
+        val started = mutableListOf<String>()
+        val completed = mutableListOf<String>()
+        LibraryBackupDirectFeedRestore.restoreAndRefresh(
+            targets = listOf(
+                DirectFeedOptInBackup("201", "https://feeds.example/201.xml"),
+                DirectFeedOptInBackup("202", "https://feeds.example/202.xml"),
+            ),
+            actions = DirectFeedRestoreActions(
+                restoreStub = { _, _ -> },
+                ensureFeedUrl = { _, _ -> },
+                invalidateCache = {},
+                refreshFeed = { _, _ -> EpisodeSupplementOutcome.NoDisconnect },
+                saveTip = { _, _ -> },
+                syncTrackedUrl = {},
+            ),
+            onTargetStarted = { started.add(it) },
+            onTargetCompleted = { completed.add(it) },
+        )
+        assertEquals(listOf("201", "202"), started.sorted())
+        assertEquals(listOf("201", "202"), completed.sorted())
+    }
 }

--- a/core/catalog/src/test/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManagerProgressTest.kt
+++ b/core/catalog/src/test/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupManagerProgressTest.kt
@@ -1,0 +1,226 @@
+package cx.aswin.boxlore.core.catalog.backup
+
+import android.content.Context
+import android.content.SharedPreferences
+import cx.aswin.boxlore.core.catalog.PodcastRepository
+import cx.aswin.boxlore.core.catalog.SubscriptionRepository
+import cx.aswin.boxlore.core.catalog.ports.ListeningHistoryBackupPort
+import cx.aswin.boxlore.core.database.ListeningHistoryEntity
+import cx.aswin.boxlore.core.database.PodcastDao
+import cx.aswin.boxlore.core.domain.RssSubscriptionResult
+import cx.aswin.boxlore.core.model.Episode
+import cx.aswin.boxlore.core.ranking.AdaptiveRankingRepository
+import cx.aswin.boxlore.core.rss.RssPodcastRepository
+import cx.aswin.boxlore.core.testing.TestFixtures
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.nullable
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+
+class LibraryBackupManagerProgressTest {
+    private lateinit var podcastDao: PodcastDao
+    private lateinit var subscriptionRepository: SubscriptionRepository
+    private lateinit var podcastRepository: PodcastRepository
+    private lateinit var adaptiveRankingRepository: AdaptiveRankingRepository
+    private lateinit var rssPodcastRepository: RssPodcastRepository
+    private lateinit var manager: LibraryBackupManager
+    private val fakeListeningHistory = object : ListeningHistoryBackupPort {
+        override fun getAllHistory(): Flow<List<ListeningHistoryEntity>> = flowOf(emptyList())
+        override suspend fun upsertHistoryEntity(entity: ListeningHistoryEntity) {}
+        override suspend fun markAllEpisodesCompleted(
+            episodes: List<Episode>,
+            podcastId: String,
+            podcastTitle: String,
+            podcastImageUrl: String?,
+        ) {}
+    }
+
+    @BeforeEach
+    fun setUp() {
+        val context = fakeContext()
+        podcastDao = mock(PodcastDao::class.java)
+        subscriptionRepository = SubscriptionRepository(podcastDao)
+        podcastRepository = mock(PodcastRepository::class.java)
+        adaptiveRankingRepository = mock(AdaptiveRankingRepository::class.java)
+        rssPodcastRepository = mock(RssPodcastRepository::class.java)
+
+        manager = LibraryBackupManager(
+            subscriptionRepository = subscriptionRepository,
+            listeningHistory = fakeListeningHistory,
+            podcastRepository = podcastRepository,
+            context = context,
+            adaptiveRankingRepository = adaptiveRankingRepository,
+            rssPodcastRepository = rssPodcastRepository,
+        )
+    }
+
+    @Test
+    fun `importLibraryFromJson emits preparing and zero-target completion for empty library`() = runTest {
+        val progressEvents = mutableListOf<JsonBackupProgress>()
+        val json = """{"version": 4, "subscriptions": [], "history": []}"""
+
+        val result = manager.importLibraryFromJson(json) { progressEvents.add(it) }
+
+        assertEquals(Pair(0, false), result)
+        assertEquals(2, progressEvents.size)
+        assertEquals(JsonBackupPhase.PREPARING, progressEvents.first().phase)
+        assertEquals(JsonBackupPhase.COMPLETED, progressEvents.last().phase)
+        assertEquals(0, progressEvents.last().current)
+        assertEquals(0, progressEvents.last().total)
+    }
+
+    @Test
+    fun `importLibraryFromJson emits feed progress callbacks for restored shows`() = runTest {
+        val progressEvents = mutableListOf<JsonBackupProgress>()
+        val json = """
+            {
+              "version": 4,
+              "subscriptions": [
+                {
+                  "podcastId": "1001",
+                  "title": "Tech Talk",
+                  "author": "Host",
+                  "imageUrl": "https://example.com/art.jpg",
+                  "subscribedAt": 1000,
+                  "notificationsEnabled": true,
+                  "autoDownloadEnabled": false
+                }
+              ],
+              "history": []
+            }
+        """.trimIndent()
+
+        `when`(podcastRepository.syncSubscriptions(listOf("1001"))).thenReturn(emptyMap())
+
+        val result = manager.importLibraryFromJson(json) { progressEvents.add(it) }
+
+        assertEquals(Pair(1, true), result)
+        assertTrue(progressEvents.any { it.phase == JsonBackupPhase.PREPARING })
+        assertTrue(
+            progressEvents.any {
+                it.phase == JsonBackupPhase.REFRESHING_FEEDS &&
+                    it.current == 0 &&
+                    it.total == 1 &&
+                    it.currentTitle == "Tech Talk"
+            },
+        )
+        assertTrue(
+            progressEvents.any {
+                it.phase == JsonBackupPhase.REFRESHING_FEEDS &&
+                    it.current == 1 &&
+                    it.total == 1
+            },
+        )
+        val completed = progressEvents.last()
+        assertEquals(JsonBackupPhase.COMPLETED, completed.phase)
+        assertEquals(1, completed.current)
+        assertEquals(1, completed.total)
+    }
+
+    @Test
+    fun `importLibraryFromJson rethrows coroutine CancellationException during RSS refresh`() = runTest {
+        val rssShow = TestFixtures.podcast(id = "rss:feed-1", title = "RSS Show", sourceType = "rss")
+        `when`(rssPodcastRepository.addSubscription("https://example.com/rss.xml"))
+            .thenReturn(RssSubscriptionResult(podcast = rssShow, episodeCount = 10, automaticUpdateChecksSupported = true))
+        `when`(rssPodcastRepository.refreshCatalogIfNeeded("rss:feed-1"))
+            .thenAnswer { throw CancellationException("coroutine cancelled") }
+
+        val json = """
+            {
+              "version": 4,
+              "subscriptions": [
+                {
+                  "podcastId": "rss:feed-1",
+                  "title": "RSS Show",
+                  "feedUrl": "https://example.com/rss.xml",
+                  "sourceType": "rss",
+                  "subscribedAt": 1000,
+                  "notificationsEnabled": false,
+                  "autoDownloadEnabled": false
+                }
+              ],
+              "history": []
+            }
+        """.trimIndent()
+
+        var caught: Throwable? = null
+        try {
+            manager.importLibraryFromJson(json)
+        } catch (e: Throwable) {
+            caught = e
+        }
+        assertTrue(caught is CancellationException)
+    }
+
+    @Test
+    fun `importLibraryFromJson handles ordinary RSS refresh failure and completes`() = runTest {
+        val progressEvents = mutableListOf<JsonBackupProgress>()
+        val rssShow = TestFixtures.podcast(id = "rss:feed-2", title = "RSS Show 2", sourceType = "rss")
+        `when`(rssPodcastRepository.addSubscription("https://example.com/rss2.xml"))
+            .thenReturn(RssSubscriptionResult(podcast = rssShow, episodeCount = 10, automaticUpdateChecksSupported = true))
+        `when`(rssPodcastRepository.refreshCatalogIfNeeded("rss:feed-2"))
+            .thenAnswer { throw RuntimeException("network error") }
+
+        val json = """
+            {
+              "version": 4,
+              "subscriptions": [
+                {
+                  "podcastId": "rss:feed-2",
+                  "title": "RSS Show 2",
+                  "feedUrl": "https://example.com/rss2.xml",
+                  "sourceType": "rss",
+                  "subscribedAt": 1000,
+                  "notificationsEnabled": false,
+                  "autoDownloadEnabled": false
+                }
+              ],
+              "history": []
+            }
+        """.trimIndent()
+
+        val result = manager.importLibraryFromJson(json) { progressEvents.add(it) }
+
+        assertEquals(Pair(1, false), result)
+        assertEquals(JsonBackupPhase.COMPLETED, progressEvents.last().phase)
+        assertEquals(1, progressEvents.last().current)
+    }
+
+    @Test
+    fun `importLibraryFromJson returns minus one on malformed json`() = runTest {
+        val progressEvents = mutableListOf<JsonBackupProgress>()
+        val result = manager.importLibraryFromJson("{ broken json") { progressEvents.add(it) }
+
+        assertEquals(Pair(-1, false), result)
+        assertEquals(1, progressEvents.size)
+        assertEquals(JsonBackupPhase.PREPARING, progressEvents.single().phase)
+    }
+
+    private fun fakeContext(): Context {
+        val prefs = mock(SharedPreferences::class.java)
+        val editor = mock(SharedPreferences.Editor::class.java)
+        `when`(prefs.getString(anyString(), nullable(String::class.java))).thenReturn(null)
+        `when`(prefs.getAll()).thenReturn(emptyMap())
+        `when`(prefs.contains(anyString())).thenReturn(false)
+        `when`(prefs.edit()).thenReturn(editor)
+        `when`(editor.putString(anyString(), anyString())).thenReturn(editor)
+        `when`(editor.commit()).thenReturn(true)
+
+        val appContext = mock(Context::class.java)
+        `when`(appContext.getSharedPreferences(anyString(), anyInt())).thenReturn(prefs)
+
+        val context = mock(Context::class.java)
+        `when`(context.applicationContext).thenReturn(appContext)
+        `when`(context.getSharedPreferences(anyString(), anyInt())).thenReturn(prefs)
+        return context
+    }
+}

--- a/core/catalog/src/test/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupProgressTest.kt
+++ b/core/catalog/src/test/java/cx/aswin/boxlore/core/catalog/backup/LibraryBackupProgressTest.kt
@@ -1,0 +1,58 @@
+package cx.aswin.boxlore.core.catalog.backup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LibraryBackupProgressTest {
+    @Test
+    fun defaultValues_areInitializedProperly() {
+        val progress = JsonBackupProgress()
+        assertEquals(JsonBackupPhase.PREPARING, progress.phase)
+        assertEquals(0, progress.current)
+        assertEquals(0, progress.total)
+        assertEquals("", progress.currentTitle)
+        assertEquals(0f, progress.progressRatio)
+    }
+
+    @Test
+    fun progressRatio_withZeroTotal_returnsZero() {
+        val progress = JsonBackupProgress(
+            phase = JsonBackupPhase.SUBSCRIBING,
+            current = 5,
+            total = 0,
+        )
+        assertEquals(0f, progress.progressRatio)
+    }
+
+    @Test
+    fun progressRatio_withPositiveTotal_computesAccurately() {
+        val progress = JsonBackupProgress(
+            phase = JsonBackupPhase.SUBSCRIBING,
+            current = 25,
+            total = 100,
+            currentTitle = "Test Podcast",
+        )
+        assertEquals(0.25f, progress.progressRatio)
+    }
+
+    @Test
+    fun progressRatio_clampedAtOne() {
+        val progress = JsonBackupProgress(
+            phase = JsonBackupPhase.COMPLETED,
+            current = 15,
+            total = 10,
+        )
+        assertEquals(1f, progress.progressRatio)
+    }
+
+    @Test
+    fun allPhases_areDefined() {
+        val phases = JsonBackupPhase.entries
+        assertTrue(phases.contains(JsonBackupPhase.PREPARING))
+        assertTrue(phases.contains(JsonBackupPhase.SUBSCRIBING))
+        assertTrue(phases.contains(JsonBackupPhase.RESTORING_HISTORY))
+        assertTrue(phases.contains(JsonBackupPhase.REFRESHING_FEEDS))
+        assertTrue(phases.contains(JsonBackupPhase.COMPLETED))
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #1047 by providing real-time show-by-show progress during JSON backup restore and streamlining the notification permission banner into a single dynamic action with automatic resume refresh.

## Motivation

When restoring a JSON backup with a large library, database record insertion completed in milliseconds, flashing progress from 0% to 100%. Then during the lengthy network feed-downloading phase (`REFRESHING_FEEDS`), no progress updates were emitted and progress remained at 0f, causing `BoxLoreLoader.CircularWavy` to display an empty, unmoving circle and leaving users feeling that the restore was frozen. Additionally, the notification banner presented duplicate side-by-side buttons and did not default to requesting the system runtime permission dialog.

## What changed

- **Real-Time Feed Restore Progress**:
  - `LibraryBackupDirectFeedRestore.restoreAndRefresh` now accepts `onTargetStarted` and `onTargetCompleted` callbacks, atomically tracking progress per show across concurrent network downloads.
  - `LibraryBackupManager` reports real-time progress (`current`, `total`, and `currentTitle`) throughout feed refreshes and PI/RSS syncing.
  - Extracted `syncPiSubscriptionsWithProgress` and `refreshRssCatalogsWithProgress` to maintain clean module boundaries and keep method lengths within Detekt limits.
- **Restore Loading Screen & Hero Motion**:
  - `heroVisualFor` in `OpmlImportProgressContent.kt` returns `ImportHeroVisual.Indeterminate` while progress is `0f` or preparing, ensuring the circular wavy loader continuously spins rather than rendering a static empty circle.
  - Standardized the restore copy to match OPML import:
    - **Title**: "Restoring podcasts"
    - **Subtitle**: "Subscribing X of Y"
    - **Detail**: Container card displaying the podcast title currently being restored.
- **Single-Button Notification Banner**:
  - Refactored `ImportNotificationPermissionCard.kt` to present strictly **one button** and removed unnecessary settings icons.
  - On Android 13+ (`SDK >= 33`), the button starts as `"Enable notifications"` to launch the system runtime permission prompt (`POST_NOTIFICATIONS`).
  - If the prompt fails, is denied, or system notifications are disabled in OS settings, the single button dynamically flips to `"Enable in settings"` to navigate to system settings.
  - Added an `ON_RESUME` lifecycle observer in `SuccessCopy` so enabling notifications in OS settings automatically dismisses the banner upon returning to boxlore.

## Behavior & compatibility

- Backwards-compatible with all existing JSON backup schemas (versions 1 through 6).
- Preserves all database, subscription, playback history, and ranking restore integrity.
- Product name in copy remains strictly lowercase **boxlore**.

## Impact (required)

### User impact — pick **exactly one**

- [ ] `user-impact-critical`
- [ ] `user-impact-high`
- [x] `user-impact-medium`
- [ ] `user-impact-low`
- [ ] `no-user-impact`

### Listener impact — **required when** `user-impact-critical`, `user-impact-high`, or `user-impact-medium`

**What changes in the user’s life:**

Listeners restoring their library backup now see continuous, animated feedback showing exactly which podcast feed is being downloaded, how many shows remain, and a smoothly advancing circular wavy progress indicator. The post-restore notification prompt is streamlined to a single tap to enable alerts, clearing automatically when enabled.

## Release copy (verbatim — highest priority)

### CHANGELOG.md (developer copy)

<!-- release-copy:changelog:start -->

### Fixed
- Streamlined JSON library restore with real-time show-by-show progress reporting and active wavy loader animation throughout feed downloads.
- Refactored post-restore notification card to a single dynamic button that triggers the system runtime permission dialog and refreshes on resume.

<!-- release-copy:changelog:end -->

### README What's New / Upcoming (listener copy)

<!-- release-copy:readme:start -->

### Improvements
- Added real-time show progress and active animated loader when restoring library backups.
- Streamlined notification permission prompt after backup restore to a single tap.

<!-- release-copy:readme:end -->

## Test plan

- [x] Built and deployed locally (`./gradlew installDebug`) onto physical device `24129PN74I - 16`.
- [x] Verified unit tests pass across all modules (`./gradlew testDebugUnitTest --continue`).
- [x] Verified code formatting and static analysis (`./gradlew ktlintCheck detekt`).
- [x] Verified staged secrets scan (`gitleaks protect --staged`).
- [x] Verified restore loading screen actively displays spinning wavy loader and show-by-show count.
- [x] Verified notification banner triggers system dialog first and switches to settings button upon denial.
